### PR TITLE
fix(docs): remove dead links to deleted files

### DIFF
--- a/docs/site/guide/artifacts/index.md
+++ b/docs/site/guide/artifacts/index.md
@@ -11,7 +11,6 @@ Amelia produces structured artifacts throughout the development lifecycle. These
 
 | Type | Description | Example |
 |------|-------------|---------|
-| **Design** | Technical specs defining how to build a feature | [View →](./design-example) |
 | **Plan** | Batched execution steps with risk assessment | [View →](./plan-example) |
 | **Review** | Feedback on correctness, security, maintainability | [View →](./review-example) |
 

--- a/docs/site/guide/artifacts/plan-example.md
+++ b/docs/site/guide/artifacts/plan-example.md
@@ -46,5 +46,4 @@ batches:
 
 ## Learn More
 
-- See the [Design Example](./design-example) for how plans are derived from designs
 - Check the [Roadmap](/reference/roadmap) for automated plan generation timeline

--- a/docs/site/guide/artifacts/review-example.md
+++ b/docs/site/guide/artifacts/review-example.md
@@ -51,6 +51,5 @@ Brief overview of changes and overall assessment.
 
 ## Learn More
 
-- See the [Design Example](./design-example) for what reviews validate against
 - See the [Plan Example](./plan-example) for execution context
 - Check the [Roadmap](/reference/roadmap) for automated review timeline

--- a/docs/site/reference/roadmap.md
+++ b/docs/site/reference/roadmap.md
@@ -104,8 +104,6 @@ Long-running agents fail across context windows because each session starts fres
 - [Gap 6: Session Memory Retrieval](/ideas/research/context-engineering-gaps#gap-6-session-memory-retrieval) - On-demand access to relevant history
 - [Gap 7: Artifact Handle System](/ideas/research/context-engineering-gaps#gap-7-artifact-handle-system) - Reference large objects by pointer
 
-See [Session Continuity Design](/ideas/session-continuity) for detailed specification.
-
 ---
 
 ## Phase 4: Verification Framework [Planned]


### PR DESCRIPTION
## Summary

Fixes VitePress build failure caused by dead links to files deleted in PR #163.

## Changes

Removed 4 dead links:
- `./design-example` in `guide/artifacts/index.md`
- `./design-example` in `guide/artifacts/review-example.md`
- `./design-example` in `guide/artifacts/plan-example.md`
- `/ideas/session-continuity` in `reference/roadmap.md`

## Related

- Follow-up to #163 (docs cleanup)
- Fixes [failed action run](https://github.com/existential-birds/amelia/actions/runs/20622448933)

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Design artifact type from the artifacts guide; now covers Plan and Review artifacts only.
  * Updated Plan and Review example documentation to remove references to Design examples.
  * Streamlined reference documentation by removing cross-links to removed sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->