### PR TITLE
fix: add missing -> None return type hints to async test functions

### DIFF
--- a/tests/integration/test_server_startup.py
+++ b/tests/integration/test_server_startup.py
@@ -45,7 +45,7 @@ class TestServerStartup:
         server.should_exit = True
         await task
 
-    async def test_server_starts_and_responds(self, server):
+    async def test_server_starts_and_responds(self, server) -> None:
         """Server starts and responds to health checks."""
         async with httpx.AsyncClient() as client:
             response = await client.get(f"{server}/api/health/live")
@@ -53,7 +53,7 @@ class TestServerStartup:
             assert response.status_code == 200
             assert response.json()["status"] == "alive"
 
-    async def test_health_endpoint_returns_metrics(self, server):
+    async def test_health_endpoint_returns_metrics(self, server) -> None:
         """Health endpoint returns system metrics."""
         async with httpx.AsyncClient() as client:
             response = await client.get(f"{server}/api/health")
@@ -64,7 +64,7 @@ class TestServerStartup:
             assert "memory_mb" in data
             assert "uptime_seconds" in data
 
-    async def test_docs_endpoint_available(self, server):
+    async def test_docs_endpoint_available(self, server) -> None:
         """Swagger docs are accessible."""
         async with httpx.AsyncClient() as client:
             response = await client.get(f"{server}/api/docs")
@@ -72,7 +72,7 @@ class TestServerStartup:
             assert response.status_code == 200
             assert "swagger" in response.text.lower() or "openapi" in response.text.lower()
 
-    async def test_openapi_schema_available(self, server):
+    async def test_openapi_schema_available(self, server) -> None:
         """OpenAPI schema is accessible."""
         async with httpx.AsyncClient() as client:
             response = await client.get(f"{server}/api/openapi.json")
@@ -85,7 +85,7 @@ class TestServerStartup:
 class TestLifespanStartup:
     """Tests for lifespan startup behavior."""
 
-    async def test_lifespan_creates_database_directory(self):
+    async def test_lifespan_creates_database_directory(self) -> None:
         """Lifespan creates database parent directory if missing."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Set up a database path in a non-existent subdirectory
@@ -102,7 +102,7 @@ class TestLifespanStartup:
                     assert db_path.parent.exists()
                     assert db_path.parent.is_dir()
 
-    async def test_lifespan_initializes_config(self):
+    async def test_lifespan_initializes_config(self) -> None:
         """Lifespan initializes config so get_config works."""
         # Ensure config is None before test
         main_module._config = None

--- a/tests/unit/agents/prompts/test_resolver.py
+++ b/tests/unit/agents/prompts/test_resolver.py
@@ -23,7 +23,7 @@ class TestGetPrompt:
     """Tests for get_prompt method."""
 
     @pytest.mark.asyncio
-    async def test_returns_default_when_no_custom_version(self, mock_repository):
+    async def test_returns_default_when_no_custom_version(self, mock_repository) -> None:
         """Should return default when no custom version set."""
         mock_repository.get_prompt.return_value = Prompt(
             id="architect.system",
@@ -39,7 +39,7 @@ class TestGetPrompt:
         assert result.content == PROMPT_DEFAULTS["architect.system"].content
 
     @pytest.mark.asyncio
-    async def test_returns_custom_version_when_set(self, mock_repository):
+    async def test_returns_custom_version_when_set(self, mock_repository) -> None:
         """Should return custom version content when active."""
         custom_content = "Custom architect prompt..."
         mock_repository.get_prompt.return_value = Prompt(
@@ -63,7 +63,7 @@ class TestGetPrompt:
         assert result.content == custom_content
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_default_on_db_error(self, mock_repository):
+    async def test_falls_back_to_default_on_db_error(self, mock_repository) -> None:
         """Should return default when database fails."""
         mock_repository.get_prompt.side_effect = Exception("DB error")
         resolver = PromptResolver(mock_repository)
@@ -73,7 +73,7 @@ class TestGetPrompt:
         assert result.content == PROMPT_DEFAULTS["architect.system"].content
 
     @pytest.mark.asyncio
-    async def test_raises_for_unknown_prompt(self, mock_repository):
+    async def test_raises_for_unknown_prompt(self, mock_repository) -> None:
         """Should raise ValueError for unknown prompt ID."""
         mock_repository.get_prompt.return_value = None
         resolver = PromptResolver(mock_repository)
@@ -86,7 +86,7 @@ class TestGetAllActive:
     """Tests for get_all_active method."""
 
     @pytest.mark.asyncio
-    async def test_returns_all_prompts(self, mock_repository):
+    async def test_returns_all_prompts(self, mock_repository) -> None:
         """Should return all prompt defaults."""
         mock_repository.get_prompt.return_value = None  # All use defaults
         resolver = PromptResolver(mock_repository)
@@ -102,7 +102,7 @@ class TestRecordForWorkflow:
     """Tests for record_for_workflow method."""
 
     @pytest.mark.asyncio
-    async def test_records_custom_versions_only(self, mock_repository):
+    async def test_records_custom_versions_only(self, mock_repository) -> None:
         """Should only record custom versions, not defaults."""
         mock_repository.get_prompt.return_value = Prompt(
             id="architect.system",
@@ -123,7 +123,7 @@ class TestRecordForWorkflow:
         assert mock_repository.record_workflow_prompt.called
 
     @pytest.mark.asyncio
-    async def test_does_not_record_defaults(self, mock_repository):
+    async def test_does_not_record_defaults(self, mock_repository) -> None:
         """Should not record anything when all use defaults."""
         mock_repository.get_prompt.return_value = None  # All defaults
         resolver = PromptResolver(mock_repository)

--- a/tests/unit/server/database/test_connection.py
+++ b/tests/unit/server/database/test_connection.py
@@ -10,7 +10,7 @@ from amelia.server.database.connection import Database
 class TestDatabaseConnection:
     """Tests for Database class."""
 
-    async def test_database_creates_directory(self, temp_db_path):
+    async def test_database_creates_directory(self, temp_db_path) -> None:
         """Database creates parent directory if it doesn't exist."""
         nested_path = temp_db_path.parent / "nested" / "dir" / "test.db"
         db = Database(nested_path)
