### PR TITLE
docs: fix dead links after documentation cleanup

### DIFF
--- a/docs/site/design-system/index.md
+++ b/docs/site/design-system/index.md
@@ -202,8 +202,5 @@ Using design tokens
 
 ## Next Steps
 
-- Explore the [Color System](/design-system/color-system) in detail
 - Learn about [Typography](/design-system/typography) and type scale
-- Create [Diagrams](/design-system/diagrams) with D2 and Mermaid
-- Build [Presentations](/design-system/presentations) with Slidev
-- Reference the complete [Token API](/design-system/tokens)
+- Reference the complete [Token API](/design-system/tokens) for colors and design tokens

--- a/docs/site/design-system/tokens.md
+++ b/docs/site/design-system/tokens.md
@@ -683,5 +683,3 @@ Supported in all modern browsers:
 
 - [Typography Guide](/design-system/typography)
 - [Getting Started](/design-system/)
-- [Diagrams](/design-system/diagrams)
-- [Presentations](/design-system/presentations)

--- a/docs/site/design-system/typography.md
+++ b/docs/site/design-system/typography.md
@@ -400,7 +400,5 @@ Maintain optimal line length for readability:
 
 ## Next Steps
 
-- Explore the [Color System](/design-system/color-system) for text colors
-- Create [Diagrams](/design-system/diagrams) with consistent fonts
-- Build [Presentations](/design-system/presentations) using the type scale
-- Reference the complete [Token API](/design-system/tokens)
+- Reference the complete [Token API](/design-system/tokens) for colors and typography
+- Return to [Getting Started](/design-system/) for an overview

--- a/docs/site/reference/roadmap.md
+++ b/docs/site/reference/roadmap.md
@@ -2,7 +2,7 @@
 
 > **Vision:** Complete end-to-end workflow control without ever opening GitHub, Jira, or any tracker web UI—with agents that maintain context across sessions and verify their own work. Built on the assumption that LLMs will continually improve, so Amelia automatically gets better as models advance.
 >
-> **Architecture:** Aligned with the [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) methodology for building reliable LLM-powered software. See also [Context Engineering Gaps](/ideas/research/context-engineering-gaps) for agentic context management requirements.
+> **Architecture:** Aligned with the [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) methodology for building reliable LLM-powered software.
 >
 > **Track Progress:** [GitHub Project Board](https://github.com/orgs/existential-birds/projects/2)
 
@@ -72,11 +72,6 @@ A browser-based dashboard that provides visibility into workflow state, enables 
 - **F6 (Launch/Pause/Resume)**: REST API enables external launch (`POST /workflows`) and query (`GET /workflows/{id}`)
 - **F11 (Trigger from Anywhere)**: WebSocket events enable async notification to any connected client
 
-**Context Engineering:**
-- [Gap 1: Context Compiler](/ideas/research/context-engineering-gaps#gap-1-context-compiler) - Add infrastructure for fresh context projection per LLM call
-- [Gap 3: Prompt Prefix Stability](/ideas/research/context-engineering-gaps#gap-3-prompt-prefix-stability-for-cache-optimization) - Design prompts for cache reuse
-- [Gap 5: Agent Scope Isolation](/ideas/research/context-engineering-gaps#gap-5-agent-scope-isolation) - Minimal default context per agent
-
 ---
 
 ## Phase 3: Session Continuity [Planned]
@@ -97,12 +92,6 @@ Long-running agents fail across context windows because each session starts fres
 - **F5 (Unified State)**: `amelia-progress.json` becomes single source of truth, Git-reconstructible
 - **F6 (Launch/Pause/Resume)**: Explicit pause points and resume protocol for session handoffs
 - **F3 (Own Context Window)**: Progress artifacts provide structured context for new sessions
-
-**Context Engineering:**
-- [Gap 2: Schema-Driven Summarization](/ideas/research/context-engineering-gaps#gap-2-schema-driven-summarization) - Compact context preserving semantic structure
-- [Gap 4: Tiered Memory Architecture](/ideas/research/context-engineering-gaps#gap-4-tiered-memory-architecture) - Working Context / Sessions / Memory / Artifacts hierarchy
-- [Gap 6: Session Memory Retrieval](/ideas/research/context-engineering-gaps#gap-6-session-memory-retrieval) - On-demand access to relevant history
-- [Gap 7: Artifact Handle System](/ideas/research/context-engineering-gaps#gap-7-artifact-handle-system) - Reference large objects by pointer
 
 ---
 
@@ -256,7 +245,7 @@ A document-assisted design tool: upload reference materials, explore them throug
 - **F3 (Own Context Window)**: RAG retrieval enables custom context construction from documents
 - **F13 (Pre-fetch Context)**: Design documents pre-loaded before Architect planning
 
-See [Spec Builder Design](/ideas/spec-builder) for detailed specification.
+See [Spec Builder Design](https://github.com/existential-birds/amelia/issues/204) for detailed specification.
 
 ---
 
@@ -276,7 +265,7 @@ When facing complex decisions without clear answers, spawn multiple agents with 
 - **F10 (Small Focused Agents)**: Each debater is a focused agent with a single perspective
 - **F7 (Contact Humans with Tools)**: Human checkpoints as structured intervention points
 
-See [Debate Mode Design](/ideas/debate-mode) for detailed specification.
+See [Debate Mode Design](https://github.com/existential-birds/amelia/issues/202) for detailed specification.
 
 ---
 
@@ -296,7 +285,7 @@ A shared knowledge base that helps developers learn frameworks while providing a
 - **F3 (Own Context Window)**: Framework docs become structured context for code generation
 - **F13 (Pre-fetch Context)**: Relevant documentation pre-fetched based on task keywords
 
-See [Knowledge Library Design](/ideas/knowledge-library) for detailed specification.
+See [Knowledge Library Design](https://github.com/existential-birds/amelia/issues/203) for detailed specification.
 
 ---
 
@@ -494,10 +483,6 @@ def developer_node(state: State) -> State:
   - Recent commits touching related code
   - CI pipeline status
 - Include in Architect context for informed planning
-
-See [12-Factor Agents Compliance Analysis](/ideas/research/12-factor-compliance) for detailed factor-by-factor assessment.
-
-See [Context Engineering Gaps](/ideas/research/context-engineering-gaps) for agentic context management requirements that should be addressed in Phases 2-3.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes 21 dead links in VitePress documentation after the documentation cleanup in #205.

## Changes

### design-system/tokens.md
- Removed links to deleted files: `/design-system/diagrams`, `/design-system/presentations`

### design-system/typography.md
- Removed links to deleted files: `/design-system/color-system`, `/design-system/diagrams`, `/design-system/presentations`

### design-system/index.md
- Removed links to deleted files: `/design-system/color-system`, `/design-system/diagrams`, `/design-system/presentations`

### reference/roadmap.md
- Removed all `/ideas/research/context-engineering-gaps` references (8 occurrences)
- Removed `/ideas/research/12-factor-compliance` reference
- Updated `/ideas/spec-builder` → GitHub issue #204
- Updated `/ideas/debate-mode` → GitHub issue #202
- Updated `/ideas/knowledge-library` → GitHub issue #203

## Test plan

- [x] `pnpm build` passes with no dead link errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed exploratory items from design system documentation, including Color System exploration and diagram/presentation tools.
  * Consolidated Next Steps guidance across design documentation to emphasize core resources.
  * Simplified roadmap documentation structure and updated navigation references.
  * Removed Context Engineering references to streamline documentation hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->