### PR TITLE
fix(api): resolve 404 on /api/prompts endpoint

### DIFF
--- a/amelia/server/routes/prompts.py
+++ b/amelia/server/routes/prompts.py
@@ -195,7 +195,7 @@ class ResetResponse(BaseModel):
 # Routes
 
 
-@router.get("/", response_model=PromptListResponse)
+@router.get("", response_model=PromptListResponse)
 async def list_prompts(
     repository: "PromptRepository" = Depends(get_prompt_repository),
 ) -> PromptListResponse:


### PR DESCRIPTION
## Summary

Fixes 404 error when accessing the `/api/prompts` endpoint without a trailing slash. The frontend API client calls `/api/prompts` but the backend route required `/api/prompts/`.

## Changes

### Fixed
- Changed prompts list route decorator from `"/"` to `""` to match requests without trailing slash

## Motivation

The prompts configuration page was broken because:
1. The route was defined as `@router.get("/")` which requires `/api/prompts/`
2. The SPA catch-all route in `main.py` intercepts paths starting with `api/` and returns 404 before FastAPI's trailing-slash redirect can activate
3. The frontend API client correctly calls `/api/prompts` (without trailing slash)

## Testing

- [x] Manual testing performed - verified `/api/prompts` returns JSON instead of 404
- [x] Existing unit tests pass

### Manual Testing Steps

1. Start the server: `uv run amelia dev`
2. Verify endpoint works: `curl http://127.0.0.1:8420/api/prompts`
3. Navigate to `/prompts` in the dashboard

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the prompts list API endpoint URL path for correct routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->