### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-01-06
+
+### Added
+
+- **orchestrator:** Add plan validator node for LLM-based structured plan extraction ([#221](https://github.com/existential-birds/amelia/pull/221))
+  - Validates architect output into structured fields (goal, plan_markdown, key_files)
+  - Configurable validator model via `Profile.validator_model` for cost optimization
+  - New server configuration: checkpoint retention, stream tool results toggle
+- **architect:** Implement streaming agentic execution for codebase exploration ([#208](https://github.com/existential-birds/amelia/pull/208))
+- **drivers:** Unify agentic message abstraction across API and CLI drivers ([#201](https://github.com/existential-birds/amelia/pull/201))
+
+### Fixed
+
+- **core:** Normalize tool names across drivers to prevent inconsistent state ([#217](https://github.com/existential-birds/amelia/pull/217))
+- **dashboard:** Fix z-index layering of scanlines and vignette overlays ([#216](https://github.com/existential-birds/amelia/pull/216))
+
 ## [0.4.1] - 2026-01-01
 
 ### Fixed
@@ -147,7 +163,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/existential-birds/amelia/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/existential-birds/amelia/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/existential-birds/amelia/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/existential-birds/amelia/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/existential-birds/amelia/compare/v0.2.1...v0.2.2

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -18,7 +18,7 @@ from amelia.core.state import ExecutionState
 from amelia.main import app
 
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 __all__ = [
     "app",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "Elastic-2.0",
   "type": "module",
   "scripts": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.4.1"
+version = "0.5.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0
- Update CHANGELOG.md with changes since v0.4.1

### Highlights

**Added:**
- Plan validator node for LLM-based structured plan extraction
- Streaming agentic execution for architect codebase exploration
- Unified agentic message abstraction across drivers

**Fixed:**
- Tool name normalization across drivers
- Dashboard z-index layering issues

## Post-merge steps

After merging, run:
```
/release-tag 0.5.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)