@@ -20,7 +20,7 @@ class TestDatabaseConnection:
 
         assert nested_path.parent.exists()
 
-    async def test_database_connect_creates_file(self, temp_db_path):
+    async def test_database_connect_creates_file(self, temp_db_path) -> None:
         """Database file is created on connect."""
         db = Database(temp_db_path)
         await db.connect()
@@ -28,17 +28,17 @@ class TestDatabaseConnection:
 
         assert temp_db_path.exists()
 
-    async def test_database_wal_mode_enabled(self, connected_db):
+    async def test_database_wal_mode_enabled(self, connected_db) -> None:
         """WAL mode is enabled for concurrent access."""
         result = await connected_db.fetch_one("PRAGMA journal_mode")
         assert result[0].lower() == "wal"
 
-    async def test_database_foreign_keys_enabled(self, connected_db):
+    async def test_database_foreign_keys_enabled(self, connected_db) -> None:
         """Foreign keys are enforced."""
         result = await connected_db.fetch_one("PRAGMA foreign_keys")
         assert result[0] == 1
 
-    async def test_database_context_manager(self, temp_db_path):
+    async def test_database_context_manager(self, temp_db_path) -> None:
         """Database can be used as async context manager."""
         async with Database(temp_db_path) as db:
             await db.execute("CREATE TABLE test (id INTEGER)")
@@ -46,7 +46,7 @@ class TestDatabaseConnection:
         # Connection should be closed
         assert temp_db_path.exists()
 
-    async def test_database_transaction(self, temp_db_path):
+    async def test_database_transaction(self, temp_db_path) -> None:
         """Transactions can be used for atomic operations."""
         db = Database(temp_db_path)
         await db.connect()
@@ -61,7 +61,7 @@ class TestDatabaseConnection:
 
         assert len(results) == 2
 
-    async def test_database_transaction_rollback(self, temp_db_path):
+    async def test_database_transaction_rollback(self, temp_db_path) -> None:
         """Transaction rolls back on exception."""
         db = Database(temp_db_path)
         await db.connect()

--- a/tests/unit/server/database/test_prompt_repository.py
+++ b/tests/unit/server/database/test_prompt_repository.py
@@ -28,7 +28,7 @@ class TestPromptCRUD:
     """Tests for prompt CRUD operations."""
 
     @pytest.mark.asyncio
