### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-01-09
+
+### Added
+
+- **drivers:** Add driver-agnostic token usage tracking ([#252](https://github.com/existential-birds/amelia/pull/252))
+  - Unified `DriverUsage` model tracks tokens, cost, and duration across all driver types
+  - Both API and CLI drivers now emit consistent usage metrics
+  - Orchestrator aggregates usage per-agent for dashboard cost breakdown
+
+### Changed
+
+- **Breaking:** Auto-infer provider from driver setting, removing redundant configuration ([#254](https://github.com/existential-birds/amelia/pull/254))
+
+  **Migration:** Remove `provider` field from profile configuration. The provider is now automatically inferred from the driver setting (e.g., `api:openrouter` infers OpenRouter provider).
+
 ## [0.7.0] - 2026-01-08
 
 ### Added
@@ -202,7 +217,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/existential-birds/amelia/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/existential-birds/amelia/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/existential-birds/amelia/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/existential-birds/amelia/compare/v0.5.0...v0.5.1

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -18,7 +18,7 @@ from amelia.core.state import ExecutionState
 from amelia.main import app
 
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = [
     "app",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Elastic-2.0",
   "type": "module",
   "scripts": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.7.0"
+version = "0.8.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to 0.8.0
- Update CHANGELOG.md with changes since v0.7.0

### Breaking Changes

- **drivers:** Auto-infer provider from driver setting, removing redundant configuration (#254)

### New Features

- **drivers:** Add driver-agnostic token usage tracking (#252)

## Post-merge steps

After merging, run:
```
/release-tag 0.8.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)