### PR TITLE
fix(dashboard): remove unused ripple animation from QuickShotModal

### DIFF
--- a/dashboard/src/components/__tests__/QuickShotModal.test.tsx
+++ b/dashboard/src/components/__tests__/QuickShotModal.test.tsx
@@ -340,7 +340,7 @@ describe('QuickShotModal', () => {
 
       await user.click(screen.getByRole('button', { name: /^start$/i }));
 
-      // Wait for the launching state to appear (after 400ms ripple animation)
+      // Wait for the launching state to appear
       await waitFor(() => {
         expect(screen.getByText(/launching/i)).toBeInTheDocument();
       });

--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -368,17 +368,6 @@
   }
 }
 
-@keyframes quick-shot-lightning-ripple {
-  0% {
-    transform: scale(0);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(2.5);
-    opacity: 0;
-  }
-}
-
 @keyframes quick-shot-scan-line {
   0% { left: -100%; }
   100% { left: 100%; }
@@ -403,10 +392,6 @@
 
   .animate-quick-shot-charge {
     animation: quick-shot-charge-pulse 2s ease-in-out infinite;
-  }
-
-  .animate-quick-shot-ripple {
-    animation: quick-shot-lightning-ripple 400ms ease-out;
   }
 
   .animate-quick-shot-scan {


### PR DESCRIPTION
## Summary

Removes dead CSS code and an outdated test comment that were left over from the ripple effect removal in QuickShotModal.

## Changes

### Removed
- `@keyframes quick-shot-lightning-ripple` animation keyframes from globals.css
- `.animate-quick-shot-ripple` utility class from globals.css

### Fixed
- Updated test comment to remove outdated "400ms ripple animation" reference

## Motivation

Issue #261 identified that the ripple effect was removed from QuickShotModal but some artifacts remained:
- CSS animation definitions were no longer used
- Test comment referenced the old 400ms delay behavior

This cleanup removes the dead code to reduce CSS bundle size and prevent confusion.

## Testing

- [x] Unit tests pass (22 QuickShotModal tests)
- [x] Linting passes
- [x] Type checking passes

### Verification

```bash
pnpm test:run QuickShotModal  # All 22 tests pass
```

## Related Issues

- Closes #261

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)