### PR TITLE
fix(tests): set OPENROUTER_API_KEY in mock_deepagents fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@
 This module provides factory fixtures for creating test data and mocks
 used throughout the test suite for the agentic execution model.
 """
+import os
 from collections.abc import Callable, Generator
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
@@ -200,7 +201,8 @@ def mock_deepagents() -> Generator[MagicMock, None, None]:
     """
     from collections.abc import AsyncIterator
 
-    with patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create_agent, \
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-api-key"}), \
+         patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create_agent, \
          patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init_model, \
          patch("amelia.drivers.api.deepagents.FilesystemBackend") as mock_backend_class:
 


### PR DESCRIPTION
## Summary

Fixes CI test failures in `tests/unit/test_api_driver.py` where tests using `openrouter:` model prefix were failing because `OPENROUTER_API_KEY` was not set.

The `mock_deepagents` fixture mocks `create_deep_agent` and `init_chat_model`, but `_create_chat_model()` checks for `OPENROUTER_API_KEY` **before** calling `init_chat_model`. In CI, the env var isn't set, so tests fail with:

```
ValueError: OPENROUTER_API_KEY environment variable is required for OpenRouter models
```

**Fix:** Add `patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-api-key"})` to the fixture context so the env var check passes.

## Test plan

- [x] All 586 tests pass locally
- [x] Linting and type checking pass
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to improve test environment configuration.

---

*No user-visible changes in this release.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->