### PR TITLE
refactor: remove 102 dead re-exports from __init__.py files

### DIFF
--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -5,38 +5,11 @@ Provide a LangGraph-based orchestrator that coordinates specialized AI agents
 descriptions.
 
 Exports:
-    app: The Typer CLI application entry point.
-    create_orchestrator_graph: Factory function for the LangGraph state machine.
-    ExecutionState: The core state type passed through the orchestration graph.
-    get_pipeline: Factory function to get a pipeline by name.
-    ImplementationState: State type for the implementation pipeline.
-    create_implementation_graph: Factory for the implementation pipeline graph.
     __version__: Package version string.
 """
-
-from amelia.main import app
-from amelia.pipelines import get_pipeline
-from amelia.pipelines.implementation import (
-    ImplementationState,
-    create_implementation_graph,
-)
-
-
-# Backward compatibility aliases
-# ExecutionState is kept for backward compatibility with existing code
-# New code should use ImplementationState from pipelines.implementation
-ExecutionState = ImplementationState
-# create_orchestrator_graph is now create_implementation_graph
-create_orchestrator_graph = create_implementation_graph
 
 __version__ = "0.10.0"
 
 __all__ = [
-    "ExecutionState",
-    "ImplementationState",
     "__version__",
-    "app",
-    "create_implementation_graph",
-    "create_orchestrator_graph",
-    "get_pipeline",
 ]

--- a/amelia/agents/__init__.py
+++ b/amelia/agents/__init__.py
@@ -3,34 +3,4 @@
 Provide specialized AI agents that handle distinct phases of the development
 workflow. Each agent wraps an LLM driver and implements domain-specific logic
 for planning, implementation, evaluation, or review.
-
-Exports:
-    Architect: Plan implementation strategy from issue descriptions.
-    Developer: Execute code changes following the architect's plan.
-    Evaluator: Evaluate and prioritize review feedback items.
-    Disposition: Enum for evaluation outcomes (accept, reject, defer).
-    EvaluatedItem: A single evaluated feedback item with disposition.
-    EvaluationResult: Collection of evaluated items with summary.
-    Reviewer: Review code changes and provide structured feedback.
 """
-
-from amelia.agents.architect import Architect
-from amelia.agents.developer import Developer
-from amelia.agents.evaluator import (
-    Disposition,
-    EvaluatedItem,
-    EvaluationResult,
-    Evaluator,
-)
-from amelia.agents.reviewer import Reviewer
-
-
-__all__ = [
-    "Architect",
-    "Developer",
-    "Disposition",
-    "EvaluatedItem",
-    "EvaluationResult",
-    "Evaluator",
-    "Reviewer",
-]

--- a/amelia/agents/prompts/__init__.py
+++ b/amelia/agents/prompts/__init__.py
@@ -1,26 +1,4 @@
-# amelia/agents/prompts/__init__.py
 """Agent prompt configuration package.
 
 Provides prompt defaults and resolution for configurable agent prompts.
 """
-from amelia.agents.prompts.defaults import PROMPT_DEFAULTS, PromptDefault
-from amelia.agents.prompts.models import (
-    Prompt,
-    PromptRepositoryProtocol,
-    PromptVersion,
-    ResolvedPrompt,
-    WorkflowPromptVersion,
-)
-from amelia.agents.prompts.resolver import PromptResolver
-
-
-__all__ = [
-    "PROMPT_DEFAULTS",
-    "Prompt",
-    "PromptDefault",
-    "PromptRepositoryProtocol",
-    "PromptResolver",
-    "PromptVersion",
-    "ResolvedPrompt",
-    "WorkflowPromptVersion",
-]

--- a/amelia/cli/__init__.py
+++ b/amelia/cli/__init__.py
@@ -1,6 +1,1 @@
 """CLI subcommands for Amelia."""
-
-from amelia.cli.config import config_app
-
-
-__all__ = ["config_app"]

