### PR TITLE
docs: update documentation for v0.8.0+ changes

### DIFF
--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 /**
- * Shared sidebar configuration for Ideas, Reference, and Design System sections.
+ * Shared sidebar configuration for Ideas and Reference sections.
  * Used across multiple URL prefixes to maintain consistent navigation.
  */
 const sharedSidebar = [
@@ -22,15 +22,6 @@ const sharedSidebar = [
     items: [
       { text: 'Roadmap', link: '/reference/roadmap' }
     ]
-  },
-  {
-    text: 'Design System',
-    collapsed: true,
-    items: [
-      { text: 'Getting Started', link: '/design-system/' },
-      { text: 'Typography', link: '/design-system/typography' },
-      { text: 'Design Tokens', link: '/design-system/tokens' }
-    ]
   }
 ]
 
@@ -39,7 +30,6 @@ const sharedSidebar = [
  *
  * Configures the Amelia documentation site with:
  * - Project-wide documentation
- * - Design system reference
  * - Ideas/brainstorming section
  * - Dark/light mode support
  */
@@ -87,7 +77,6 @@ export default defineConfig({
           ]
         }
       ],
-      '/design-system/': sharedSidebar,
       '/reference/': sharedSidebar,
       '/ideas/': sharedSidebar
     },

--- a/docs/site/architecture/concepts.md
+++ b/docs/site/architecture/concepts.md
@@ -68,15 +68,13 @@ The Developer uses an agentic execution model where the LLM autonomously decides
 
 **Role**: Reviews code changes, provides feedback, approves or requests fixes.
 
-**Strategies**:
-- `single`: One general review covering all aspects
-- `competitive`: Parallel reviews from Security, Performance, and Usability personas, then aggregated into final feedback
+The Reviewer uses agentic execution to auto-detect technologies, load appropriate review skills, and fetch the diff via git. It produces structured feedback with issues categorized by severity (critical, major, minor).
 
 | Output | Description |
 |--------|-------------|
 | `approved` | Boolean - whether changes are acceptable |
-| `comments` | Detailed feedback on the changes |
-| `severity` | Issue severity (low, medium, high, critical) |
+| `issues` | List of issues with severity (critical, major, minor) and descriptions |
+| `summary` | High-level summary of the review findings |
 
 The Reviewer examines code changes and either approves them or provides feedback. If changes are not approved, the Developer receives the feedback and attempts fixes. This review-fix loop continues until approved or the maximum iterations (`max_review_iterations`) is reached.
 

--- a/docs/site/architecture/data-model.md
+++ b/docs/site/architecture/data-model.md
@@ -8,7 +8,6 @@ This document describes the core data structures used throughout the Amelia orch
 |------|------------|-------------|
 | `DriverType` | `"cli:claude" \| "api:openai" \| "api:openrouter" \| "cli" \| "api"` | LLM driver type. |
 | `TrackerType` | `"jira" \| "github" \| "none" \| "noop"` | Issue tracker type. |
-| `StrategyType` | `"single" \| "competitive"` | Review strategy. |
 | `AgenticStatus` | `"running" \| "awaiting_approval" \| "completed" \| "failed" \| "cancelled"` | Agentic execution status. |
 | `Severity` | `"low" \| "medium" \| "high" \| "critical"` | Review issue severity. |
 
@@ -36,7 +35,6 @@ Defines the runtime environment and constraints.
 | `driver` | `DriverType` | — | LLM driver type (e.g., "api:openrouter", "cli:claude"). |
 | `model` | `str \| None` | `None` | LLM model identifier. Required for API drivers (e.g., "minimax/minimax-m2"). |
 | `tracker` | `TrackerType` | `"none"` | Issue tracker type. |
