### PR TITLE
fix(orchestrator): remove duplicate STAGE_STARTED emission in planning flow

### DIFF
--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -2064,15 +2064,6 @@ class OrchestratorService:
         # Resolve prompts for architect
         prompts = await self._resolve_prompts(workflow_id)
 
-        # Emit STAGE_STARTED for architect so dashboard shows it as active
-        await self._emit(
-            workflow_id,
-            EventType.STAGE_STARTED,
-            "Starting architect",
-            agent="architect",
-            data={"stage": "architect_node"},
-        )
-
         async with AsyncSqliteSaver.from_conn_string(
             str(self._checkpoint_path)
         ) as checkpointer:


### PR DESCRIPTION
## Summary

Remove the explicit `STAGE_STARTED` emission in `_run_planning_task` that caused the dashboard to show "2 runs" for the architect node and emit duplicate "Starting architect" messages.

## Changes

### Removed
- Redundant `STAGE_STARTED` emission before `graph.astream()` in `_run_planning_task`

## Motivation

When running `plan_now` or `queue` with planning, the architect node showed "2 runs" in the dashboard due to duplicate `STAGE_STARTED` emissions:

1. **Explicit pre-emission** (removed): Added to show architect as active before stream started
2. **Automatic emission** (kept): `_handle_tasks_event` emits when LangGraph's task stream reports the node starting

The pre-emission was added before the combined stream mode (`["updates", "tasks"]`) was adopted. Now that task events auto-trigger `STAGE_STARTED` via `_handle_tasks_event`, it's redundant.

## Testing

- [x] Unit tests pass
- [x] Pre-push hooks pass (ruff, mypy, pytest)

## Related Issues

- Closes #276

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)