--- a/amelia/client/__init__.py
+++ b/amelia/client/__init__.py
@@ -3,36 +3,4 @@
 Provide HTTP client utilities for communicating with the Amelia server
 from CLI commands. Include error handling, git context extraction, and
 typed API wrappers for workflow management.
-
-Exports:
-    AmeliaClient: Async HTTP client for the Amelia server API.
-    AmeliaClientError: Base exception for client errors.
-    ServerUnreachableError: Server connection failure.
-    WorkflowConflictError: Workflow already exists for repository.
-    RateLimitError: Server rate limit exceeded.
-    WorkflowNotFoundError: Requested workflow does not exist.
-    InvalidRequestError: Malformed request to server.
-    get_worktree_context: Extract git repository context for requests.
 """
-from amelia.client.api import (
-    AmeliaClient,
-    AmeliaClientError,
-    InvalidRequestError,
-    RateLimitError,
-    ServerUnreachableError,
-    WorkflowConflictError,
-    WorkflowNotFoundError,
-)
-from amelia.client.git import get_worktree_context
-
-
-__all__ = [
-    "get_worktree_context",
-    "AmeliaClient",
-    "AmeliaClientError",
-    "ServerUnreachableError",
-    "WorkflowConflictError",
-    "RateLimitError",
-    "WorkflowNotFoundError",
-    "InvalidRequestError",
-]

--- a/amelia/drivers/__init__.py
+++ b/amelia/drivers/__init__.py
@@ -3,19 +3,4 @@
 Provide an abstraction layer between agents and LLM providers. Drivers
 implement a common interface, allowing the orchestrator to switch between
 direct API calls and CLI-wrapped tools without code changes.
-
-Exports:
-    DriverInterface: Protocol defining the LLM driver contract.
-    get_driver: Function to create driver instances from configuration keys.
-    DriverFactory: Deprecated class wrapper for backward compatibility.
 """
-
-from amelia.drivers.base import DriverInterface
-from amelia.drivers.factory import DriverFactory, get_driver
-
-
-__all__ = [
-    "DriverInterface",
-    "get_driver",
-    "DriverFactory",
-]

--- a/amelia/drivers/cli/__init__.py
+++ b/amelia/drivers/cli/__init__.py
@@ -3,11 +3,4 @@
 Provide CLI-wrapper drivers that delegate to external CLI tools rather than
 making direct API calls. Enable enterprise compliance where direct API calls
 may be prohibited by routing through approved CLI binaries.
-
-Exports:
-    ClaudeCliDriver: Driver wrapping the Claude CLI for LLM interactions.
 """
-from amelia.drivers.cli.claude import ClaudeCliDriver
-
-
-__all__ = ["ClaudeCliDriver"]

--- a/amelia/ext/__init__.py
+++ b/amelia/ext/__init__.py
@@ -4,73 +4,13 @@ Define protocols that enterprise or third-party integrations can implement
 without modifying core source files. Core provides no-op default
 implementations for all extension points.
 
-Extension Points:
-    PolicyHook: Intercept decisions (approvals, resource limits).
-    AuditExporter: Export workflow events to external systems.
-    AnalyticsSink: Send telemetry to observability platforms.
-    AuthProvider: Plug in authentication mechanisms.
-
-Example:
-    >>> from amelia.ext import get_registry
-    >>> registry = get_registry()
-    >>> registry.register_audit_exporter(my_exporter)
-
 Exports:
-    PolicyHook: Protocol for policy enforcement hooks.
-    AuditExporter: Protocol for audit event exporters.
-    AnalyticsSink: Protocol for analytics/telemetry sinks.
-    AuthProvider: Protocol for authentication providers.
-    WorkflowEvent: Event model for workflow state changes.
     WorkflowEventType: Enum of workflow event categories.
-    JsonValue: Type alias for JSON-serializable values.
-    ExtensionRegistry: Central registry for extension instances.
-    get_registry: Retrieve the global extension registry singleton.
-    emit_workflow_event: Emit an event to all registered exporters.
-    check_policy_workflow_start: Check policy before workflow starts.
-    check_policy_approval: Check policy before approving changes.
-    record_metric: Record a metric to all analytics sinks.
-    flush_exporters: Flush all pending audit events.
-    PolicyDeniedError: Raised when a policy check fails.
 """
 
