### PR TITLE
fix(docs): update README limitations and fix JIRA_BASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,37 @@ See [Configuration Reference](docs/configuration.md) for full details.
 ## Current Status
 
 **What works:**
-- Full orchestrator loop with human approval gates
-- API driver (OpenAI via pydantic-ai) with structured outputs
-- CLI driver (Claude CLI wrapper) with structured outputs
+- Full orchestrator loop with human approval gates (CLI mode)
+- CLI driver (Claude CLI wrapper) with structured outputs, streaming, and agentic execution
 - Local code review with competitive strategy
-- Jira and GitHub tracker integrations
-- Real tool execution in Developer agent
-- FastAPI server with SQLite persistence
+- GitHub tracker integration (via `gh` CLI)
+- Real tool execution in Developer agent (shell commands, file writes)
+- FastAPI server with SQLite persistence and WebSocket event streaming
 - Workflow state machine with event tracking
-- React dashboard foundation (Vite, shadcn/ui, React Router v7, aviation theme)
-- Unified `amelia dev` command with color-coded output for server + dashboard
 
-**Limitations/Coming Soon:**
-- TaskDAG doesn't validate cyclic dependencies
+**Limitations:**
+
+_This is an experimental project. Set expectations accordingly._
+
+**Web Dashboard (not ready for use):**
+- All pages display "Coming soon" placeholders - no actual workflow data rendered
+- API client, WebSocket hooks, and data loaders are implemented but not connected to UI
+- Toast notifications only log to console
+- Connection status indicator is hardcoded
+
+**API Driver (OpenAI):**
+- No agentic execution support (structured mode only)
+- API key validation is incomplete
+- Less tested than CLI driver
+
+**Orchestrator:**
+- Failed tasks permanently block all dependent tasks (no retry or skip mechanism)
+- `RetryConfig` is defined but not actually used anywhere
+- Server crash recovery is a placeholder (interrupted workflows not recovered)
+- Workflow detail API missing token usage and event history
+
+**Not Implemented:**
+- Checkpoint resumption after interruption
+- Session continuity across runs
+- Task prioritization (all ready tasks treated equally)
+- Structured error categories or retry strategies

--- a/amelia/trackers/jira.py
+++ b/amelia/trackers/jira.py
@@ -19,7 +19,7 @@ class JiraTracker(BaseTracker):
     def __init__(self) -> None:
         """Initialize JiraTracker with configuration validation."""
         self._validate_config()
-        self.jira_url = os.environ["JIRA_URL"]
+        self.jira_url = os.environ["JIRA_BASE_URL"]
         self.email = os.environ["JIRA_EMAIL"]
         self.token = os.environ["JIRA_API_TOKEN"]
 
@@ -31,8 +31,8 @@ class JiraTracker(BaseTracker):
             ConfigurationError: If any required variable is missing
         """
         missing = []
-        if not os.environ.get("JIRA_URL"):
-            missing.append("JIRA_URL")
+        if not os.environ.get("JIRA_BASE_URL"):
+            missing.append("JIRA_BASE_URL")
         if not os.environ.get("JIRA_EMAIL"):
             missing.append("JIRA_EMAIL")
         if not os.environ.get("JIRA_API_TOKEN"):

--- a/tests/unit/test_tracker_config_validation.py
+++ b/tests/unit/test_tracker_config_validation.py
@@ -21,16 +21,16 @@ class TestJiraTrackerConfigValidation:
         "missing_var,present_vars",
         [
             (
-                "JIRA_URL",
+                "JIRA_BASE_URL",
                 {"JIRA_EMAIL": "test@example.com", "JIRA_API_TOKEN": "token123"},
             ),
             (
                 "JIRA_EMAIL",
-                {"JIRA_URL": "https://example.atlassian.net", "JIRA_API_TOKEN": "token123"},
+                {"JIRA_BASE_URL": "https://example.atlassian.net", "JIRA_API_TOKEN": "token123"},
             ),
             (
                 "JIRA_API_TOKEN",
-                {"JIRA_URL": "https://example.atlassian.net", "JIRA_EMAIL": "test@example.com"},
+                {"JIRA_BASE_URL": "https://example.atlassian.net", "JIRA_EMAIL": "test@example.com"},
             ),
         ],
         ids=["missing_url", "missing_email", "missing_token"]
@@ -48,7 +48,7 @@ class TestJiraTrackerConfigValidation:
 
     def test_all_jira_vars_present_succeeds(self, monkeypatch):
         """With all env vars set, JiraTracker should initialize."""
-        monkeypatch.setenv("JIRA_URL", "https://example.atlassian.net")
+        monkeypatch.setenv("JIRA_BASE_URL", "https://example.atlassian.net")
         monkeypatch.setenv("JIRA_EMAIL", "test@example.com")
         monkeypatch.setenv("JIRA_API_TOKEN", "token123")
 


### PR DESCRIPTION
## Summary

- Rename `JIRA_URL` → `JIRA_BASE_URL` to match documentation (fixes env var mismatch)
- Replace inaccurate "What works" section with honest current status
- Add comprehensive **Limitations** section for newly public repo

## Changes

### JIRA Environment Variable Fix
- `amelia/trackers/jira.py`: `JIRA_URL` → `JIRA_BASE_URL`
- `tests/unit/test_tracker_config_validation.py`: Updated test cases

### README Limitations
Sets realistic expectations for users discovering the public repo:

| Area | Key Limitations |
|------|-----------------|
| **Web Dashboard** | All pages are "Coming soon" stubs; infrastructure built but not wired |
| **API Driver** | No agentic execution; incomplete key validation |
| **Orchestrator** | Failed tasks block dependents; no retry mechanism; crash recovery is placeholder |
| **Not Implemented** | Checkpoint resumption, session continuity, task prioritization |

## Test plan

- [x] `uv run pytest tests/unit/test_tracker_config_validation.py` - All 8 tests pass
- [x] Full test suite passes (533 tests)
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)