### PR TITLE
refactor: remove dead code from Architect.analyze() and StructuredReviewResult paths

### DIFF
--- a/amelia/agents/__init__.py
+++ b/amelia/agents/__init__.py
@@ -12,8 +12,6 @@ Exports:
     EvaluatedItem: A single evaluated feedback item with disposition.
     EvaluationResult: Collection of evaluated items with summary.
     Reviewer: Review code changes and provide structured feedback.
-    ReviewItem: A single review comment with severity and location.
-    StructuredReviewResult: Parsed review output with approval status.
 """
 
 from amelia.agents.architect import Architect
@@ -24,7 +22,7 @@ from amelia.agents.evaluator import (
     EvaluationResult,
     Evaluator,
 )
-from amelia.agents.reviewer import Reviewer, ReviewItem, StructuredReviewResult
+from amelia.agents.reviewer import Reviewer
 
 
 __all__ = [
@@ -34,7 +32,5 @@ __all__ = [
     "EvaluatedItem",
     "EvaluationResult",
     "Evaluator",
-    "ReviewItem",
     "Reviewer",
-    "StructuredReviewResult",
 ]

--- a/amelia/agents/prompts/defaults.py
+++ b/amelia/agents/prompts/defaults.py
@@ -29,13 +29,6 @@ class PromptDefault(BaseModel):
 
 
 PROMPT_DEFAULTS: dict[str, PromptDefault] = {
-    "architect.system": PromptDefault(
-        agent="architect",
-        name="Architect System Prompt",
-        description="Defines the architect's role for general analysis tasks",
-        content="""You are a senior software architect creating implementation plans.
-Your role is to analyze issues and produce detailed markdown implementation plans.""",
-    ),
     "architect.plan": PromptDefault(
         agent="architect",
         name="Architect Plan Format",
@@ -89,26 +82,6 @@ Guidelines:
 - Include TDD approach: write test first, run to verify it fails, implement, run to verify it passes
 - Be specific about file paths, commands, and expected outputs
 - Keep steps granular (2-5 minutes of work each)""",