-    async def test_create_prompt(self, repo: PromptRepository):
+    async def test_create_prompt(self, repo: PromptRepository) -> None:
         """Should create a prompt."""
         prompt = Prompt(
             id="test.prompt",
@@ -42,7 +42,7 @@ class TestPromptCRUD:
         assert result.name == "Test Prompt"
 
     @pytest.mark.asyncio
-    async def test_list_prompts(self, repo: PromptRepository):
+    async def test_list_prompts(self, repo: PromptRepository) -> None:
         """Should list all prompts."""
         await repo.create_prompt(Prompt(id="p1", agent="a", name="Prompt 1"))
         await repo.create_prompt(Prompt(id="p2", agent="b", name="Prompt 2"))
@@ -50,7 +50,7 @@ class TestPromptCRUD:
         assert len(prompts) == 2
 
     @pytest.mark.asyncio
-    async def test_get_prompt_not_found(self, repo: PromptRepository):
+    async def test_get_prompt_not_found(self, repo: PromptRepository) -> None:
         """Should return None for non-existent prompt."""
         result = await repo.get_prompt("nonexistent")
         assert result is None
@@ -60,7 +60,7 @@ class TestVersionManagement:
     """Tests for version management."""
 
     @pytest.mark.asyncio
-    async def test_create_version(self, repo: PromptRepository):
+    async def test_create_version(self, repo: PromptRepository) -> None:
         """Should create a new version."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         version = await repo.create_version(
@@ -72,7 +72,7 @@ class TestVersionManagement:
         assert version.content == "New prompt content"
 
     @pytest.mark.asyncio
-    async def test_create_version_increments_number(self, repo: PromptRepository):
+    async def test_create_version_increments_number(self, repo: PromptRepository) -> None:
         """Version numbers should auto-increment."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         v1 = await repo.create_version("test.prompt", "Content 1", "First")
@@ -81,7 +81,7 @@ class TestVersionManagement:
         assert v2.version_number == 2
 
     @pytest.mark.asyncio
-    async def test_create_version_sets_active(self, repo: PromptRepository):
+    async def test_create_version_sets_active(self, repo: PromptRepository) -> None:
         """Creating a version should set it as active."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         version = await repo.create_version("test.prompt", "Content", None)
@@ -89,7 +89,7 @@ class TestVersionManagement:
         assert prompt.current_version_id == version.id
 
     @pytest.mark.asyncio
-    async def test_get_versions(self, repo: PromptRepository):
+    async def test_get_versions(self, repo: PromptRepository) -> None:
         """Should list all versions for a prompt."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         await repo.create_version("test.prompt", "V1", None)
@@ -101,7 +101,7 @@ class TestVersionManagement:
         assert versions[1].version_number == 1
 
     @pytest.mark.asyncio
-    async def test_get_version_by_id(self, repo: PromptRepository):
+    async def test_get_version_by_id(self, repo: PromptRepository) -> None:
         """Should get a specific version by ID."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         created = await repo.create_version("test.prompt", "Content", None)
@@ -110,7 +110,7 @@ class TestVersionManagement:
         assert result.content == "Content"
 
     @pytest.mark.asyncio
-    async def test_set_active_version(self, repo: PromptRepository):
+    async def test_set_active_version(self, repo: PromptRepository) -> None:
         """Should change the active version."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         v1 = await repo.create_version("test.prompt", "V1", None)
@@ -121,7 +121,7 @@ class TestVersionManagement:
         assert prompt.current_version_id == v1.id
 
     @pytest.mark.asyncio
-    async def test_reset_to_default(self, repo: PromptRepository):
+    async def test_reset_to_default(self, repo: PromptRepository) -> None:
         """Should clear current_version_id."""
         await repo.create_prompt(Prompt(id="test.prompt", agent="test", name="Test"))
         await repo.create_version("test.prompt", "Content", None)
@@ -134,7 +134,7 @@ class TestWorkflowLinking:
     """Tests for workflow-prompt linking."""
 
     @pytest.mark.asyncio
-    async def test_record_workflow_prompt(self, repo: PromptRepository, db: Database):
+    async def test_record_workflow_prompt(self, repo: PromptRepository, db: Database) -> None:
         """Should record which version a workflow used."""
         # Create workflow
         await db.execute(
@@ -152,7 +152,7 @@ class TestWorkflowLinking:
         assert results[0].version_id == version.id
 
     @pytest.mark.asyncio
-    async def test_get_workflow_prompts_empty(self, repo: PromptRepository):
+    async def test_get_workflow_prompts_empty(self, repo: PromptRepository) -> None:
         """Should return empty list for workflow with no prompts."""
         results = await repo.get_workflow_prompts("nonexistent")
         assert results == []

--- a/tests/unit/server/database/test_prompt_schema.py
+++ b/tests/unit/server/database/test_prompt_schema.py
@@ -17,7 +17,7 @@ async def db(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_prompts_table_exists(db: Database):
+async def test_prompts_table_exists(db: Database) -> None:
     """Prompts table should exist after schema creation."""
     result = await db.fetch_one(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='prompts'"
@@ -27,7 +27,7 @@ async def test_prompts_table_exists(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_prompt_versions_table_exists(db: Database):
+async def test_prompt_versions_table_exists(db: Database) -> None:
     """Prompt versions table should exist after schema creation."""
     result = await db.fetch_one(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='prompt_versions'"
@@ -37,7 +37,7 @@ async def test_prompt_versions_table_exists(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_workflow_prompt_versions_table_exists(db: Database):
+async def test_workflow_prompt_versions_table_exists(db: Database) -> None:
     """Workflow prompt versions table should exist after schema creation."""
     result = await db.fetch_one(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='workflow_prompt_versions'"
@@ -46,7 +46,7 @@ async def test_workflow_prompt_versions_table_exists(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_can_insert_prompt(db: Database):
+async def test_can_insert_prompt(db: Database) -> None:
     """Should be able to insert a prompt."""
     await db.execute(
         """INSERT INTO prompts (id, agent, name, description, current_version_id)
@@ -59,7 +59,7 @@ async def test_can_insert_prompt(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_can_insert_prompt_version(db: Database):
+async def test_can_insert_prompt_version(db: Database) -> None:
     """Should be able to insert a prompt version with foreign key."""
     # First insert the prompt
     await db.execute(
@@ -79,7 +79,7 @@ async def test_can_insert_prompt_version(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_version_unique_constraint(db: Database):
+async def test_version_unique_constraint(db: Database) -> None:
     """Same prompt+version_number should fail unique constraint."""
     await db.execute(
         "INSERT INTO prompts (id, agent, name) VALUES (?, ?, ?)",
@@ -97,7 +97,7 @@ async def test_version_unique_constraint(db: Database):
 
 
 @pytest.mark.asyncio
-async def test_workflow_prompt_version_foreign_keys(db: Database):
+async def test_workflow_prompt_version_foreign_keys(db: Database) -> None:
     """Workflow prompt versions should enforce foreign keys."""
     # Create a workflow first
     await db.execute(

--- a/tests/unit/server/database/test_repository.py
+++ b/tests/unit/server/database/test_repository.py
@@ -18,7 +18,7 @@ class TestWorkflowRepository:
         """WorkflowRepository instance."""
         return WorkflowRepository(db_with_schema)
 
-    async def test_create_workflow(self, repository):
+    async def test_create_workflow(self, repository) -> None:
         """Can create a workflow."""
         state = ServerExecutionState(
             id=str(uuid4()),
@@ -34,7 +34,7 @@ class TestWorkflowRepository:
         assert retrieved is not None
         assert retrieved.issue_id == "ISSUE-123"
 
-    async def test_get_by_worktree(self, repository):
+    async def test_get_by_worktree(self, repository) -> None:
         """Can get active workflow by worktree path."""
         state = ServerExecutionState(
             id=str(uuid4()),
@@ -49,7 +49,7 @@ class TestWorkflowRepository:
         assert retrieved is not None
         assert retrieved.id == state.id
 
-    async def test_get_by_worktree_only_active(self, repository):
+    async def test_get_by_worktree_only_active(self, repository) -> None:
         """get_by_worktree only returns active workflows."""
         # Create completed workflow
         completed = ServerExecutionState(
@@ -65,7 +65,7 @@ class TestWorkflowRepository:
         result = await repository.get_by_worktree("/path/to/repo")
         assert result is None
 
-    async def test_update_workflow(self, repository):
+    async def test_update_workflow(self, repository) -> None:
         """Can update workflow state."""
         state = ServerExecutionState(
             id=str(uuid4()),
@@ -84,7 +84,7 @@ class TestWorkflowRepository:
         assert retrieved.workflow_status == "in_progress"
         assert retrieved.started_at is not None
 
-    async def test_set_status_validates_transition(self, repository):
+    async def test_set_status_validates_transition(self, repository) -> None:
         """set_status validates state machine transitions."""
         state = ServerExecutionState(
             id=str(uuid4()),
@@ -99,7 +99,7 @@ class TestWorkflowRepository:
         with pytest.raises(InvalidStateTransitionError):
             await repository.set_status(state.id, "completed")
 
-    async def test_set_status_with_failure_reason(self, repository):
+    async def test_set_status_with_failure_reason(self, repository) -> None:
         """set_status can set failure reason."""
         state = ServerExecutionState(
             id=str(uuid4()),
@@ -116,7 +116,7 @@ class TestWorkflowRepository:
         assert retrieved.workflow_status == "failed"
         assert retrieved.failure_reason == "Something went wrong"
 
-    async def test_list_active_workflows(self, repository):
+    async def test_list_active_workflows(self, repository) -> None:
         """Can list all active workflows."""
         # Create various workflows
         active1 = ServerExecutionState(
@@ -155,7 +155,7 @@ class TestWorkflowRepository:
     # Event Persistence Tests
     # =========================================================================
 
-    async def test_save_event(self, repository, make_event):
+    async def test_save_event(self, repository, make_event) -> None:
         """Should persist event to database."""
         # First create a workflow (required for foreign key)
         state = ServerExecutionState(
@@ -183,7 +183,7 @@ class TestWorkflowRepository:
         max_seq = await repository.get_max_event_sequence("wf-1")
         assert max_seq == 1
 
-    async def test_get_max_event_sequence_with_events(self, repository, make_event):
+    async def test_get_max_event_sequence_with_events(self, repository, make_event) -> None:
         """Should return max sequence number."""
         # First create a workflow
         state = ServerExecutionState(
@@ -210,7 +210,7 @@ class TestWorkflowRepository:
         max_seq = await repository.get_max_event_sequence("wf-1")
         assert max_seq == 3
 
-    async def test_save_event_with_pydantic_model_in_data(self, repository, make_event):
+    async def test_save_event_with_pydantic_model_in_data(self, repository, make_event) -> None:
         """Should serialize Pydantic models in event data.
 
         Regression test for: TypeError: Object of type Profile is not JSON serializable
@@ -253,7 +253,7 @@ class TestWorkflowRepository:
         max_seq = await repository.get_max_event_sequence("wf-pydantic")
         assert max_seq == 1
 
-    async def test_get_recent_events(self, repository, make_event):
+    async def test_get_recent_events(self, repository, make_event) -> None:
         """Should return recent events for a workflow in chronological order."""
         # Create a workflow
         state = ServerExecutionState(
@@ -286,7 +286,7 @@ class TestWorkflowRepository:
         assert events[1].id == "evt-recent-2"
         assert events[2].id == "evt-recent-3"
 
-    async def test_get_recent_events_with_limit(self, repository, make_event):
+    async def test_get_recent_events_with_limit(self, repository, make_event) -> None:
         """Should respect limit parameter."""
         # Create a workflow
         state = ServerExecutionState(
@@ -318,7 +318,7 @@ class TestWorkflowRepository:
         assert events[0].id == "evt-lim-4"
         assert events[1].id == "evt-lim-5"
 
-    async def test_get_recent_events_empty(self, repository):
+    async def test_get_recent_events_empty(self, repository) -> None:
         """Should return empty list for workflow with no events."""
         # Create a workflow
         state = ServerExecutionState(
@@ -337,7 +337,7 @@ class TestWorkflowRepository:
         assert len(events) == 0
 
     @pytest.mark.parametrize("limit", [0, -1, -100])
-    async def test_get_recent_events_non_positive_limit(self, repository, limit):
+    async def test_get_recent_events_non_positive_limit(self, repository, limit) -> None:
         """Should return empty list for non-positive limit values."""
         # No need to create workflow - should return early before DB query
         events = await repository.get_recent_events("any-workflow", limit=limit)

--- a/tests/unit/server/database/test_repository_backfill.py
+++ b/tests/unit/server/database/test_repository_backfill.py
@@ -20,7 +20,7 @@ class TestEventBackfill:
     )
     async def test_event_exists(
         self, repository, workflow, event_id, should_exist, setup_event, make_event
-    ):
+    ) -> None:
         """event_exists() returns correct boolean based on existence."""
         if setup_event:
             event = make_event(
@@ -33,7 +33,7 @@ class TestEventBackfill:
 
         assert await repository.event_exists(event_id) == should_exist
 
-    async def test_get_events_after_returns_newer_events(self, repository, workflow, make_event):
+    async def test_get_events_after_returns_newer_events(self, repository, workflow, make_event) -> None:
         """get_events_after() returns events with sequence > since_event sequence."""
         # Create sequence of events
         for i in range(1, 6):
@@ -55,7 +55,7 @@ class TestEventBackfill:
         assert newer_events[1].id == "evt-4"
         assert newer_events[2].id == "evt-5"
 
-    async def test_get_events_after_filters_by_workflow(self, repository, make_event):
+    async def test_get_events_after_filters_by_workflow(self, repository, make_event) -> None:
         """get_events_after() only returns events from same workflow."""
         # Create two workflows
         wf1 = ServerExecutionState(
@@ -117,7 +117,7 @@ class TestEventBackfill:
         assert newer_events[0].id == "wf1-evt-2"
         assert newer_events[0].workflow_id == "wf-1"
 
-    async def test_get_events_after_raises_when_event_not_found(self, repository):
+    async def test_get_events_after_raises_when_event_not_found(self, repository) -> None:
         """get_events_after() raises ValueError when event doesn't exist."""
         with pytest.raises(ValueError, match="Event .* not found"):
             await repository.get_events_after("evt-nonexistent")

--- a/tests/unit/server/database/test_schema.py
+++ b/tests/unit/server/database/test_schema.py
@@ -7,7 +7,7 @@ import pytest
 class TestWorktreeConstraints:
     """Tests for worktree uniqueness constraints."""
 
-    async def test_unique_active_worktree_constraint(self, db_with_schema):
+    async def test_unique_active_worktree_constraint(self, db_with_schema) -> None:
         """Only one active workflow per worktree is allowed."""
         # Insert first workflow
         await db_with_schema.execute("""
@@ -22,7 +22,7 @@ class TestWorktreeConstraints:
                 VALUES ('id2', 'ISSUE-2', '/path/to/worktree', 'main', 'pending', '{}')
             """)
 
-    async def test_completed_workflows_dont_conflict(self, db_with_schema):
+    async def test_completed_workflows_dont_conflict(self, db_with_schema) -> None:
         """Completed workflows don't block new workflows in same worktree."""
         # Insert completed workflow
         await db_with_schema.execute("""

--- a/tests/unit/server/events/test_bus.py
+++ b/tests/unit/server/events/test_bus.py
@@ -97,7 +97,7 @@ def test_emit_subscriber_exception(event_bus: EventBus, sample_event: WorkflowEv
     assert received[0] == sample_event
 
 
-async def test_broadcast_task_tracking(event_bus: EventBus, sample_event: WorkflowEvent):
+async def test_broadcast_task_tracking(event_bus: EventBus, sample_event: WorkflowEvent) -> None:
     """Broadcast tasks should be tracked and cleaned up."""
     broadcast_called = asyncio.Event()
 
@@ -119,7 +119,7 @@ async def test_broadcast_task_tracking(event_bus: EventBus, sample_event: Workfl
     # If we get here, broadcast was called with the event
 
 
-async def test_cleanup_waits_for_broadcast_tasks(event_bus: EventBus, sample_event: WorkflowEvent):
+async def test_cleanup_waits_for_broadcast_tasks(event_bus: EventBus, sample_event: WorkflowEvent) -> None:
     """cleanup() should wait for all broadcast tasks to complete."""
     # Create mock connection manager with slow broadcast
     mock_manager = AsyncMock()
@@ -146,7 +146,7 @@ async def test_cleanup_waits_for_broadcast_tasks(event_bus: EventBus, sample_eve
     assert len(event_bus._broadcast_tasks) == 0
 
 
-async def test_cleanup_handles_task_exceptions(event_bus: EventBus, sample_event: WorkflowEvent):
+async def test_cleanup_handles_task_exceptions(event_bus: EventBus, sample_event: WorkflowEvent) -> None:
     """cleanup() should handle exceptions in broadcast tasks gracefully."""
     # Create mock connection manager that raises
     mock_manager = AsyncMock()

--- a/tests/unit/server/events/test_connection_manager.py
+++ b/tests/unit/server/events/test_connection_manager.py
@@ -26,14 +26,14 @@ class TestConnectionManager:
         ws.close = AsyncMock()
         return ws
 
-    async def test_disconnect_removes_connection(self, manager, mock_websocket):
+    async def test_disconnect_removes_connection(self, manager, mock_websocket) -> None:
         """disconnect() removes connection from tracking."""
         await manager.connect(mock_websocket)
         await manager.disconnect(mock_websocket)
 
         assert manager.active_connections == 0
 
-    async def test_subscribe_multiple_workflows(self, manager, mock_websocket):
+    async def test_subscribe_multiple_workflows(self, manager, mock_websocket) -> None:
         """Can subscribe to multiple workflows."""
         await manager.connect(mock_websocket)
         await manager.subscribe(mock_websocket, "wf-123")
@@ -42,7 +42,7 @@ class TestConnectionManager:
         assert "wf-123" in manager._connections[mock_websocket]
         assert "wf-456" in manager._connections[mock_websocket]
 
-    async def test_subscribe_all_clears_subscription_set(self, manager, mock_websocket):
+    async def test_subscribe_all_clears_subscription_set(self, manager, mock_websocket) -> None:
         """subscribe_all() clears subscription set (empty = all)."""
         await manager.connect(mock_websocket)
         await manager.subscribe(mock_websocket, "wf-123")
@@ -61,7 +61,7 @@ class TestConnectionManager:
     )
     async def test_broadcast_filtering(
         self, manager, mock_websocket, subscription_workflow, event_workflow, should_send, make_event
-    ):
+    ) -> None:
         """broadcast() respects subscription filters."""
         await manager.connect(mock_websocket)
         if subscription_workflow:
@@ -81,7 +81,7 @@ class TestConnectionManager:
         else:
             mock_websocket.send_json.assert_not_awaited()
 
-    async def test_broadcast_handles_disconnected_socket(self, manager, mock_websocket, make_event):
+    async def test_broadcast_handles_disconnected_socket(self, manager, mock_websocket, make_event) -> None:
         """broadcast() removes disconnected sockets gracefully."""
         await manager.connect(mock_websocket)
         mock_websocket.send_json.side_effect = WebSocketDisconnect()
@@ -98,7 +98,7 @@ class TestConnectionManager:
         # Connection should be removed after disconnect
         assert manager.active_connections == 0
 
-    async def test_close_all_handles_errors(self, manager, mock_websocket):
+    async def test_close_all_handles_errors(self, manager, mock_websocket) -> None:
         """close_all() handles errors gracefully."""
         mock_websocket.close.side_effect = Exception("Close failed")
 
@@ -108,7 +108,7 @@ class TestConnectionManager:
         # Should not raise, just clear connections
         assert manager.active_connections == 0
 
-    async def test_active_connections_count(self, manager):
+    async def test_active_connections_count(self, manager) -> None:
         """active_connections property returns correct count."""
         ws1 = AsyncMock()
         ws1.accept = AsyncMock()

--- a/tests/unit/server/events/test_connection_manager_stream.py
+++ b/tests/unit/server/events/test_connection_manager_stream.py
@@ -32,7 +32,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_sends_to_all_connections(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should send to all connections regardless of subscription."""
         ws1 = websocket_factory()
         ws2 = websocket_factory()
@@ -60,7 +60,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_payload_structure(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should send correct payload structure with subtype."""
         mock_websocket = websocket_factory()
         await manager.connect(mock_websocket)
@@ -85,7 +85,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_handles_disconnected_socket(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should remove disconnected sockets gracefully."""
         mock_websocket = websocket_factory()
         await manager.connect(mock_websocket)
@@ -98,7 +98,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_timeout_handling(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should timeout slow clients and remove them."""
         mock_websocket = websocket_factory()
         await manager.connect(mock_websocket)
@@ -115,7 +115,7 @@ class TestConnectionManagerStream:
         # Connection should be removed after timeout
         assert manager.active_connections == 0
 
-    async def test_broadcast_stream_with_no_connections(self, manager, sample_stream_event):
+    async def test_broadcast_stream_with_no_connections(self, manager, sample_stream_event) -> None:
         """broadcast_stream() should handle no connections gracefully."""
         assert manager.active_connections == 0
 
@@ -124,7 +124,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_concurrent_sends(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should send to multiple clients concurrently."""
         # Create multiple websockets
         websockets = [websocket_factory() for _ in range(5)]
@@ -140,7 +140,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_serializes_datetime(
         self, manager, websocket_factory
-    ):
+    ) -> None:
         """broadcast_stream() should serialize datetime to ISO string."""
         mock_websocket = websocket_factory()
         timestamp = datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC)
@@ -166,7 +166,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_with_tool_data(
         self, manager, websocket_factory
-    ):
+    ) -> None:
         """broadcast_stream() should include tool data when present."""
         mock_websocket = websocket_factory()
         event = StreamEvent(
@@ -192,7 +192,7 @@ class TestConnectionManagerStream:
 
     async def test_broadcast_stream_partial_failure(
         self, manager, websocket_factory, sample_stream_event
-    ):
+    ) -> None:
         """broadcast_stream() should continue if some clients fail."""
         # Create three websockets
         ws1 = websocket_factory()

--- a/tests/unit/server/routes/test_websocket_routes.py
+++ b/tests/unit/server/routes/test_websocket_routes.py
@@ -43,7 +43,7 @@ class TestWebSocketEndpoint:
     )
     async def test_websocket_handles_client_messages(
         self, mock_connection_manager, mock_repository, mock_websocket, message, expected_method, expected_arg
-    ):
+    ) -> None:
         """WebSocket routes client messages to connection manager."""
         mock_websocket.receive_json.side_effect = [message, WebSocketDisconnect()]
 
@@ -56,7 +56,7 @@ class TestWebSocketEndpoint:
         else:
             method.assert_awaited_once_with(mock_websocket)
 
-    async def test_websocket_backfill_when_since_provided(self, mock_connection_manager, mock_repository, mock_websocket):
+    async def test_websocket_backfill_when_since_provided(self, mock_connection_manager, mock_repository, mock_websocket) -> None:
         """WebSocket performs backfill when ?since= parameter provided."""
         # Mock backfill events
         backfill_events = [
@@ -100,7 +100,7 @@ class TestWebSocketEndpoint:
         )
         assert backfill_complete_sent
 
-    async def test_websocket_sends_backfill_expired_when_event_missing(self, mock_connection_manager, mock_repository, mock_websocket):
+    async def test_websocket_sends_backfill_expired_when_event_missing(self, mock_connection_manager, mock_repository, mock_websocket) -> None:
         """WebSocket sends backfill_expired when requested event doesn't exist."""
         # Simulate event not found - get_events_after raises ValueError
         mock_repository.get_events_after.side_effect = ValueError("Event evt-nonexistent not found")

--- a/tests/unit/server/test_dev.py
+++ b/tests/unit/server/test_dev.py
@@ -172,7 +172,7 @@ class TestAutoInstall:
         (0, True),
         (1, False),
     ], ids=["success", "failure"])
-    async def test_run_pnpm_install(self, return_code, expected):
+    async def test_run_pnpm_install(self, return_code, expected) -> None:
         """Test pnpm install handles exit codes correctly."""
         from amelia.server.dev import run_pnpm_install
 
@@ -202,7 +202,7 @@ class TestProcessManager:
         process.kill = MagicMock()
         return process
 
-    async def test_process_manager_shutdown_terminates_processes(self, mock_process: AsyncMock):
+    async def test_process_manager_shutdown_terminates_processes(self, mock_process: AsyncMock) -> None:
         """Shutdown terminates running processes."""
         from amelia.server.dev import ProcessManager
 

--- a/tests/unit/server/test_websocket_shutdown.py
+++ b/tests/unit/server/test_websocket_shutdown.py
@@ -7,7 +7,7 @@ from amelia.server.events.connection_manager import ConnectionManager
 class TestWebSocketShutdown:
     """Tests for WebSocket shutdown during server lifecycle."""
 
-    async def test_lifespan_closes_websocket_connections_on_shutdown(self):
+    async def test_lifespan_closes_websocket_connections_on_shutdown(self) -> None:
         """Lifespan shutdown closes all WebSocket connections."""
         # Create a connection manager instance for testing
         connection_manager = ConnectionManager()

--- a/tests/unit/test_design_parser.py
+++ b/tests/unit/test_design_parser.py
@@ -22,7 +22,7 @@ def mock_driver_for_parser():
     return mock
 
 
-async def test_parse_design_extracts_fields(mock_driver_for_parser, tmp_path):
+async def test_parse_design_extracts_fields(mock_driver_for_parser, tmp_path) -> None:
     # Create a mock design markdown file
     design_file = tmp_path / "design.md"
     design_file.write_text("# Test Feature\n\nSome design content here.")
@@ -34,6 +34,6 @@ async def test_parse_design_extracts_fields(mock_driver_for_parser, tmp_path):
     mock_driver_for_parser.generate.assert_called_once()
 
 
-async def test_parse_design_file_not_found(mock_driver_for_parser):
+async def test_parse_design_file_not_found(mock_driver_for_parser) -> None:
     with pytest.raises(FileNotFoundError):
         await parse_design("/nonexistent/path.md", mock_driver_for_parser)

--- a/tests/unit/test_human_approval_node.py
+++ b/tests/unit/test_human_approval_node.py
@@ -24,14 +24,14 @@ class TestHumanApprovalNodeServerMode:
 
     async def test_server_mode_returns_state_unchanged_when_not_approved(
         self, base_state
-    ):
+    ) -> None:
         """In server mode, node returns empty dict (interrupt handles pause)."""
         config = {"configurable": {"execution_mode": "server"}}
         result = await human_approval_node(base_state, config)
         # Should return empty dict - interrupt mechanism handles the pause
         assert result == {}
 
-    async def test_server_mode_preserves_approval_from_resume(self, base_state):
+    async def test_server_mode_preserves_approval_from_resume(self, base_state) -> None:
         """In server mode, node returns empty dict (approval preserved by state)."""
         state = base_state.model_copy(update={"human_approved": True})
         config = {"configurable": {"execution_mode": "server"}}
@@ -49,7 +49,7 @@ class TestHumanApprovalNodeCLIMode:
     @patch("amelia.core.orchestrator.typer.echo")
     async def test_cli_mode_prompts_user(
         self, mock_echo, mock_secho, mock_prompt, mock_confirm, base_state
-    ):
+    ) -> None:
         """In CLI mode, node prompts user for approval."""
         mock_confirm.return_value = True
         mock_prompt.return_value = ""
@@ -66,7 +66,7 @@ class TestHumanApprovalNodeCLIMode:
     @patch("amelia.core.orchestrator.typer.echo")
     async def test_cli_mode_default_when_no_config(
         self, mock_echo, mock_secho, mock_prompt, mock_confirm, base_state
-    ):
+    ) -> None:
         """CLI mode is default when no execution_mode in config."""
         mock_confirm.return_value = False
         mock_prompt.return_value = "rejected"

--- a/tests/unit/test_safe_file_writer.py
+++ b/tests/unit/test_safe_file_writer.py
@@ -12,7 +12,7 @@ from amelia.tools.safe_file import SafeFileWriter
 class TestSafeFileWriterSecurity:
     """Test security constraints of SafeFileWriter."""
 
-    async def test_write_within_allowed_dir_succeeds(self, tmp_path: Path):
+    async def test_write_within_allowed_dir_succeeds(self, tmp_path: Path) -> None:
         """Writing within allowed directory should succeed."""
         file_path = tmp_path / "test.txt"
         result = await SafeFileWriter.write(
@@ -23,7 +23,7 @@ class TestSafeFileWriterSecurity:
         assert "Successfully" in result
         assert file_path.read_text() == "hello world"
 
-    async def test_path_traversal_double_dot_blocked(self, tmp_path: Path):
+    async def test_path_traversal_double_dot_blocked(self, tmp_path: Path) -> None:
         """Path traversal with .. should be blocked."""
         malicious_path = str(tmp_path / ".." / ".." / "etc" / "passwd")
         with pytest.raises(PathTraversalError, match="outside allowed"):
@@ -33,7 +33,7 @@ class TestSafeFileWriterSecurity:
                 allowed_dirs=[str(tmp_path)],
             )
 
-    async def test_absolute_path_outside_allowed_blocked(self, tmp_path: Path):
+    async def test_absolute_path_outside_allowed_blocked(self, tmp_path: Path) -> None:
         """Absolute paths outside allowed dirs should be blocked."""
         with pytest.raises(PathTraversalError, match="outside allowed"):
             await SafeFileWriter.write(
@@ -42,7 +42,7 @@ class TestSafeFileWriterSecurity:
                 allowed_dirs=[str(tmp_path)],
             )
 
-    async def test_symlink_to_outside_blocked(self, tmp_path: Path):
+    async def test_symlink_to_outside_blocked(self, tmp_path: Path) -> None:
         """Symlinks pointing outside allowed dirs should be blocked."""
         link_path = tmp_path / "escape_link"
         target_outside = Path("/tmp")
@@ -63,7 +63,7 @@ class TestSafeFileWriterSecurity:
                 allowed_dirs=[str(tmp_path)],
             )
 
-    async def test_creates_parent_directories(self, tmp_path: Path):
+    async def test_creates_parent_directories(self, tmp_path: Path) -> None:
         """Missing parent directories should be created."""
         file_path = tmp_path / "nested" / "deep" / "file.txt"
         result = await SafeFileWriter.write(
@@ -74,7 +74,7 @@ class TestSafeFileWriterSecurity:
         assert "Successfully" in result
         assert file_path.read_text() == "nested content"
 
-    async def test_relative_path_resolved_against_cwd(self, tmp_path: Path, monkeypatch):
+    async def test_relative_path_resolved_against_cwd(self, tmp_path: Path, monkeypatch) -> None:
         """Relative paths should be resolved against cwd."""
         monkeypatch.chdir(tmp_path)
         result = await SafeFileWriter.write(
@@ -85,7 +85,7 @@ class TestSafeFileWriterSecurity:
         assert "Successfully" in result
         assert (tmp_path / "relative_file.txt").read_text() == "relative content"
 
-    async def test_default_allowed_dir_is_cwd(self, tmp_path: Path, monkeypatch):
+    async def test_default_allowed_dir_is_cwd(self, tmp_path: Path, monkeypatch) -> None:
         """Default allowed_dirs should be current working directory."""
         monkeypatch.chdir(tmp_path)
         file_path = tmp_path / "default_allowed.txt"
@@ -95,12 +95,12 @@ class TestSafeFileWriterSecurity:
         )
         assert "Successfully" in result
 
-    async def test_empty_path_rejected(self):
+    async def test_empty_path_rejected(self) -> None:
         """Empty file path should be rejected."""
         with pytest.raises(ValueError, match="[Ee]mpty|[Pp]ath"):
             await SafeFileWriter.write("", "content")
 
-    async def test_directory_as_target_rejected(self, tmp_path: Path):
+    async def test_directory_as_target_rejected(self, tmp_path: Path) -> None:
         """Directories should not be writable as files."""
         with pytest.raises((IsADirectoryError, ValueError, OSError)):
             await SafeFileWriter.write(
@@ -109,7 +109,7 @@ class TestSafeFileWriterSecurity:
                 allowed_dirs=[str(tmp_path.parent)],
             )
 
-    async def test_base_dir_resolves_relative_paths(self, tmp_path: Path):
+    async def test_base_dir_resolves_relative_paths(self, tmp_path: Path) -> None:
         """Relative paths should resolve against base_dir, not process cwd."""
         # Create a subdirectory to use as base_dir
         base = tmp_path / "workdir"
@@ -126,7 +126,7 @@ class TestSafeFileWriterSecurity:
         assert "Successfully" in result
         assert (base / "output.txt").read_text() == "test content"
 
-    async def test_base_dir_defaults_to_first_allowed_dir(self, tmp_path: Path):
+    async def test_base_dir_defaults_to_first_allowed_dir(self, tmp_path: Path) -> None:
         """When base_dir is None, relative paths resolve against first allowed_dir."""
         base = tmp_path / "allowed"
         base.mkdir()

--- a/tests/unit/test_safe_shell_executor.py
+++ b/tests/unit/test_safe_shell_executor.py
@@ -24,7 +24,7 @@ class TestSafeShellExecutorBlockedCommands:
             pytest.param("mkfs.ext4 /dev/sda1", id="mkfs"),
         ],
     )
-    async def test_blocked_commands(self, command):
+    async def test_blocked_commands(self, command) -> None:
         """Dangerous system commands should always be blocked."""
         with pytest.raises(BlockedCommandError, match="[Bb]locked"):
             await SafeShellExecutor.execute(command)
@@ -41,12 +41,12 @@ class TestSafeShellExecutorDangerousPatterns:
             pytest.param("rm -rf /etc", id="rm_etc"),
         ],
     )
-    async def test_dangerous_rm_patterns_blocked(self, command):
+    async def test_dangerous_rm_patterns_blocked(self, command) -> None:
         """Dangerous rm patterns should be blocked."""
         with pytest.raises(DangerousCommandError, match="[Dd]angerous"):
             await SafeShellExecutor.execute(command)
 
-    async def test_safe_rm_allowed(self):
+    async def test_safe_rm_allowed(self) -> None:
         """Normal rm commands should be allowed."""
         try:
             await SafeShellExecutor.execute("rm nonexistent_file_12345.txt")
@@ -71,7 +71,7 @@ class TestSafeShellExecutorMetacharacters:
             pytest.param("echo malicious > /etc/passwd", id="redirect"),
         ],
     )