-from amelia.ext.exceptions import PolicyDeniedError
-from amelia.ext.hooks import (
-    check_policy_approval,
-    check_policy_workflow_start,
-    emit_workflow_event,
-    flush_exporters,
-    record_metric,
-)
-from amelia.ext.protocols import (
-    AnalyticsSink,
-    AuditExporter,
-    AuthProvider,
-    JsonValue,
-    PolicyHook,
-    WorkflowEvent,
-    WorkflowEventType,
-)
-from amelia.ext.registry import ExtensionRegistry, get_registry
+from amelia.ext.protocols import WorkflowEventType
 
 
 __all__ = [
-    # Protocols
-    "PolicyHook",
-    "AuditExporter",
-    "AnalyticsSink",
-    "AuthProvider",
-    "WorkflowEvent",
     "WorkflowEventType",
-    "JsonValue",
-    # Registry
-    "ExtensionRegistry",
-    "get_registry",
-    # Hook functions
-    "emit_workflow_event",
-    "check_policy_workflow_start",
-    "check_policy_approval",
-    "record_metric",
-    "flush_exporters",
-    # Exceptions
-    "PolicyDeniedError",
 ]

--- a/amelia/pipelines/__init__.py
+++ b/amelia/pipelines/__init__.py
@@ -4,28 +4,12 @@ This package provides the foundational types and registry for multiple
 workflow pipelines (Implementation, Review, etc.).
 
 Exports:
-    Pipeline: Protocol that all pipelines implement.
-    PipelineMetadata: Immutable metadata describing a pipeline.
-    BasePipelineState: Common state fields shared by all pipelines.
-    HistoryEntry: Structured history entry for agent actions.
     get_pipeline: Factory function to get a pipeline by name.
-    list_pipelines: List all available pipelines.
 """
 
-from amelia.pipelines.base import (
-    BasePipelineState,
-    HistoryEntry,
-    Pipeline,
-    PipelineMetadata,
-)
-from amelia.pipelines.registry import get_pipeline, list_pipelines
+from amelia.pipelines.registry import get_pipeline
 
 
 __all__ = [
-    "BasePipelineState",
-    "HistoryEntry",
-    "Pipeline",
-    "PipelineMetadata",
     "get_pipeline",
-    "list_pipelines",
 ]

--- a/amelia/pipelines/implementation/__init__.py
+++ b/amelia/pipelines/implementation/__init__.py
@@ -1,15 +1,14 @@
 """Implementation pipeline for building features from issues.
 
 This pipeline implements the Architect -> Developer <-> Reviewer flow.
+
+Exports:
+    create_implementation_graph: Factory for the implementation pipeline graph.
 """
 
 from amelia.pipelines.implementation.graph import create_implementation_graph
-from amelia.pipelines.implementation.pipeline import ImplementationPipeline
-from amelia.pipelines.implementation.state import ImplementationState
 
 
 __all__ = [
     "create_implementation_graph",
-    "ImplementationPipeline",
-    "ImplementationState",
 ]

--- a/amelia/pipelines/review/__init__.py
+++ b/amelia/pipelines/review/__init__.py
@@ -2,13 +2,14 @@
 
 This pipeline implements the Reviewer -> Evaluator -> Developer cycle
 for reviewing and fixing code changes.
+
+Exports:
+    create_review_graph: Factory function for the review LangGraph.
 """
 
 from amelia.pipelines.review.graph import create_review_graph
-from amelia.pipelines.review.pipeline import ReviewPipeline
 
 
 __all__ = [
     "create_review_graph",
-    "ReviewPipeline",
 ]

