### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-01-01
+
+### Fixed
+
+- **server:** Fix 404 error on `/api/prompts` endpoint when accessed without trailing slash ([#189](https://github.com/existential-birds/amelia/pull/189))
+
 ## [0.4.0] - 2026-01-01
 
 ### Added

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -18,7 +18,7 @@ from amelia.core.state import ExecutionState
 from amelia.main import app
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     "app",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.4.0"
+version = "0.4.1"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to 0.4.1
- Update CHANGELOG.md with changes since v0.4.0

### Changes in this release

#### Fixed
- **server:** Fix 404 error on `/api/prompts` endpoint when accessed without trailing slash (#189)

## Post-merge steps

After merging, run:
```
/release-tag 0.4.1
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 404 regression for the /api/prompts endpoint when accessed without a trailing slash.

* **Chores**
  * Version bumped to 0.4.1 across all packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->