### PR TITLE
feat(server): add workflow retry logic with exponential backoff

### DIFF
--- a/.claude/commands/amelia/ensure-doc.md
+++ b/.claude/commands/amelia/ensure-doc.md
@@ -3,6 +3,9 @@ description: ensure all code is properly documented
 ---
 
 ensure all endpoints are covered by openapi spec
+- skip this check if the project uses FastAPI with auto-generated docs (swagger at /docs or redoc at /redoc)
+- only verify manual openapi specs if the project doesn't use auto-generation
+
 ensure all functions and classes follow google python documentation standards
 
 ultrathink and use subagents to explore the codebase and verify

--- a/amelia/agents/reviewer.py
+++ b/amelia/agents/reviewer.py
@@ -35,9 +35,16 @@ class Reviewer:
         self.driver = driver
 
     async def review(self, state: ExecutionState, code_changes: str) -> ReviewResult:
-        """
-        Reviews code changes in the context of the current execution state and issue.
-        Implements single or competitive review strategy based on the profile.
+        """Review code changes in context of execution state and issue.
+
+        Selects single or competitive review strategy based on profile settings.
+
+        Args:
+            state: Current execution state containing issue and profile context.
+            code_changes: Diff or description of code changes to review.
+
+        Returns:
+            ReviewResult with approval status, comments, and severity level.
         """
         if state.profile.strategy == "competitive":
             return await self._competitive_review(state, code_changes)

--- a/amelia/core/types.py
+++ b/amelia/core/types.py
@@ -8,6 +8,21 @@ TrackerType = Literal["jira", "github", "none", "noop"]
 StrategyType = Literal["single", "competitive"]
 ExecutionMode = Literal["structured", "agentic"]
 
+
+class RetryConfig(BaseModel):
+    """Retry configuration for transient failures.
+
+    Attributes:
+        max_retries: Maximum number of retry attempts (0-10).
+        base_delay: Base delay in seconds for exponential backoff (0.1-30.0).
+        max_delay: Maximum delay cap in seconds (1.0-300.0).
+    """
+
+    max_retries: int = Field(default=3, ge=0, le=10)
+    base_delay: float = Field(default=1.0, ge=0.1, le=30.0)
+    max_delay: float = Field(default=60.0, ge=1.0, le=300.0)
+
+
 class Profile(BaseModel):
     """Configuration profile for Amelia execution.
 
@@ -19,7 +34,9 @@ class Profile(BaseModel):
         execution_mode: Execution mode (structured or agentic).
         plan_output_dir: Directory for storing generated plans.
         working_dir: Working directory for agentic execution.
+        retry: Retry configuration for transient failures.
     """
+
     name: str
     driver: DriverType
     tracker: TrackerType = "none"
@@ -27,6 +44,7 @@ class Profile(BaseModel):
     execution_mode: ExecutionMode = "structured"
     plan_output_dir: str = "docs/plans"
     working_dir: str | None = None
+    retry: RetryConfig = Field(default_factory=RetryConfig)
 
 class Settings(BaseModel):
     """Global settings for Amelia.

--- a/amelia/logging.py
+++ b/amelia/logging.py
@@ -94,12 +94,19 @@ def _amelia_banner() -> str:
 def _log_format(record: "Record") -> str:
     """Custom log format with dashboard colors.
 
-    Colors by level:
-        - DEBUG: sage muted (#88A896)
-        - INFO: blue (#5B9BD5)
-        - SUCCESS: sage green (#5B8A72)
-        - WARNING: gold (#FFC857)
-        - ERROR/CRITICAL: rust red (#A33D2E)
+    Args:
+        record: Loguru record containing log metadata and message.
+
+    Returns:
+        Format string with ANSI color codes for the log message.
+
+    Note:
+        Colors by level:
+            - DEBUG: sage muted (#88A896)
+            - INFO: blue (#5B9BD5)
+            - SUCCESS: sage green (#5B8A72)
+            - WARNING: gold (#FFC857)
+            - ERROR/CRITICAL: rust red (#A33D2E)
     """
     level = record["level"].name
 