--- a/amelia/server/__init__.py
+++ b/amelia/server/__init__.py
@@ -3,30 +3,4 @@
 Provide the HTTP server that manages workflow execution, persists state,
 and streams events to connected clients. Include database access, exception
 types, and configuration management.
-
-Exports:
-    ServerConfig: Configuration model for server settings.
-    Database: SQLite database connection and session management.
-    ConcurrencyLimitError: Too many concurrent workflows.
-    InvalidStateError: Invalid workflow state transition attempted.
-    WorkflowConflictError: Workflow already exists for repository.
-    WorkflowNotFoundError: Requested workflow does not exist.
 """
-from amelia.server.config import ServerConfig
-from amelia.server.database import Database
-from amelia.server.exceptions import (
-    ConcurrencyLimitError,
-    InvalidStateError,
-    WorkflowConflictError,
-    WorkflowNotFoundError,
-)
-
-
-__all__ = [
-    "ServerConfig",
-    "Database",
-    "ConcurrencyLimitError",
-    "InvalidStateError",
-    "WorkflowConflictError",
-    "WorkflowNotFoundError",
-]

--- a/amelia/server/database/__init__.py
+++ b/amelia/server/database/__init__.py
@@ -7,7 +7,6 @@ operations for workflow state.
 Exports:
     Database: Database connection manager with async session factory.
     WorkflowRepository: Repository for workflow CRUD operations.
-    WorkflowNotFoundError: Raised when a workflow lookup fails.
     SettingsRepository: Repository for server settings CRUD operations.
     ServerSettings: Server settings data class.
     ProfileRepository: Repository for profile CRUD operations.
@@ -18,7 +17,6 @@ from amelia.server.database.connection import Database
 from amelia.server.database.profile_repository import ProfileRecord, ProfileRepository
 from amelia.server.database.repository import WorkflowRepository
 from amelia.server.database.settings_repository import ServerSettings, SettingsRepository
-from amelia.server.exceptions import WorkflowNotFoundError
 
 
 __all__ = [
@@ -27,6 +25,5 @@ __all__ = [
     "ProfileRepository",
     "ServerSettings",
     "SettingsRepository",
-    "WorkflowNotFoundError",
     "WorkflowRepository",
 ]

--- a/amelia/server/events/__init__.py
+++ b/amelia/server/events/__init__.py
@@ -3,14 +3,4 @@
 Provide pub/sub infrastructure for real-time event streaming. The event bus
 broadcasts workflow events to subscribers, while the connection manager
 handles WebSocket lifecycle and message routing.
-
-Exports:
-    EventBus: Pub/sub event bus for workflow events.
-    ConnectionManager: WebSocket connection lifecycle manager.
 """
-
-from amelia.server.events.bus import EventBus
-from amelia.server.events.connection_manager import ConnectionManager
-
-
-__all__ = ["EventBus", "ConnectionManager"]

--- a/amelia/server/lifecycle/__init__.py
+++ b/amelia/server/lifecycle/__init__.py
@@ -3,22 +3,4 @@
 Provide services for server startup, shutdown, and ongoing maintenance tasks.
 Include health checking for git worktrees, log retention cleanup, and
 graceful shutdown coordination.
