### PR TITLE
fix(dashboard): lower z-index of scanlines and vignette overlays

### DIFF
--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -59,18 +59,18 @@ export function Layout() {
             aria-hidden="true"
           />
 
-          {/* Glass scanlines - z-[100] */}
+          {/* Glass scanlines - z-[5] (behind content at z-10) */}
           <div
-            className="absolute inset-0 pointer-events-none z-[100]"
+            className="absolute inset-0 pointer-events-none z-[5]"
             style={{
               background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgb(239 248 226 / 0.01) 2px, rgb(239 248 226 / 0.01) 4px)',
             }}
             aria-hidden="true"
           />
 
-          {/* Vignette - z-[99] */}
+          {/* Vignette - z-[6] (behind content at z-10) */}
           <div
-            className="absolute inset-0 pointer-events-none z-[99]"
+            className="absolute inset-0 pointer-events-none z-[6]"
             style={{
               background: 'radial-gradient(ellipse at center, transparent 30%, rgb(13 26 18 / 0.6) 100%)',
             }}


### PR DESCRIPTION
## Summary

Fixes the visual bug where decorative overlay elements (glass scanlines and vignette) rendered on top of interactive content instead of behind it.

## Changes

### Fixed
- Glass scanlines z-index: `z-[100]` → `z-[5]`
- Vignette z-index: `z-[99]` → `z-[6]`

Both overlays now render below the content wrapper (`z-10`), creating the intended subtle background texture effect.

## Motivation

The scanline and vignette overlays were obscuring buttons and other UI elements. While `pointer-events-none` allowed clicking through them, the visual appearance was incorrect—the CRT-style texture should appear as a subtle background effect, not on top of interactive elements.

## Testing

- [x] Manual testing: verified overlays now appear behind buttons and interactive elements
- [x] Verified clicking behavior unchanged (still works due to `pointer-events-none`)

### Manual Testing Steps

1. Run `uv run amelia dev`
2. Navigate to any page with buttons
3. Verify scanlines appear as a subtle background texture behind all buttons and interactive elements

## Related Issues

- Closes #211

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted visual layering of decorative UI elements to ensure proper overlay presentation and element stacking order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->