### PR TITLE
feat(state): add AgenticState model for agentic execution

### DIFF
--- a/amelia/core/agentic_state.py
+++ b/amelia/core/agentic_state.py
@@ -1,0 +1,90 @@
+"""State model for agentic execution.
+
+This module defines the state model for agentic (tool-calling) execution,
+replacing the structured batch/step execution model.
+"""
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+AgenticStatus = Literal["running", "awaiting_approval", "completed", "failed", "cancelled"]
+
+
+class ToolCall(BaseModel):
+    """A tool call made by the LLM.
+
+    Attributes:
+        id: Unique identifier for this call.
+        tool_name: Name of the tool being called.
+        tool_input: Input parameters for the tool.
+        timestamp: When the call was made (ISO format).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    timestamp: str | None = None
+
+
+class ToolResult(BaseModel):
+    """Result from a tool execution.
+
+    Attributes:
+        call_id: ID of the ToolCall this result is for.
+        tool_name: Name of the tool that was called.
+        output: Output from the tool (stdout, file content, etc.).
+        success: Whether the tool executed successfully.
+        error: Error message if success is False.
+        duration_ms: Execution time in milliseconds.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    call_id: str
+    tool_name: str
+    output: str
+    success: bool
+    error: str | None = None
+    duration_ms: int | None = None
+
+
+class AgenticState(BaseModel):
+    """State for agentic workflow execution.
+
+    Tracks the conversation, tool calls, and results for an agentic
+    execution session where the LLM autonomously decides actions.
+
+    Attributes:
+        workflow_id: Unique workflow identifier.
+        issue_key: Issue being worked on.
+        goal: High-level goal or task description.
+        system_prompt: System prompt for the agent.
+        tool_calls: History of tool calls made.
+        tool_results: History of tool results received.
+        final_response: Final response from the agent when complete.
+        status: Current execution status.
+        error: Error message if status is 'failed'.
+        session_id: Session ID for driver continuity.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    workflow_id: str
+    issue_key: str
+    goal: str
+    system_prompt: str | None = None
+
+    # Tool execution history
+    tool_calls: tuple[ToolCall, ...] = ()
+    tool_results: tuple[ToolResult, ...] = ()
+
+    # Completion state
+    final_response: str | None = None
+    status: AgenticStatus = "running"
+    error: str | None = None
+
+    # Session continuity
+    session_id: str | None = None

--- a/tests/unit/core/test_agentic_state.py
+++ b/tests/unit/core/test_agentic_state.py
@@ -1,0 +1,84 @@
+"""Tests for agentic execution state model."""
+import pytest
+from pydantic import ValidationError
+
+from amelia.core.agentic_state import AgenticState, ToolCall, ToolResult
+
+
+class TestToolCall:
+    """Test ToolCall model."""
+
+    def test_create_tool_call(self) -> None:
+        """Should create tool call with required fields."""
+        call = ToolCall(
+            id="call-1",
+            tool_name="run_shell_command",
+            tool_input={"command": "ls -la"},
+        )
+        assert call.id == "call-1"
+        assert call.tool_name == "run_shell_command"
+        assert call.tool_input == {"command": "ls -la"}
+
+    def test_tool_call_is_frozen(self) -> None:
+        """ToolCall should be immutable."""
+        call = ToolCall(id="1", tool_name="test", tool_input={})
+        with pytest.raises(ValidationError):
+            call.id = "2"
+
+
+class TestToolResult:
+    """Test ToolResult model."""
+
+    def test_create_success_result(self) -> None:
+        """Should create successful tool result."""
+        result = ToolResult(
+            call_id="call-1",
+            tool_name="run_shell_command",
+            output="file1.txt\nfile2.txt",
+            success=True,
+        )
+        assert result.success is True
+        assert result.error is None
+
+    def test_create_error_result(self) -> None:
+        """Should create error tool result."""
+        result = ToolResult(
+            call_id="call-1",
+            tool_name="run_shell_command",
+            output="",
+            success=False,
+            error="Command not found",
+        )
+        assert result.success is False
+        assert result.error == "Command not found"
+
+
+class TestAgenticState:
+    """Test AgenticState model."""
+
+    def test_create_initial_state(self) -> None:
+        """Should create state with conversation history."""
+        state = AgenticState(
+            workflow_id="wf-123",
+            issue_key="ISSUE-1",
+            goal="Implement feature X",
+        )
+        assert state.workflow_id == "wf-123"
+        assert state.tool_calls == ()
+        assert state.tool_results == ()
+        assert state.status == "running"
+
+    def test_state_tracks_tool_history(self) -> None:
+        """Should track tool call and result history."""
+        call = ToolCall(id="1", tool_name="shell", tool_input={"cmd": "ls"})
+        result = ToolResult(call_id="1", tool_name="shell", output="ok", success=True)
+
+        state = AgenticState(
+            workflow_id="wf-1",
+            issue_key="ISSUE-1",
+            goal="test",
+            tool_calls=(call,),
+            tool_results=(result,),
+        )
+        assert len(state.tool_calls) == 1
+        assert len(state.tool_results) == 1


### PR DESCRIPTION
## Summary

- Introduces immutable Pydantic models for agentic (tool-calling) workflow execution
- Provides type-safe state management for autonomous agent execution
- Replaces the structured batch/step execution model with a more flexible agentic approach

## Key Changes

### New Models (`amelia/core/agentic_state.py`)

- **`AgenticStatus`**: Literal type for workflow status (`running`, `awaiting_approval`, `completed`, `failed`, `cancelled`)
- **`ToolCall`**: Immutable model for tracking LLM tool calls with `id`, `tool_name`, `tool_input`, and optional `timestamp`
- **`ToolResult`**: Immutable model for tool execution results with `call_id`, `tool_name`, `output`, `success`, optional `error`, and `duration_ms`
- **`AgenticState`**: Main state model for agentic workflow execution, tracking:
  - Workflow context (`workflow_id`, `issue_key`, `goal`, `system_prompt`)
  - Tool execution history (`tool_calls`, `tool_results` as immutable tuples)
  - Completion state (`final_response`, `status`, `error`)
  - Session continuity (`session_id`)

All models use `frozen=True` for immutability, ensuring thread-safe state management.

### Tests (`tests/unit/core/test_agentic_state.py`)

- Validation tests for `ToolCall`, `ToolResult`, and `AgenticState` creation
- Immutability enforcement tests
- Tool history tracking tests

## Stack Context

This PR is part of the agentic-only migration stack:
1. #147 - OpenAI provider support
2. **#148 - AgenticState model** (this PR)
3. #149 - Agent rewrites
4. #150 - Orchestrator/API updates
5. #151 - Dashboard cleanup & docs

## Test Plan

- [x] Unit tests pass (`uv run pytest tests/unit/core/test_agentic_state.py`)
- [ ] Type checking passes (`uv run mypy amelia`)
- [ ] Lint passes (`uv run ruff check amelia`)
- [ ] Full test suite passes (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)