-
-Exports:
-    CleanupResult: Result of a log retention cleanup operation.
-    LogRetentionService: Service for cleaning up old workflow logs.
-    ServerLifecycle: Coordinator for server startup and shutdown.
-    WorktreeHealthChecker: Health checker for git worktree status.
 """
-
-from amelia.server.lifecycle.health_checker import WorktreeHealthChecker
-from amelia.server.lifecycle.retention import CleanupResult, LogRetentionService
-from amelia.server.lifecycle.server import ServerLifecycle
-
-
-__all__ = [
-    "CleanupResult",
-    "LogRetentionService",
-    "ServerLifecycle",
-    "WorktreeHealthChecker",
-]

--- a/amelia/server/models/__init__.py
+++ b/amelia/server/models/__init__.py
@@ -7,109 +7,15 @@ and serialization formats for all server data.
 Exports:
     EventType: Enum of workflow event types.
     WorkflowEvent: Model for workflow state change events.
-    CreateWorkflowRequest: Request model for starting a workflow.
-    RejectRequest: Request model for rejecting changes.
-    ActionResponse: Generic action success response.
-    BatchStartResponse: Response from batch start operation.
-    CreateWorkflowResponse: Response model for workflow creation.
-    ErrorResponse: Standardized error response model.
-    TokenSummary: Aggregated token usage summary.
-    WorkflowDetailResponse: Detailed workflow state response.
-    WorkflowListResponse: List of workflow summaries.
-    WorkflowSummary: Brief workflow state for listings.
-    WorkflowStatus: Enum of workflow lifecycle states.
     ServerExecutionState: Full server-side workflow state.
-    VALID_TRANSITIONS: Mapping of valid state transitions.
-    InvalidStateTransitionError: Invalid state transition attempted.
-    validate_transition: Validate a state transition.
-    TokenUsage: Per-request token usage record.
-    MODEL_PRICING: Token pricing by model.
-    calculate_token_cost: Calculate cost from token usage.
-    BackfillCompleteMessage: WebSocket backfill complete notification.
-    BackfillExpiredMessage: WebSocket backfill expired notification.
-    ClientMessage: Union of all client WebSocket message types.
-    EventMessage: WebSocket event broadcast message.
-    PingMessage: WebSocket ping message.
-    PongMessage: WebSocket pong message.
-    ServerMessage: Union of all server WebSocket message types.
-    SubscribeAllMessage: Subscribe to all workflow events.
-    SubscribeMessage: Subscribe to specific workflow events.
-    UnsubscribeMessage: Unsubscribe from workflow events.
 """
 
 from amelia.server.models.events import EventType, WorkflowEvent
-from amelia.server.models.requests import CreateWorkflowRequest, RejectRequest
-from amelia.server.models.responses import (
-    ActionResponse,
-    BatchStartResponse,
-    CreateWorkflowResponse,
-    ErrorResponse,
-    WorkflowDetailResponse,
-    WorkflowListResponse,
-    WorkflowSummary,
-)
-from amelia.server.models.state import (
-    VALID_TRANSITIONS,
-    InvalidStateTransitionError,
-    ServerExecutionState,
-    WorkflowStatus,
-    validate_transition,
-)
-from amelia.server.models.tokens import (
-    MODEL_PRICING,
-    TokenSummary,
-    TokenUsage,
-    calculate_token_cost,
-)
-from amelia.server.models.websocket import (
-    BackfillCompleteMessage,
-    BackfillExpiredMessage,
-    ClientMessage,
-    EventMessage,
-    PingMessage,
-    PongMessage,
-    ServerMessage,
-    SubscribeAllMessage,
-    SubscribeMessage,
-    UnsubscribeMessage,
-)
+from amelia.server.models.state import ServerExecutionState
 
 
 __all__ = [
-    # Events
     "EventType",
-    "WorkflowEvent",
-    # Requests
-    "CreateWorkflowRequest",
-    "RejectRequest",
-    # Responses
-    "ActionResponse",
-    "BatchStartResponse",
-    "CreateWorkflowResponse",
-    "ErrorResponse",
-    "TokenSummary",
-    "WorkflowDetailResponse",
-    "WorkflowListResponse",
-    "WorkflowSummary",
-    # State
-    "WorkflowStatus",
     "ServerExecutionState",
-    "VALID_TRANSITIONS",
-    "InvalidStateTransitionError",
-    "validate_transition",
-    # Tokens
-    "TokenUsage",
-    "MODEL_PRICING",
-    "calculate_token_cost",
-    # WebSocket
-    "BackfillCompleteMessage",
-    "BackfillExpiredMessage",
-    "ClientMessage",
-    "EventMessage",
-    "PingMessage",
-    "PongMessage",
-    "ServerMessage",
-    "SubscribeAllMessage",
-    "SubscribeMessage",
-    "UnsubscribeMessage",
+    "WorkflowEvent",
 ]

