### PR TITLE
fix(docs): remove broken Bebas Neue font symlink

### DIFF
--- a/docs/site/.vitepress/theme/style.css
+++ b/docs/site/.vitepress/theme/style.css
@@ -166,7 +166,7 @@
 
   /* Custom heading font */
   --amelia-font-heading: "Barlow Condensed", sans-serif;
-  --amelia-font-display: "Bebas Neue", sans-serif;
+  --amelia-font-display: "Barlow Condensed", sans-serif;
 }
 
 /* Technical monospace headings for H1-H2 - signals engineering credibility */

--- a/docs/site/public/fonts/bebas-neue-regular.woff2
+++ b/docs/site/public/fonts/bebas-neue-regular.woff2
@@ -1,1 +1,0 @@
-../../../../design-system/assets/fonts/bebas-neue-regular.woff2

--- a/docs/site/public/fonts/fonts.css
+++ b/docs/site/public/fonts/fonts.css
@@ -8,15 +8,6 @@
  * This ensures paths work correctly regardless of VitePress base path configuration.
  */
 
-/* Bebas Neue - Display font for headers */
-@font-face {
-  font-family: 'Bebas Neue';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('./bebas-neue-regular.woff2') format('woff2');
-}
-
 /* Barlow Condensed - Primary UI font */
 @font-face {
   font-family: 'Barlow Condensed';


### PR DESCRIPTION
## Summary
- Removed broken symlink `bebas-neue-regular.woff2` that pointed to deleted `design-system/` folder
- Updated `--amelia-font-display` to use Barlow Condensed (already available) instead of Bebas Neue

## Test plan
- [x] `pnpm build` in `docs/site/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)