-    async def test_shell_metacharacters_blocked(self, command):
+    async def test_shell_metacharacters_blocked(self, command) -> None:
         """Shell metacharacters should be blocked to prevent injection."""
         with pytest.raises(ShellInjectionError, match="metacharacter"):
             await SafeShellExecutor.execute(command)
@@ -80,22 +80,22 @@ class TestSafeShellExecutorMetacharacters:
 class TestSafeShellExecutorEdgeCases:
     """Test edge cases and input validation."""
 
-    async def test_empty_command_rejected(self):
+    async def test_empty_command_rejected(self) -> None:
         """Empty commands should be rejected."""
         with pytest.raises(ValueError, match="[Ee]mpty"):
             await SafeShellExecutor.execute("")
 
-    async def test_whitespace_only_command_rejected(self):
+    async def test_whitespace_only_command_rejected(self) -> None:
         """Whitespace-only commands should be rejected."""
         with pytest.raises(ValueError, match="[Ee]mpty"):
             await SafeShellExecutor.execute("   ")
 
-    async def test_timeout_raises_on_long_command(self):
+    async def test_timeout_raises_on_long_command(self) -> None:
         """Commands exceeding timeout should raise RuntimeError."""
         with pytest.raises(RuntimeError, match="[Tt]imed? ?out"):
             await SafeShellExecutor.execute("sleep 10", timeout=1)
 