--- a/amelia/server/orchestrator/__init__.py
+++ b/amelia/server/orchestrator/__init__.py
@@ -3,22 +3,4 @@
 Provide the service layer that coordinates LangGraph workflow execution,
 enforces concurrency limits, and manages workflow lifecycle. Handle
 starting, stopping, and monitoring active workflows.
-
-Exports:
-    ConcurrencyLimitError: Raised when concurrency limit is exceeded.
-    OrchestratorService: Service for managing workflow execution.
-    WorkflowConflictError: Raised when workflow already exists.
 """
-
-from amelia.server.exceptions import (
-    ConcurrencyLimitError,
-    WorkflowConflictError,
-)
-from amelia.server.orchestrator.service import OrchestratorService
-
-
-__all__ = [
-    "ConcurrencyLimitError",
-    "OrchestratorService",
-    "WorkflowConflictError",
-]

--- a/amelia/trackers/__init__.py
+++ b/amelia/trackers/__init__.py
@@ -3,26 +3,4 @@
 Provide adapters for fetching issue data from various project management
 systems. Each tracker implements the BaseTracker protocol to normalize
 issue data for the orchestrator.
-
-Exports:
-    BaseTracker: Protocol defining the tracker interface.
-    GithubTracker: Tracker for GitHub Issues.
-    JiraTracker: Tracker for Atlassian Jira.
-    NoopTracker: No-op tracker for standalone usage.
-    create_tracker: Factory function for tracker instantiation.
 """
-
-from amelia.trackers.base import BaseTracker
-from amelia.trackers.factory import create_tracker
-from amelia.trackers.github import GithubTracker
-from amelia.trackers.jira import JiraTracker
-from amelia.trackers.noop import NoopTracker
-
-
-__all__ = [
-    "BaseTracker",
-    "GithubTracker",
-    "JiraTracker",
-    "NoopTracker",
-    "create_tracker",
-]


### PR DESCRIPTION
## Summary

- Remove 102 unused package-level re-exports across 18 `__init__.py` files
- 11 files reduced to docstring-only (all re-exports dead)
- 7 files trimmed to keep only alive exports
- Includes backward-compat alias removal (`ExecutionState`, `create_orchestrator_graph`)

### Group A — Fully dead (docstring-only)

| File | Dead symbols removed |
|------|---------------------|
| `amelia/agents/__init__.py` | 7 |
| `amelia/drivers/__init__.py` | 3 |
| `amelia/trackers/__init__.py` | 5 |
| `amelia/server/__init__.py` | 6 |
| `amelia/server/events/__init__.py` | 2 |
| `amelia/server/lifecycle/__init__.py` | 4 |
| `amelia/server/orchestrator/__init__.py` | 3 |
| `amelia/cli/__init__.py` | 1 |
| `amelia/client/__init__.py` | 8 |
| `amelia/agents/prompts/__init__.py` | 8 |
| `amelia/drivers/cli/__init__.py` | 1 |

### Group B — Partially dead (trimmed)

| File | Kept | Removed |
|------|------|---------|
| `amelia/__init__.py` | `__version__` | 6 |
| `amelia/ext/__init__.py` | `WorkflowEventType` | 14 |
| `amelia/server/models/__init__.py` | `EventType`, `WorkflowEvent`, `ServerExecutionState` | 25 |
| `amelia/pipelines/__init__.py` | `get_pipeline` | 5 |
| `amelia/pipelines/review/__init__.py` | `create_review_graph` | 1 |
| `amelia/pipelines/implementation/__init__.py` | `create_implementation_graph` | 2 |
| `amelia/server/database/__init__.py` | 6 alive exports | 1 |

## Test plan

- [x] `uv run ruff check amelia tests` — all checks passed
- [x] `uv run mypy amelia` — no issues in 115 source files
- [x] `uv run pytest` — 1266 passed, 0 failed

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)