### PR TITLE
fix(docs): improve VitePress theme readability and visual consistency

### DIFF
--- a/docs/site/.vitepress/theme/custom.css
+++ b/docs/site/.vitepress/theme/custom.css
@@ -156,12 +156,12 @@
   border-radius: 2px;
 }
 
-/* Light mode gradient - terracotta to blue */
+/* Light mode gradient - forest green to gold */
 html:not(.dark) .vp-doc h1::before {
   background: linear-gradient(
     180deg,
-    oklch(50% 0.15 30) 0%,
-    var(--vp-c-brand-1) 100%
+    var(--vp-c-brand-3) 0%,
+    #C9A030 100%
   );
 }
 
@@ -177,6 +177,18 @@ html:not(.dark) .vp-doc h1::before {
 
 /* Ensure the outline area has proper background in both themes */
 .VPDocAside {
+  background-color: var(--vp-c-bg);
+}
+
+/* Mobile "On this page" dropdown - needs solid background */
+.VPLocalNavOutlineDropdown .items {
+  background-color: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 8px 24px var(--shadow-color-medium);
+}
+
+/* The entire flyout container */
+.VPLocalNavOutlineDropdown .items-container {
   background-color: var(--vp-c-bg);
 }
 

--- a/docs/site/.vitepress/theme/style.css
+++ b/docs/site/.vitepress/theme/style.css
@@ -17,67 +17,67 @@
   --shadow-color-medium: oklch(0% 0 0 / 0.15);
   --shadow-color-strong: oklch(0% 0 0 / 0.4);
 
-  /* Base colors */
-  --vp-c-bg: #FDF8F0;
-  --vp-c-bg-alt: #FFFDF9;
-  --vp-c-bg-elv: #F5F1E8;
+  /* Base colors - Warmer, less bright */
+  --vp-c-bg: #E8E4DA;
+  --vp-c-bg-alt: #F0EDE5;
+  --vp-c-bg-elv: #D8D4CA;
   --vp-c-text-1: #1A2F23;
-  --vp-c-text-2: #5C7263;
-  --vp-c-text-3: #88A896;
+  --vp-c-text-2: #4A5C50;
+  --vp-c-text-3: #6B7A70;
 
-  /* Brand colors - Professional Blue */
-  --vp-c-brand-1: #2E6B9C;
-  --vp-c-brand-2: #4A88C0;
-  --vp-c-brand-3: #235782;
-  --vp-c-brand-soft: rgba(46, 107, 156, 0.16);
+  /* Brand colors - Forest Green (matches dark mode's green tones) */
+  --vp-c-brand-1: #3D7552;
+  --vp-c-brand-2: #4A8A62;
+  --vp-c-brand-3: #2E5E40;
+  --vp-c-brand-soft: rgba(61, 117, 82, 0.14);
 
   /* Default (muted/neutral) */
   --vp-c-default-1: #5C7263;
-  --vp-c-default-2: #88A896;
-  --vp-c-default-3: #B8AE9C;
-  --vp-c-default-soft: rgba(92, 114, 99, 0.16);
+  --vp-c-default-2: #7A8A80;
+  --vp-c-default-3: #9AA89F;
+  --vp-c-default-soft: rgba(92, 114, 99, 0.12);
 
   /* Tip - Green accent */
   --vp-c-tip-1: #3D7552;
   --vp-c-tip-2: #5B8A72;
   --vp-c-tip-3: #2E5E40;
-  --vp-c-tip-soft: rgba(61, 117, 82, 0.16);
+  --vp-c-tip-soft: rgba(61, 117, 82, 0.12);
 
-  /* Warning - Gold */
-  --vp-c-warning-1: #E8B84A;
-  --vp-c-warning-2: #F0C766;
-  --vp-c-warning-3: #D4A63D;
-  --vp-c-warning-soft: rgba(232, 184, 74, 0.16);
+  /* Warning - Gold/Amber */
+  --vp-c-warning-1: #C9A030;
+  --vp-c-warning-2: #D4B050;
+  --vp-c-warning-3: #B08A20;
+  --vp-c-warning-soft: rgba(201, 160, 48, 0.14);
 
-  /* Danger - Red accent */
+  /* Danger - Deep Red */
   --vp-c-danger-1: #8B3224;
   --vp-c-danger-2: #A33D2E;
   --vp-c-danger-3: #72271C;
-  --vp-c-danger-soft: rgba(139, 50, 36, 0.16);
+  --vp-c-danger-soft: rgba(139, 50, 36, 0.12);
 
-  /* Info - Blue accent */
-  --vp-c-info-1: #2E6B9C;
-  --vp-c-info-2: #4A88C0;
-  --vp-c-info-3: #235782;
-  --vp-c-info-soft: rgba(46, 107, 156, 0.16);
+  /* Info - Muted Blue */
+  --vp-c-info-1: #4A7A9C;
+  --vp-c-info-2: #5A8AAC;
+  --vp-c-info-3: #3A6A8C;
+  --vp-c-info-soft: rgba(74, 122, 156, 0.12);
 
   /* Background variations */
-  --vp-c-bg-soft: rgba(26, 47, 35, 0.08);
-  --vp-c-divider: rgba(26, 47, 35, 0.15);
-  --vp-c-gutter: rgba(26, 47, 35, 0.1);
+  --vp-c-bg-soft: rgba(26, 47, 35, 0.06);
+  --vp-c-divider: rgba(26, 47, 35, 0.12);
+  --vp-c-gutter: rgba(26, 47, 35, 0.08);
 
-  /* Heading colors - Terracotta (light mode) */
-  --vp-c-heading-1: oklch(50% 0.15 30);   /* Deep terracotta */
-  --vp-c-heading-2: oklch(55% 0.13 35);   /* Lighter terracotta */
+  /* Heading colors - Forest Green (cohesive with brand) */
+  --vp-c-heading-1: oklch(38% 0.08 150);   /* Deep forest */
+  --vp-c-heading-2: oklch(42% 0.07 150);   /* Slightly lighter forest */
 
   /* Terminal Hero - inverted theme (light site → dark terminal) */
-  --terminal-bg: #0D1A12;            /* Deep forest background */
-  --terminal-text: #EFF8E2;          /* Light cream text */
-  --terminal-text-dim: #88A896;      /* Muted green */
+  --terminal-bg: #050A07;            /* Near-black (matches dark mode bg) */
+  --terminal-text: #E8F0DC;          /* Light cream text */
+  --terminal-text-dim: #6B8A78;      /* Muted green */
   --terminal-accent: #FFC857;        /* Gold accent */
   --terminal-success: #5B8A72;       /* Brighter green */
-  --terminal-chrome: #2B3D35;        /* Darker forest chrome */
-  --terminal-border: #4A5C54;        /* Subtle forest border */
+  --terminal-chrome: #12201A;        /* Darker forest chrome */
+  --terminal-border: #3A4D42;        /* Subtle forest border */
 }
 
 /**
@@ -86,54 +86,54 @@
  * -------------------------------------------------------------------------- */
 
 .dark {
-  /* Base colors */
-  --vp-c-bg: #0D1A12;
-  --vp-c-bg-alt: #1F332E;
-  --vp-c-bg-elv: #2B3D35;
-  --vp-c-text-1: #EFF8E2;
-  --vp-c-text-2: #88A896;
-  --vp-c-text-3: #5C7263;
+  /* Base colors - MUCH DARKER */
+  --vp-c-bg: #050A07;
+  --vp-c-bg-alt: #0A1410;
+  --vp-c-bg-elv: #12201A;
+  --vp-c-text-1: #E8F0DC;
+  --vp-c-text-2: #6B8A78;
+  --vp-c-text-3: #465C4E;
 
   /* Brand colors - Gold */
   --vp-c-brand-1: #FFC857;
   --vp-c-brand-2: #FFD580;
   --vp-c-brand-3: #E5B350;
-  --vp-c-brand-soft: rgba(255, 200, 87, 0.16);
+  --vp-c-brand-soft: rgba(255, 200, 87, 0.12);
 
   /* Default (muted/neutral) */
-  --vp-c-default-1: #88A896;
-  --vp-c-default-2: #5C7263;
-  --vp-c-default-3: #4A5C54;
-  --vp-c-default-soft: rgba(136, 168, 150, 0.16);
+  --vp-c-default-1: #6B8A78;
+  --vp-c-default-2: #465C4E;
+  --vp-c-default-3: #3A4D42;
+  --vp-c-default-soft: rgba(107, 138, 120, 0.12);
 
   /* Tip - Green accent */
   --vp-c-tip-1: #5B8A72;
   --vp-c-tip-2: #6FA083;
   --vp-c-tip-3: #4A7260;
-  --vp-c-tip-soft: rgba(91, 138, 114, 0.16);
+  --vp-c-tip-soft: rgba(91, 138, 114, 0.12);
 
   /* Warning - Gold */
   --vp-c-warning-1: #FFC857;
   --vp-c-warning-2: #FFD580;
   --vp-c-warning-3: #E5B350;
-  --vp-c-warning-soft: rgba(255, 200, 87, 0.16);
+  --vp-c-warning-soft: rgba(255, 200, 87, 0.12);
 
   /* Danger - Red accent */
   --vp-c-danger-1: #A33D2E;
   --vp-c-danger-2: #C14D3A;
   --vp-c-danger-3: #8B3224;
-  --vp-c-danger-soft: rgba(163, 61, 46, 0.16);
+  --vp-c-danger-soft: rgba(163, 61, 46, 0.12);
 
   /* Info - Blue accent */
   --vp-c-info-1: #5B9BD5;
   --vp-c-info-2: #7AADE0;
   --vp-c-info-3: #4A88C0;
-  --vp-c-info-soft: rgba(91, 155, 213, 0.16);
+  --vp-c-info-soft: rgba(91, 155, 213, 0.12);
 
   /* Background variations */
-  --vp-c-bg-soft: rgba(47, 61, 53, 0.3);
-  --vp-c-divider: rgba(47, 61, 53, 0.2);
-  --vp-c-gutter: rgba(47, 61, 53, 0.15);
+  --vp-c-bg-soft: rgba(30, 45, 38, 0.25);
+  --vp-c-divider: rgba(30, 45, 38, 0.18);
+  --vp-c-gutter: rgba(30, 45, 38, 0.12);
 
   /* Heading colors - Coral (dark mode) */
   --vp-c-heading-1: oklch(72% 0.14 35);   /* Warm coral */
@@ -147,6 +147,12 @@
   --terminal-success: #3D7552;       /* Green */
   --terminal-chrome: #F5F1E8;        /* Light cream chrome */
   --terminal-border: #B8AE9C;        /* Subtle border */
+
+  /* Shadow colors - lighter for dark backgrounds */
+  --shadow-color-subtle: oklch(0% 0 0 / 0.15);
+  --shadow-color-soft: oklch(0% 0 0 / 0.25);
+  --shadow-color-medium: oklch(0% 0 0 / 0.35);
+  --shadow-color-strong: oklch(0% 0 0 / 0.6);
 }
 
 /**
@@ -215,11 +221,11 @@
   --vp-button-brand-active-bg: var(--vp-c-brand-3);
 }
 
-/* Light mode button text adjustments - need light text on dark blue buttons */
+/* Light mode button text adjustments - need light text on dark green buttons */
 html:not(.dark) {
-  --vp-button-brand-text: #FFFDF9;
-  --vp-button-brand-hover-text: #FFFDF9;
-  --vp-button-brand-active-text: #FFFDF9;
+  --vp-button-brand-text: #F0EDE5;
+  --vp-button-brand-hover-text: #F0EDE5;
+  --vp-button-brand-active-text: #F0EDE5;
 }
 
 /**
@@ -241,12 +247,12 @@ html:not(.dark) {
   --vp-home-hero-image-filter: blur(40px);
 }
 
-/* Light mode hero gradient - terracotta to professional blue for visual interest */
+/* Light mode hero gradient - forest green to gold for cohesive feel */
 html:not(.dark) {
   --vp-home-hero-name-background: linear-gradient(
     120deg,
-    oklch(50% 0.15 30) 30%,
-    #2E6B9C
+    #2E5E40 30%,
+    #C9A030
   );
 }
 
