### PR TITLE
fix(reviewer): rename remaining comment_count to issue_count

### DIFF
--- a/amelia/client/streaming.py
+++ b/amelia/client/streaming.py
@@ -70,10 +70,10 @@ def _format_review_completed(console: Console, event: dict[str, Any]) -> None:
     data = event.get("data", {}) or {}
     approved = data.get("approved", False)
     severity = data.get("severity", "unknown")
-    comment_count = data.get("comment_count", 0)
+    issue_count = data.get("issue_count", 0)
     status = "[green]approved[/green]" if approved else "[yellow]changes requested[/yellow]"
     console.print(
-        f"\n[bold]Review {status}[/bold] ({severity} severity, {comment_count} comments)"
+        f"\n[bold]Review {status}[/bold] ({severity} severity, {issue_count} issues)"
     )
 
 

--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -1736,18 +1736,18 @@ class OrchestratorService:
         # Node returns ReviewResult Pydantic model directly
         approved = last_review.approved
         severity = last_review.severity
-        comment_count = len(last_review.comments) if last_review.comments else 0
+        issue_count = len(last_review.comments) if last_review.comments else 0
 
         await self._emit(
             workflow_id,
             EventType.AGENT_MESSAGE,
             f"Review {'approved' if approved else 'requested changes'} "
-            f"({severity} severity, {comment_count} comments)",
+            f"({severity} severity, {issue_count} issues)",
             agent="reviewer",
             data={
                 "approved": approved,
                 "severity": severity,
-                "comment_count": comment_count,
+                "issue_count": issue_count,
             },
         )
 


### PR DESCRIPTION
## Summary

Completes the rename of `comment_count` to `issue_count` in the reviewer event data, ensuring consistency across the codebase after the terminology change from "comments" to "issues" for review findings.

## Changes

### Changed
- Renamed `comment_count` variable to `issue_count` in `amelia/server/orchestrator/service.py`
- Updated event data key from `comment_count` to `issue_count` 
- Updated display message from "comments" to "issues" in both server and client
- Updated client streaming handler to read `issue_count` from event data

## Motivation

The reviewer agent now uses "issues" terminology instead of "comments" to better reflect that review findings are issues to be addressed. This PR fixes the remaining occurrences that were missed in the previous rename, ensuring the event data emitted by the orchestrator and consumed by the CLI client uses consistent naming.

## Testing

- [x] Verified changes are consistent with the terminology used elsewhere
- [x] No functional behavior change, only variable/key naming

---

Generated with [Claude Code](https://claude.com/claude-code)