--- a/tests/unit/server/orchestrator/test_retry_logic.py
+++ b/tests/unit/server/orchestrator/test_retry_logic.py
@@ -1,0 +1,258 @@
+"""Tests for workflow retry logic."""
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import TimeoutException
+
+from amelia.core.state import ExecutionState
+from amelia.core.types import Profile, RetryConfig, Settings
+from amelia.server.events.bus import EventBus
+from amelia.server.models.events import EventType
+from amelia.server.models.state import ServerExecutionState
+from amelia.server.orchestrator.service import TRANSIENT_EXCEPTIONS, OrchestratorService
+
+
+class TestTransientExceptions:
+    """Test TRANSIENT_EXCEPTIONS constant."""
+
+    def test_contains_expected_exceptions(self):
+        """TRANSIENT_EXCEPTIONS contains expected exception types."""
+        assert asyncio.TimeoutError in TRANSIENT_EXCEPTIONS
+        assert TimeoutException in TRANSIENT_EXCEPTIONS
+        assert ConnectionError in TRANSIENT_EXCEPTIONS
+
+
+@pytest.fixture
+def mock_event_bus():
+    """Create a real EventBus for testing event emissions."""
+    return EventBus()
+
+
+@pytest.fixture
+def mock_repository():
+    repo = AsyncMock()
+    repo.get_max_event_sequence.return_value = 0
+    repo.save_event = AsyncMock()
+    repo.set_status = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_settings():
+    return Settings(
+        active_profile="test",
+        profiles={
+            "test": Profile(name="test", driver="cli:claude"),
+        },
+    )
+
+
+@pytest.fixture
+def service(mock_event_bus, mock_repository, mock_settings):
+    svc = OrchestratorService(mock_event_bus, mock_repository, mock_settings)
+    svc._checkpoint_path = "/tmp/test.db"
+    return svc
+
+
+@pytest.fixture
+def server_state():
+    core_state = ExecutionState(
+        profile=Profile(
+            name="test",
+            driver="cli:claude",
+            retry=RetryConfig(max_retries=2, base_delay=0.1),
+        ),
+    )
+    return ServerExecutionState(
+        id="wf-123",
+        issue_id="ISSUE-456",
+        worktree_path="/tmp/test",
+        worktree_name="test-branch",
+        started_at=datetime.now(UTC),
+        execution_state=core_state,
+    )
+
+
+class TestRunWorkflowWithRetry:
+    """Test _run_workflow_with_retry method."""
+
+    async def test_succeeds_on_first_attempt(self, service, server_state):
+        """Workflow succeeds without retry if no error."""
+        service._run_workflow = AsyncMock()
+
+        await service._run_workflow_with_retry("wf-123", server_state)
+
+        assert service._run_workflow.call_count == 1
+
+    async def test_retries_on_transient_error(self, service, server_state):
+        """Workflow retries on transient error."""
+        call_count = 0
+
+        async def fail_then_succeed(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise TimeoutError("Connection timeout")
+            return None
+
+        service._run_workflow = fail_then_succeed
+
+        await service._run_workflow_with_retry("wf-123", server_state)
+
+        assert call_count == 2
+
+    async def test_fails_immediately_on_permanent_error(self, service, server_state):
+        """Workflow fails immediately on permanent error."""
+        service._run_workflow = AsyncMock(side_effect=ValueError("Invalid config"))
+
+        with pytest.raises(ValueError):
+            await service._run_workflow_with_retry("wf-123", server_state)
+
+        assert service._run_workflow.call_count == 1
+
+    async def test_fails_after_max_retries(self, service, server_state):
+        """Workflow fails after exhausting max_retries."""
+        service._run_workflow = AsyncMock(
+            side_effect=TimeoutError("Always timeout")
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await service._run_workflow_with_retry("wf-123", server_state)
+
+        # Initial attempt + 2 retries = 3 calls
+        assert service._run_workflow.call_count == 3
+
+        # Verify set_status was called with failure reason
+        service._repository.set_status.assert_called_once_with(
+            "wf-123",
+            "failed",
+            failure_reason="Failed after 3 attempts: Always timeout",
+        )
+
+    async def test_fails_when_execution_state_is_none(self, service):
+        """Workflow fails immediately when execution_state is None."""
+        # Create a ServerExecutionState with execution_state=None
+        state = ServerExecutionState(
+            id="wf-123",
+            issue_id="ISSUE-456",
+            worktree_path="/tmp/test",
+            worktree_name="test-branch",
+            started_at=datetime.now(UTC),
+            execution_state=None,
+        )
+
+        service._run_workflow = AsyncMock()
+
+        await service._run_workflow_with_retry("wf-123", state)
+
+        # Verify repository.set_status was called with correct args
+        service._repository.set_status.assert_called_once_with(
+            "wf-123", "failed", failure_reason="Missing execution state"
+        )
+
+        # Verify _run_workflow was NOT called (early return)
+        service._run_workflow.assert_not_called()
+
+    async def test_respects_max_delay_config(self, service, monkeypatch):
+        """Workflow retry delay respects max_delay configuration."""
+        # Track sleep durations
+        sleep_durations = []
+        original_sleep = asyncio.sleep
+
+        async def mock_sleep(delay):
+            sleep_durations.append(delay)
+            # Use a very short sleep to speed up test
+            await original_sleep(0.001)
+
+        monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+
+        # Create state with custom retry config
+        core_state = ExecutionState(
+            profile=Profile(
+                name="test",
+                driver="cli:claude",
+                retry=RetryConfig(max_retries=3, base_delay=10.0, max_delay=15.0),
+            ),
+        )
+        state = ServerExecutionState(
+            id="wf-123",
+            issue_id="ISSUE-456",
+            worktree_path="/tmp/test",
+            worktree_name="test-branch",
+            started_at=datetime.now(UTC),
+            execution_state=core_state,
+        )
+
+        # Make workflow fail with transient errors
+        service._run_workflow = AsyncMock(
+            side_effect=TimeoutError("Always timeout")
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await service._run_workflow_with_retry("wf-123", state)
+
+        # Verify delays: 10.0 (first retry), 15.0 (capped by max_delay), 15.0 (capped)
+        # Without max_delay, it would be: 10.0, 20.0, 40.0
+        assert len(sleep_durations) == 3
+        assert sleep_durations[0] == 10.0  # base_delay * 2^0
+        assert sleep_durations[1] == 15.0  # min(base_delay * 2^1, max_delay) = min(20, 15)
+        assert sleep_durations[2] == 15.0  # min(base_delay * 2^2, max_delay) = min(40, 15)
+
+    async def test_failure_event_emitted_only_after_retries_exhausted(
+        self, service, server_state, mock_event_bus
+    ):
+        """WORKFLOW_FAILED event should only be emitted after all retries are exhausted."""
+        # Track emitted events
+        received_events = []
+        mock_event_bus.subscribe(lambda e: received_events.append(e))
+
+        # Make workflow always fail with transient error
+        service._run_workflow = AsyncMock(
+            side_effect=TimeoutError("Connection timeout")
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await service._run_workflow_with_retry("wf-123", server_state)
+
+        # Verify _run_workflow was called 3 times (initial + 2 retries)
+        assert service._run_workflow.call_count == 3
+
+        # Verify WORKFLOW_FAILED event was emitted exactly once at the end
+        failed_events = [e for e in received_events if e.event_type == EventType.WORKFLOW_FAILED]
+        assert len(failed_events) == 1, "WORKFLOW_FAILED should be emitted exactly once"
+
+        # Verify the failure event has correct data
+        failed_event = failed_events[0]
+        assert "after 3 attempts" in failed_event.message
+        assert failed_event.data["attempts"] == 3
+        assert "Connection timeout" in failed_event.data["error"]
+
+    async def test_failure_event_emitted_immediately_for_non_transient_error(
+        self, service, server_state, mock_event_bus
+    ):
+        """WORKFLOW_FAILED event should be emitted immediately for non-transient errors."""
+        # Track emitted events
+        received_events = []
+        mock_event_bus.subscribe(lambda e: received_events.append(e))
+
+        # Make workflow fail with non-transient error
+        service._run_workflow = AsyncMock(side_effect=ValueError("Invalid config"))
+
+        with pytest.raises(ValueError):
+            await service._run_workflow_with_retry("wf-123", server_state)
+
+        # Verify _run_workflow was called only once (no retries)
+        assert service._run_workflow.call_count == 1
+
+        # Verify WORKFLOW_FAILED event was emitted
+        failed_events = [e for e in received_events if e.event_type == EventType.WORKFLOW_FAILED]
+        assert len(failed_events) == 1, "WORKFLOW_FAILED should be emitted once"
+
+        # Verify the failure event has correct data
+        failed_event = failed_events[0]
+        assert "Invalid config" in failed_event.message
+        assert failed_event.data["error_type"] == "non-transient"
+        assert "Invalid config" in failed_event.data["error"]

--- a/tests/unit/server/orchestrator/test_service.py
+++ b/tests/unit/server/orchestrator/test_service.py
@@ -739,6 +739,29 @@ async def test_emit_concurrent_lock_creation_race(
     assert set(sequences) == set(range(1, 11))
 
 
+class TestStartWorkflowWithRetry:
+    """Test start_workflow uses retry wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_calls_retry_wrapper(
+        self, orchestrator: OrchestratorService, mock_repository: AsyncMock, valid_worktree: str
+    ):
+        """start_workflow creates task with _run_workflow_with_retry."""
+        orchestrator._run_workflow_with_retry = AsyncMock()
+
+        workflow_id = await orchestrator.start_workflow(
+            issue_id="TEST-1",
+            worktree_path=valid_worktree,
+        )
+
+        # Wait briefly for task to start
+        await asyncio.sleep(0.01)
+
+        # The task should call _run_workflow_with_retry
+        assert workflow_id is not None
+        orchestrator._run_workflow_with_retry.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_get_workflow_by_worktree_uses_cache(
     orchestrator: OrchestratorService,

--- a/tests/unit/test_retry_config.py
+++ b/tests/unit/test_retry_config.py
@@ -1,0 +1,58 @@
+"""Tests for RetryConfig model."""
+
+import pytest
+from pydantic import ValidationError
+
+from amelia.core.types import RetryConfig
+
+
+class TestRetryConfigDefaults:
+    """Test default values for RetryConfig."""
+
+    def test_default_values(self):
+        """RetryConfig has sensible defaults."""
+        config = RetryConfig()
+        assert config.max_retries == 3
+        assert config.base_delay == 1.0
+        assert config.max_delay == 60.0
+
+
+class TestRetryConfigValidation:
+    """Test validation constraints for RetryConfig."""
+
+    def test_max_retries_minimum(self):
+        """max_retries cannot be negative."""
+        with pytest.raises(ValidationError):
+            RetryConfig(max_retries=-1)
+
+    def test_max_retries_maximum(self):
+        """max_retries cannot exceed 10."""
+        with pytest.raises(ValidationError):
+            RetryConfig(max_retries=11)
+
+    def test_base_delay_minimum(self):
+        """base_delay must be at least 0.1."""
+        with pytest.raises(ValidationError):
+            RetryConfig(base_delay=0.05)
+
+    def test_base_delay_maximum(self):
+        """base_delay cannot exceed 30.0."""
+        with pytest.raises(ValidationError):
+            RetryConfig(base_delay=31.0)
+
+    def test_valid_custom_values(self):
+        """Valid custom values are accepted."""
+        config = RetryConfig(max_retries=5, base_delay=2.0, max_delay=120.0)
+        assert config.max_retries == 5
+        assert config.base_delay == 2.0
+        assert config.max_delay == 120.0
+
+    def test_max_delay_minimum(self):
+        """max_delay must be at least 1.0."""
+        with pytest.raises(ValidationError):
+            RetryConfig(max_delay=0.5)
+
+    def test_max_delay_maximum(self):
+        """max_delay cannot exceed 300.0."""
+        with pytest.raises(ValidationError):
+            RetryConfig(max_delay=301.0)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,6 +1,6 @@
 """Tests for core types."""
 
-from amelia.core.types import ExecutionMode, Profile
+from amelia.core.types import ExecutionMode, Profile, RetryConfig
 
 
 def test_execution_mode_literal_values():
@@ -33,3 +33,22 @@ def test_profile_working_dir_custom():
     """Profile should accept custom working_dir."""
     profile = Profile(name="test", driver="cli:claude", working_dir="/custom/path")
     assert profile.working_dir == "/custom/path"
+
+
+class TestProfileRetryConfig:
+    """Test Profile.retry field."""
+
+    def test_profile_has_default_retry_config(self):
+        """Profile has default RetryConfig."""
+        profile = Profile(name="test", driver="cli:claude")
+        assert profile.retry.max_retries == 3
+        assert profile.retry.base_delay == 1.0
+        assert profile.retry.max_delay == 60.0
+
+    def test_profile_accepts_custom_retry_config(self):
+        """Profile accepts custom RetryConfig."""
+        custom_retry = RetryConfig(max_retries=5, base_delay=2.0, max_delay=120.0)
+        profile = Profile(name="test", driver="cli:claude", retry=custom_retry)
+        assert profile.retry.max_retries == 5
+        assert profile.retry.base_delay == 2.0
+        assert profile.retry.max_delay == 120.0


### PR DESCRIPTION
## Summary

Add automatic retry with configurable exponential backoff for transient failures (timeouts, connection errors) in workflow execution. This improves reliability by automatically recovering from temporary network issues without manual intervention.

## Changes

### Added
- `RetryConfig` model to `Profile` with configurable `max_retries`, `base_delay`, and `max_delay`
- `_run_workflow_with_retry` wrapper in `OrchestratorService` that handles transient failures
- `TRANSIENT_EXCEPTIONS` constant defining which exceptions trigger retry (TimeoutError, TimeoutException, ConnectionError)
- Comprehensive tests for retry configuration validation and retry behavior

### Changed
- `start_workflow` now uses the retry wrapper instead of calling `_run_workflow` directly
- `_run_workflow` exceptions now propagate to the retry wrapper for proper handling
- Improved docstrings in `logging.py` and `reviewer.py` to follow Google style

### Removed
- `docs/README.md` (documentation index file)

## Motivation

Workflow execution can fail due to transient network issues (timeouts, connection resets) that are recoverable. Without retry logic, these failures require manual re-triggering. This feature adds automatic recovery with exponential backoff to handle temporary issues gracefully while failing fast on non-transient errors.

## Testing

- [x] Unit tests added for `RetryConfig` validation constraints
- [x] Unit tests added for retry behavior (success, transient retry, permanent fail, max retries)
- [x] Unit tests verify event emission timing (only after retries exhausted)
- [x] Integration with existing `OrchestratorService` tests

### Manual Testing Steps

1. Configure a profile with custom retry settings in `settings.amelia.yaml`:
   ```yaml
   profiles:
     test:
       retry:
         max_retries: 2
         base_delay: 1.0
         max_delay: 30.0
   ```
2. Start a workflow and simulate network issues
3. Verify retries occur with exponential backoff
4. Verify failure after max retries is reached

## Related Issues

- Closes #46

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy amelia`)

---

Generated with [Claude Code](https://claude.com/claude-code)