-    async def test_nonzero_exit_code_raises(self):
+    async def test_nonzero_exit_code_raises(self) -> None:
         """Commands with non-zero exit should raise RuntimeError."""
         with pytest.raises(RuntimeError, match="exit code"):
             await SafeShellExecutor.execute("python -c 'exit(1)'")
@@ -104,7 +104,7 @@ class TestSafeShellExecutorEdgeCases:
 class TestSafeShellExecutorStrictMode:
     """Test optional strict mode with allowlist."""
 
-    async def test_strict_mode_blocks_unlisted_commands(self):
+    async def test_strict_mode_blocks_unlisted_commands(self) -> None:
         """In strict mode, commands not in allowlist should be blocked."""
         with pytest.raises(CommandNotAllowedError, match="not in allowed"):
             await SafeShellExecutor.execute(
@@ -112,7 +112,7 @@ class TestSafeShellExecutorStrictMode:
                 strict_mode=True
             )
 
-    async def test_strict_mode_allows_listed_commands(self):
+    async def test_strict_mode_allows_listed_commands(self) -> None:
         """In strict mode, allowlisted commands should work."""
         result = await SafeShellExecutor.execute(
             "echo hello",
@@ -120,7 +120,7 @@ class TestSafeShellExecutorStrictMode:
         )
         assert result == "hello"
 
