### PR TITLE
docs: remove dead links from sidebar navigation

### DIFF
--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -8,20 +8,12 @@ const sharedSidebar = [
   {
     text: 'Ideas & Explorations',
     items: [
-      { text: 'Overview', link: '/ideas/' },
-      { text: 'Session Continuity', link: '/ideas/session-continuity' },
-      { text: 'Knowledge Library', link: '/ideas/knowledge-library' },
-      { text: 'Debate Mode', link: '/ideas/debate-mode' },
-      { text: 'Spec Builder', link: '/ideas/spec-builder' },
-      { text: 'Planning Workflows', link: '/ideas/planning-workflows' }
+      { text: 'Overview', link: '/ideas/' }
     ]
   },
   {
     text: 'Research',
     items: [
-      { text: 'Benchmarking', link: '/ideas/research/benchmarking' },
-      { text: '12-Factor Compliance', link: '/ideas/research/12-factor-compliance' },
-      { text: 'Context Engineering', link: '/ideas/research/context-engineering-gaps' },
       { text: 'Knowledge Agents', link: '/ideas/research/knowledge-agents' }
     ]
   },
@@ -36,10 +28,7 @@ const sharedSidebar = [
     collapsed: true,
     items: [
       { text: 'Getting Started', link: '/design-system/' },
-      { text: 'Color System', link: '/design-system/color-system' },
       { text: 'Typography', link: '/design-system/typography' },
-      { text: 'Diagrams', link: '/design-system/diagrams' },
-      { text: 'Presentations', link: '/design-system/presentations' },
       { text: 'Design Tokens', link: '/design-system/tokens' }
     ]
   }


### PR DESCRIPTION
## Summary

Removes 11 dead links from the VitePress sidebar navigation that were left behind after the documentation cleanup in #205.

**Dead links removed:**

| Section | Removed Links |
|---------|---------------|
| Ideas & Explorations | Session Continuity, Knowledge Library, Debate Mode, Spec Builder, Planning Workflows |
| Research | Benchmarking, 12-Factor Compliance, Context Engineering |
| Design System | Color System, Diagrams, Presentations |

## Test Plan

- [ ] Run `pnpm dev` in `docs/site/` and verify sidebar renders without errors
- [ ] Click through remaining sidebar links to confirm they resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation navigation to streamline the user experience. Simplified Ideas & Explorations, Research, and Design System sections by consolidating content and removing secondary documentation items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->