-| `strategy` | `StrategyType` | `"single"` | Review strategy (single or competitive). |
 | `working_dir` | `str \| None` | `None` | Working directory for agentic execution. |
 | `plan_output_dir` | `str` | `"docs/plans"` | Directory for saving implementation plans. |
 | `retry` | `RetryConfig` | `RetryConfig()` | Retry configuration for transient failures. |

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -219,10 +219,9 @@ async for event in developer.execute_agentic(
 # Get code changes
 code_changes = state.code_changes_for_review or get_git_diff("HEAD")
 
-# Run review (single or competitive strategy)
+# Run review
 reviewer = Reviewer(driver)
 review_result = await reviewer.review(state, code_changes)
-# Competitive: parallel Security/Performance/Usability reviews, aggregated
 
 state.last_review = review_result
 
@@ -242,7 +241,6 @@ class Profile(BaseModel):
     driver: DriverType                             # "api:openrouter" | "cli:claude" | "cli" | "api"
     model: str | None = None                       # Model identifier for API drivers
     tracker: TrackerType = "none"                  # "jira" | "github" | "none" | "noop"
-    strategy: StrategyType = "single"              # "single" | "competitive"
     working_dir: str | None = None
     plan_output_dir: str = "docs/plans"
     retry: RetryConfig = Field(default_factory=RetryConfig)
@@ -713,7 +711,7 @@ amelia/
 │   ├── __init__.py
 │   ├── architect.py          # Markdown plan generation with goal extraction
 │   ├── developer.py          # Agentic execution with streaming tool calls
-│   └── reviewer.py           # Code review (single/competitive strategies)
+│   └── reviewer.py           # Code review
 ├── client/
 │   ├── __init__.py
 │   ├── api.py                # AmeliaClient REST client

--- a/docs/site/guide/configuration.md
+++ b/docs/site/guide/configuration.md
@@ -18,7 +18,6 @@ profiles:
     name: work
     driver: cli:claude        # LLM via claude CLI
     tracker: jira             # Issues from Jira
-    strategy: competitive     # Multiple parallel reviewers
     plan_output_dir: "docs/plans"
     max_review_iterations: 5  # More iterations for complex reviews
     retry:
@@ -32,7 +31,6 @@ profiles:
     driver: api:openrouter    # LLM via OpenRouter API
     model: "minimax/minimax-m2"  # Required for API drivers
     tracker: github           # Issues from GitHub
-    strategy: single          # Single reviewer
     plan_output_dir: "docs/plans"
 
   # Testing profile
@@ -41,7 +39,6 @@ profiles:
     driver: api:openrouter
     model: "minimax/minimax-m2"
     tracker: noop             # No real tracker
-    strategy: single
 ```
 
 ## Profile Structure
@@ -102,17 +99,6 @@ Default: `"none"`
 | `github` | GitHub issues | `gh` CLI authenticated (`gh auth login`) |
 | `none` | No tracker | None |
 | `noop` | Alias for `none` | None |
-
-### `profiles.<name>.strategy` (optional)
-
-How code review is performed.
-
-Default: `"single"`
-
-| Value | Description | Behavior |
-|-------|-------------|----------|
-| `single` | One reviewer pass | General review from single LLM call |
-| `competitive` | Multiple parallel reviews | Security, Performance, Usability reviews run concurrently, results aggregated |
 
 ### `profiles.<name>.plan_output_dir` (optional)
 
@@ -237,7 +223,6 @@ Amelia validates profiles on startup:
 - Required fields (`name`, `driver`) must be present
 - Driver values must be one of: `api`, `api:openrouter`, `cli`, `cli:claude`
 - Tracker values must be one of: `jira`, `github`, `none`, `noop`
-- Strategy must be `single` or `competitive`
 - API drivers require the `model` field
 - Retry values must be within allowed ranges
 
@@ -268,7 +253,7 @@ profiles:
     model: "minimax/minimax-m2"
 ```
 
-This uses: `tracker: none`, `strategy: single`, default retry settings.
+This uses: `tracker: none`, default retry settings.
 
 ### Enterprise (CLI + Jira)
 
@@ -281,7 +266,6 @@ profiles:
     name: work
     driver: cli:claude
     tracker: jira
-    strategy: competitive
     max_review_iterations: 5
 ```
 
@@ -297,21 +281,18 @@ profiles:
     name: work
     driver: cli:claude
     tracker: jira
-    strategy: competitive
 
   home:
     name: home
     driver: api:openrouter
     model: "minimax/minimax-m2"
     tracker: github
-    strategy: single
 
   test:
     name: test
     driver: api:openrouter
     model: "minimax/minimax-m2"
     tracker: noop
-    strategy: single
 ```
 
 Usage:

--- a/docs/site/guide/usage.md
+++ b/docs/site/guide/usage.md
@@ -16,7 +16,6 @@ profiles:
     driver: api:openrouter
     model: "minimax/minimax-m2"
     tracker: github
-    strategy: single
 ```
 
 ## Configuration
@@ -31,7 +30,6 @@ Amelia uses profile-based configuration in `settings.amelia.yaml`. See [Configur
 | `driver` | Yes | - | LLM driver: `api:openrouter`, `api`, `cli:claude`, or `cli` |
 | `model` | API only | - | LLM model identifier (required for API drivers) |
 | `tracker` | No | `none` | Issue source: `github`, `jira`, `none`, or `noop` |
-| `strategy` | No | `single` | Review strategy: `single` or `competitive` |
 | `plan_output_dir` | No | `docs/plans` | Directory for generated plans |
 | `working_dir` | No | `null` | Working directory for agentic execution |
 | `max_review_iterations` | No | `3` | Maximum review-fix loop iterations |
@@ -78,7 +76,6 @@ profiles:
     driver: api:openrouter
     model: "minimax/minimax-m2"
     tracker: github
-    strategy: single
     plan_output_dir: "docs/plans"
     max_review_iterations: 3
     retry:
@@ -90,7 +87,6 @@ profiles:
     name: enterprise
     driver: cli:claude
     tracker: jira
-    strategy: competitive
     max_review_iterations: 5
     retry:
       max_retries: 5


### PR DESCRIPTION
## Summary

Updates VitePress documentation to reflect codebase changes since v0.8.0, including the reviewer consolidation (#271) and planning status feature (#269).

## Changes

### Removed
- All `strategy` field references from configuration examples and docs
- `StrategyType` type alias from data model documentation
- Competitive/single review strategy descriptions
- Design System section from navigation (content still exists but not linked)

### Changed
- Rewrote Reviewer section in `concepts.md` to describe agentic-only design
- Updated Profile documentation to remove `strategy` field

### Added
- `planning` status to workflow state transitions in troubleshooting guide
- New troubleshooting section for "Workflow stuck in planning state"
- Clarification that planning status does NOT block worktree

## Testing

- [x] VitePress build succeeds (`pnpm build`)
- [x] Verified no stale `strategy` field references remain
- [x] Verified no `StrategyType` references remain

## Related Issues

- Follows #271 (consolidate reviewer to agentic-only)
- Follows #269 (planning status feature)

---

Generated with [Claude Code](https://claude.com/claude-code)