-    ),
-    "reviewer.structured": PromptDefault(
-        agent="reviewer",
-        name="Reviewer Structured Prompt",
-        description="Instructions for code review with structured JSON output",
-        content="""You are an expert code reviewer. Review the provided code changes and produce structured feedback.
-
-OUTPUT FORMAT:
-- Summary: 1-2 sentence overview
-- Items: Numbered list with format [FILE:LINE] TITLE
-  - For each item provide: Issue (what's wrong), Why (why it matters), Fix (recommended solution)
-- Good Patterns: List things done well to preserve
-- Verdict: "approved" | "needs_fixes" | "blocked"
-
-SEVERITY LEVELS:
-- critical: Blocking issues (security, data loss, crashes)
-- major: Should fix before merge (bugs, performance, maintainability)
-- minor: Nice to have (style, minor improvements)
-
-Be specific with file paths and line numbers. Provide actionable feedback.""",
     ),
     "reviewer.agentic": PromptDefault(
         agent="reviewer",

--- a/amelia/pipelines/implementation/state.py
+++ b/amelia/pipelines/implementation/state.py
@@ -19,7 +19,6 @@ from amelia.pipelines.base import BasePipelineState
 
 if TYPE_CHECKING:
     from amelia.agents.evaluator import EvaluationResult
-    from amelia.agents.reviewer import StructuredReviewResult
 
 
 class ImplementationState(BasePipelineState):
@@ -67,7 +66,6 @@ class ImplementationState(BasePipelineState):
     task_review_iteration: int = 0
 
     # Structured review workflow
-    structured_review: StructuredReviewResult | None = None
     evaluation_result: EvaluationResult | None = None
     approved_items: list[int] = Field(default_factory=list)
     auto_approve: bool = False
@@ -82,8 +80,8 @@ class ImplementationState(BasePipelineState):
 def rebuild_implementation_state() -> None:
     """Rebuild ImplementationState to resolve forward references.
 
-    Must be called after importing StructuredReviewResult and EvaluationResult
-    to enable Pydantic validation and Python's get_type_hints() to work.
+    Must be called after importing EvaluationResult to enable Pydantic
+    validation and Python's get_type_hints() to work.
 
     This function:
     1. Imports the forward-referenced types
@@ -97,18 +95,15 @@ def rebuild_implementation_state() -> None:
     import sys  # noqa: PLC0415
 
     from amelia.agents.evaluator import EvaluationResult  # noqa: PLC0415
-    from amelia.agents.reviewer import StructuredReviewResult  # noqa: PLC0415
 
     # Inject types into this module's namespace for get_type_hints() compatibility.
     # These dynamic assignments are required for Python's typing.get_type_hints()
     # to resolve forward references when used by LangGraph's StateGraph.
     module = sys.modules[__name__]
-    module.StructuredReviewResult = StructuredReviewResult  # type: ignore[attr-defined]  # Dynamic module injection for LangGraph
     module.EvaluationResult = EvaluationResult  # type: ignore[attr-defined]  # Dynamic module injection for LangGraph
 
     ImplementationState.model_rebuild(
         _types_namespace={
-            "StructuredReviewResult": StructuredReviewResult,
             "EvaluationResult": EvaluationResult,
         }
     )

--- a/amelia/server/models/state.py
+++ b/amelia/server/models/state.py
@@ -189,19 +189,16 @@ def rebuild_server_execution_state() -> None:
     import sys  # noqa: PLC0415
 
     from amelia.agents.evaluator import EvaluationResult  # noqa: PLC0415
-    from amelia.agents.reviewer import StructuredReviewResult  # noqa: PLC0415
     from amelia.pipelines.implementation.state import ImplementationState  # noqa: PLC0415
 
     # Inject types into this module's namespace for get_type_hints() compatibility
     module = sys.modules[__name__]
     module.ImplementationState = ImplementationState  # type: ignore[attr-defined]  # Dynamic module injection for LangGraph
-    module.StructuredReviewResult = StructuredReviewResult  # type: ignore[attr-defined]  # Dynamic module injection for LangGraph
     module.EvaluationResult = EvaluationResult  # type: ignore[attr-defined]  # Dynamic module injection for LangGraph
 
     ServerExecutionState.model_rebuild(
         _types_namespace={
             "ImplementationState": ImplementationState,
-            "StructuredReviewResult": StructuredReviewResult,
             "EvaluationResult": EvaluationResult,
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ from amelia.server.database import ProfileRecord
 from amelia.server.events.bus import EventBus
 
 
-# Rebuild state models to resolve forward references for StructuredReviewResult
-# and EvaluationResult. This must be called before any tests instantiate these states.
+# Rebuild state models to resolve forward references for EvaluationResult.
+# This must be called before any tests instantiate these states.
 rebuild_implementation_state()
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,7 +29,7 @@ from amelia.server.models.state import (
 )
 
 
-# Rebuild ImplementationState first (resolves StructuredReviewResult, EvaluationResult),
+# Rebuild ImplementationState first (resolves EvaluationResult),
 # then ServerExecutionState (resolves ImplementationState union member)
 rebuild_implementation_state()
 rebuild_server_execution_state()

--- a/tests/unit/agents/prompts/test_defaults.py
+++ b/tests/unit/agents/prompts/test_defaults.py
@@ -8,15 +8,13 @@ from amelia.agents.prompts.defaults import PROMPT_DEFAULTS
 
 def test_prompt_default_is_frozen() -> None:
     """PromptDefault should be immutable."""
-    default = PROMPT_DEFAULTS["architect.system"]
+    default = PROMPT_DEFAULTS["architect.plan"]
     with pytest.raises(ValidationError, match="Instance is frozen"):
         default.agent = "modified"  # type: ignore[misc]  # Intentional: testing frozen model rejects assignment
 
 
 @pytest.mark.parametrize("prompt_id,expected_agent", [
-    ("architect.system", "architect"),
     ("architect.plan", "architect"),
-    ("reviewer.structured", "reviewer"),
     ("reviewer.agentic", "reviewer"),
 ])
 def test_prompt_default_exists(prompt_id: str, expected_agent: str) -> None:

--- a/tests/unit/agents/prompts/test_resolver.py
+++ b/tests/unit/agents/prompts/test_resolver.py
@@ -25,35 +25,35 @@ class TestGetPrompt:
     async def test_returns_default_when_no_custom_version(self, mock_repository) -> None:
         """Should return default when no custom version set."""
         mock_repository.get_prompt.return_value = Prompt(
-            id="architect.system",
+            id="architect.plan",
             agent="architect",
-            name="Architect System Prompt",
+            name="Architect Plan Format",
             current_version_id=None,  # No custom version
         )
         resolver = PromptResolver(mock_repository)
-        result = await resolver.get_prompt("architect.system")
+        result = await resolver.get_prompt("architect.plan")
 
         assert result.is_default is True
         assert result.version_id is None
-        assert result.content == PROMPT_DEFAULTS["architect.system"].content
+        assert result.content == PROMPT_DEFAULTS["architect.plan"].content
 
     async def test_returns_custom_version_when_set(self, mock_repository) -> None:
         """Should return custom version content when active."""
         custom_content = "Custom architect prompt..."
         mock_repository.get_prompt.return_value = Prompt(
-            id="architect.system",
+            id="architect.plan",
             agent="architect",
-            name="Architect System Prompt",
+            name="Architect Plan Format",
             current_version_id="v-123",
         )
         mock_repository.get_version.return_value = PromptVersion(
             id="v-123",
-            prompt_id="architect.system",
+            prompt_id="architect.plan",
             version_number=3,
             content=custom_content,
         )
         resolver = PromptResolver(mock_repository)
-        result = await resolver.get_prompt("architect.system")
+        result = await resolver.get_prompt("architect.plan")
 
         assert result.is_default is False
         assert result.version_id == "v-123"
@@ -64,10 +64,10 @@ class TestGetPrompt:
         """Should return default when database fails."""
         mock_repository.get_prompt.side_effect = Exception("DB error")
         resolver = PromptResolver(mock_repository)
-        result = await resolver.get_prompt("architect.system")
+        result = await resolver.get_prompt("architect.plan")
 
         assert result.is_default is True
-        assert result.content == PROMPT_DEFAULTS["architect.system"].content
+        assert result.content == PROMPT_DEFAULTS["architect.plan"].content
 
     async def test_raises_for_unknown_prompt(self, mock_repository) -> None:
         """Should raise ValueError for unknown prompt ID."""
@@ -88,9 +88,9 @@ class TestGetAllActive:
         result = await resolver.get_all_active()
 
         assert len(result) == len(PROMPT_DEFAULTS)
-        assert "architect.system" in result
         assert "architect.plan" in result
-        assert "reviewer.structured" in result
+        assert "reviewer.agentic" in result
+        assert "evaluator.system" in result
 
 
 class TestRecordForWorkflow:
@@ -99,14 +99,14 @@ class TestRecordForWorkflow:
     async def test_records_custom_versions_only(self, mock_repository) -> None:
         """Should only record custom versions, not defaults."""
         mock_repository.get_prompt.return_value = Prompt(
-            id="architect.system",
+            id="architect.plan",
             agent="architect",
-            name="Test",
+            name="Architect Plan Format",
             current_version_id="v-123",
         )
         mock_repository.get_version.return_value = PromptVersion(
             id="v-123",
-            prompt_id="architect.system",
+            prompt_id="architect.plan",
             version_number=1,
             content="Custom content",
         )

--- a/tests/unit/agents/test_architect_prompts.py
+++ b/tests/unit/agents/test_architect_prompts.py
@@ -1,7 +1,7 @@
 """Tests for Architect agent prompt injection."""
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,30 +22,6 @@ class TestArchitectPromptInjection:
             plan_markdown="# Test Plan",
             key_files=["test.py"],
         )
-
-    async def test_uses_injected_system_prompt_for_analyze(
-        self,
-        mock_driver: MagicMock,
-        mock_execution_state_factory: Callable[..., tuple[ImplementationState, Profile]],
-    ) -> None:
-        """Should use injected system prompt instead of default for analyze."""
-        custom_prompt = "You are a custom architect..."
-        prompts = {"architect.system": custom_prompt}
-        config = AgentConfig(driver="cli", model="sonnet")
-
-        state, profile = mock_execution_state_factory()
-        mock_driver.generate = AsyncMock(return_value=(
-            {"goal": "Test goal", "strategy": "Test strategy", "key_files": [], "risks": []},
-            "session-1",
-        ))
-
-        with patch("amelia.agents.architect.get_driver", return_value=mock_driver):
-            architect = Architect(config, prompts=prompts)
-            await architect.analyze(state, profile, workflow_id="wf-1")
-
-        # Verify the custom prompt was used
-        call_args = mock_driver.generate.call_args
-        assert call_args.kwargs["system_prompt"] == custom_prompt
 
     async def test_uses_injected_plan_prompt(
         self,
@@ -88,28 +64,6 @@ class TestArchitectPromptInjection:
         assert len(captured_instructions) == 1
         assert captured_instructions[0] == custom_plan_prompt
 
-    async def test_falls_back_to_class_default_for_analyze(
-        self,
-        mock_driver: MagicMock,
-        mock_execution_state_factory: Callable[..., tuple[ImplementationState, Profile]],
-    ) -> None:
-        """Should use class default when system prompt not injected."""
-        config = AgentConfig(driver="cli", model="sonnet")
-        state, profile = mock_execution_state_factory()
-        mock_driver.generate = AsyncMock(return_value=(
-            {"goal": "Test goal", "strategy": "Test strategy", "key_files": [], "risks": []},
-            "session-1",
-        ))
-
-        with patch("amelia.agents.architect.get_driver", return_value=mock_driver):
-            architect = Architect(config)  # No prompts injected
-            await architect.analyze(state, profile, workflow_id="wf-1")
-
-        call_args = mock_driver.generate.call_args
-        # Verify a non-empty default system prompt is used
-        assert call_args.kwargs["system_prompt"]
-        assert len(call_args.kwargs["system_prompt"]) > 50
-
     async def test_falls_back_to_class_default_for_plan(
         self,
         mock_driver: MagicMock,
@@ -151,24 +105,6 @@ class TestArchitectPromptInjection:
         assert instructions is not None
         assert len(instructions) > 50
 
-    async def test_system_prompt_property(
-        self,
-        mock_driver: MagicMock,
-    ) -> None:
-        """Test system_prompt property returns correct value."""
-        custom_prompt = "Custom system prompt"
-        config = AgentConfig(driver="cli", model="sonnet")
-
-        with patch("amelia.agents.architect.get_driver", return_value=mock_driver):
-            # With custom prompt
-            architect_custom = Architect(config, prompts={"architect.system": custom_prompt})
-            assert architect_custom.system_prompt == custom_prompt
-
-            # Without custom prompt (default)
-            architect_default = Architect(config)
-            assert architect_default.system_prompt
-            assert len(architect_default.system_prompt) > 50
-
     async def test_plan_prompt_property(
         self,
         mock_driver: MagicMock,
@@ -186,24 +122,3 @@ class TestArchitectPromptInjection:
             architect_default = Architect(config)
             assert architect_default.plan_prompt
             assert len(architect_default.plan_prompt) > 50
-
-    async def test_empty_prompts_dict_uses_defaults(
-        self,
-        mock_driver: MagicMock,
-        mock_execution_state_factory: Callable[..., tuple[ImplementationState, Profile]],
-    ) -> None:
-        """Empty prompts dict should fall back to defaults."""
-        config = AgentConfig(driver="cli", model="sonnet")
-        state, profile = mock_execution_state_factory()
-        mock_driver.generate = AsyncMock(return_value=(
-            {"goal": "Test goal", "strategy": "Test strategy", "key_files": [], "risks": []},
-            "session-1",
-        ))
-
-        with patch("amelia.agents.architect.get_driver", return_value=mock_driver):
-            architect = Architect(config, prompts={})  # Empty dict
-            await architect.analyze(state, profile, workflow_id="wf-1")
-
-        call_args = mock_driver.generate.call_args
-        assert call_args.kwargs["system_prompt"]
-        assert len(call_args.kwargs["system_prompt"]) > 50

--- a/tests/unit/agents/test_reviewer.py
+++ b/tests/unit/agents/test_reviewer.py
@@ -6,13 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from amelia.agents.reviewer import (
-    Reviewer,
-    ReviewItem,
-    StructuredReviewResult,
-    normalize_severity,
-)
-from amelia.core.types import AgentConfig, Profile, Severity
+from amelia.agents.reviewer import Reviewer
+from amelia.core.types import AgentConfig, Profile
 from amelia.drivers.base import AgenticMessage, AgenticMessageType
 from amelia.pipelines.implementation.state import ImplementationState
 from amelia.server.models.events import EventType
@@ -63,77 +58,6 @@ class TestReviewerInit:
             mock_get_driver.assert_called_once_with("cli", model="sonnet")
             assert reviewer.driver is mock_driver
             assert reviewer.options == {"max_iterations": 5}
-
-
-class TestNormalizeSeverity:
-    """Tests for normalize_severity helper function."""
-
-    @pytest.mark.parametrize("input_val,expected", [
-        ("critical", "critical"),
-        ("major", "major"),
-        ("minor", "minor"),
-        ("none", "none"),
-        ("invalid", "minor"),  # Invalid falls back to default
-        ("", "minor"),  # Empty falls back to default
-        ("CRITICAL", "minor"),  # Case sensitive - uppercase is invalid
-        ("low", "minor"),  # Old value is now invalid
-        ("medium", "minor"),  # Old value is now invalid
-        ("high", "minor"),  # Old value is now invalid
-    ])
-    def test_normalize_severity(self, input_val: str, expected: str) -> None:
-        """Test severity normalization with various inputs."""
-        assert normalize_severity(input_val) == expected
-
-    def test_none_value_returns_default(self) -> None:
-        """Test that Python None returns the default."""
-        assert normalize_severity(None) == "minor"
-
-    def test_custom_default(self) -> None:
-        """Test that custom default is used for invalid values."""
-        assert normalize_severity("invalid", default=Severity.MAJOR) == "major"
-        assert normalize_severity(None, default=Severity.CRITICAL) == "critical"
-
-
-class TestReviewItem:
-    """Tests for ReviewItem model."""
-
-    def test_review_item_severity_values(self) -> None:
-        """Test that severity accepts only valid values."""
-        for severity in ["critical", "major", "minor", "none"]:
-            item = ReviewItem(
-                number=1,
-                title="Test",
-                file_path="test.py",
-                line=1,
-                severity=severity,  # type: ignore[arg-type]  # Testing valid Literal values via iteration
-                issue="Issue",
-                why="Why",
-                fix="Fix",
-            )
-            assert item.severity == severity
-
-
-class TestStructuredReviewResult:
-    """Tests for StructuredReviewResult model."""
-
-    def test_structured_review_result_verdict_values(self) -> None:
-        """Test that verdict accepts only valid values."""
-        for verdict in ["approved", "needs_fixes", "blocked"]:
-            result = StructuredReviewResult(
-                summary="Review",
-                items=[],
-                verdict=verdict,  # type: ignore[arg-type]  # Testing valid Literal values via iteration
-            )
-            assert result.verdict == verdict
-
-    def test_structured_review_result_default_good_patterns(self) -> None:
-        """Test that good_patterns defaults to empty list."""
-        result = StructuredReviewResult(
-            summary="Review",
-            items=[],
-            verdict="approved",
-        )
-        assert result.good_patterns == []
 
 
 class TestAgenticReview:

--- a/tests/unit/server/routes/test_prompts.py
+++ b/tests/unit/server/routes/test_prompts.py
@@ -146,11 +146,11 @@ class TestResetToDefault:
     def test_reset_to_default(self, client, mock_repo):
         """Should reset prompt to default."""
         mock_repo.get_prompt.return_value = Prompt(
-            id="architect.system", agent="architect", name="Test"
+            id="architect.plan", agent="architect", name="Architect Plan Format"
         )
-        response = client.post("/api/prompts/architect.system/reset")
+        response = client.post("/api/prompts/architect.plan/reset")
         assert response.status_code == 200
-        mock_repo.reset_to_default.assert_called_once_with("architect.system")
+        mock_repo.reset_to_default.assert_called_once_with("architect.plan")
 
 
 class TestGetDefault:
@@ -158,10 +158,10 @@ class TestGetDefault:
 
     def test_get_default_content(self, client, mock_repo):
         """Should return hardcoded default content."""
-        response = client.get("/api/prompts/architect.system/default")
+        response = client.get("/api/prompts/architect.plan/default")
         assert response.status_code == 200
         data = response.json()
-        assert data["content"] == PROMPT_DEFAULTS["architect.system"].content
+        assert data["content"] == PROMPT_DEFAULTS["architect.plan"].content
 
     def test_get_default_unknown_prompt(self, client, mock_repo):
         """Should return 404 for unknown prompt."""


### PR DESCRIPTION
## Summary

Remove ~450 lines of dead code left behind after the refactoring to agentic-only execution, cleaning up unused code paths in the Architect and Reviewer agents.

## Changes

### Removed

**Architect dead code:**
- `PlanOutput` class (superseded by `MarkdownPlanOutput`)
- `ArchitectOutput` class (only used by dead `analyze()`)
- `SYSTEM_PROMPT` constant
- `system_prompt` property
- `_build_prompt()` method
- `analyze()` method

**Reviewer dead code:**
- `ReviewVerdict` enum
- `normalize_severity()` function
- `ReviewItem` class
- `StructuredReviewResult` class (never instantiated in production)

**Prompt defaults:**
- `"architect.system"` entry
- `"reviewer.structured"` entry

### Changed

- Updated module exports in `amelia/agents/__init__.py`
- Updated related test files to remove tests for dead code
- Updated import statements throughout affected modules

## Motivation

These code paths were leftovers from the previous non-agentic execution model. After refactoring to agentic-only execution, they became unreachable dead code that added maintenance burden without providing value.

## Testing

- [x] All existing tests pass (1233 tests)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)

No new tests needed since this is pure removal of unused code.

## Related Issues

- Closes #339

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated (if needed) - N/A, removed code was internal

---

Generated with [Claude Code](https://claude.com/claude-code)