@@ -331,12 +337,12 @@ html:not(.dark) {
  * -------------------------------------------------------------------------- */
 
 :root {
-  --vp-code-block-bg: rgba(47, 61, 53, 0.4);
+  --vp-code-block-bg: rgba(20, 35, 28, 0.5);
   --vp-code-tab-divider: var(--vp-c-divider);
-  --vp-code-copy-code-border-color: rgba(255, 200, 87, 0.3);
-  --vp-code-copy-code-bg: rgba(47, 61, 53, 0.6);
+  --vp-code-copy-code-border-color: rgba(255, 200, 87, 0.2);
+  --vp-code-copy-code-bg: rgba(20, 35, 28, 0.7);
   --vp-code-copy-code-hover-border-color: var(--vp-c-brand-1);
-  --vp-code-copy-code-hover-bg: rgba(47, 61, 53, 0.8);
+  --vp-code-copy-code-hover-bg: rgba(20, 35, 28, 0.9);
   --vp-code-copy-code-active-text: var(--vp-c-brand-1);
 }
 
@@ -372,7 +378,7 @@ html:not(.dark) {
  * -------------------------------------------------------------------------- */
 
 .dark {
-  --grid-line-color: rgba(136, 168, 150, 0.04);
+  --grid-line-color: rgba(136, 168, 150, 0.025);
 }
 
 /* Subtle grid pattern on main content area */
@@ -389,8 +395,8 @@ html:not(.dark) {
   background:
     radial-gradient(
       ellipse at 70% 30%,
-      rgba(255, 200, 87, 0.04) 0%,
+      rgba(255, 200, 87, 0.03) 0%,
       transparent 50%
     ),
-    url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.015'/%3E%3C/svg%3E");
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.012'/%3E%3C/svg%3E");
 }


### PR DESCRIPTION
## Summary

Fixes the mobile "On this page" outline menu transparency issue and refines the VitePress theme color palette for better readability and visual consistency across light and dark modes.

## Changes

### Fixed
- Mobile "On this page" dropdown now has a solid background instead of transparent, preventing content from showing through when scrolling

### Changed
- **Light mode**: Warmer, less bright base colors with forest green brand palette (replacing blue)
- **Dark mode**: Significantly darker backgrounds for better contrast
- Heading gradients now use forest green to gold, matching the updated brand colors
- Reduced opacity values throughout for a softer visual appearance
- Terminal hero colors adjusted to match the darker dark mode theme

## Motivation

The transparent outline dropdown caused readability issues on mobile when page content scrolled behind the fixed position menu. The broader color refinements create a more cohesive theme with better contrast and visual harmony between light and dark modes.

## Testing

- [x] Manual testing performed - verified on both desktop and mobile viewports
- [x] Checked light and dark mode transitions
- [x] Verified code blocks, hero section, and outline menu styling

### Manual Testing Steps

1. Run `pnpm dev` in `docs/site/`
2. Navigate to any documentation page
3. On mobile viewport (or browser dev tools), tap "On this page" dropdown
4. Scroll the page - dropdown should maintain solid background
5. Toggle between light/dark modes to verify color consistency

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)