-    async def test_strict_mode_still_blocks_dangerous(self):
+    async def test_strict_mode_still_blocks_dangerous(self) -> None:
         """In strict mode, dangerous commands are still blocked even if in allowlist."""
         with pytest.raises((BlockedCommandError, DangerousCommandError)):
             await SafeShellExecutor.execute(
@@ -128,7 +128,7 @@ class TestSafeShellExecutorStrictMode:
                 strict_mode=True
             )
 
-    async def test_custom_allowlist_in_strict_mode(self):
+    async def test_custom_allowlist_in_strict_mode(self) -> None:
         """Custom allowlist should work in strict mode."""
         # Use echo which works cross-platform (macOS/Linux)
         result = await SafeShellExecutor.execute(


### PR DESCRIPTION
## Summary

Adds explicit `-> None` return type hints to all async test functions that were missing them, ensuring compliance with the project's "type hints everywhere" policy.

## Changes

### Fixed
- Added `-> None` return type hints to 113 async test functions across 18 test files

## Motivation

Issue #94 identified that many async test functions were missing return type annotations. Per CLAUDE.md, this project requires "type hints everywhere." This PR ensures consistency and enables better type checking for test code.

## Testing

- [x] All existing tests pass (`uv run pytest`)
- [x] Type checking passes (`uv run mypy amelia`)
- [x] Linting passes (`uv run ruff check`)

No behavior changes - this is a type annotation-only fix.

## Related Issues

- Closes #94

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added explicit return type annotations to test methods across the codebase for improved type checking and code clarity. No functional changes to test behavior or application functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->