### PR TITLE
feat(server): auto-build dashboard on `amelia dev` startup

### DIFF
--- a/amelia/server/banner.py
+++ b/amelia/server/banner.py
@@ -150,9 +150,9 @@ def get_service_urls_display(
     display_host = "localhost" if api_host == "0.0.0.0" else api_host
     api_url = f"http://{display_host}:{api_port}"
 
-    # In dev mode, dashboard runs on Vite (port 5173)
+    # In dev mode, dashboard runs on Vite (port 8421)
     # In user mode, dashboard is served from API server
-    dashboard_url = "http://localhost:5173" if is_dev_mode else api_url
+    dashboard_url = "http://localhost:8421" if is_dev_mode else api_url
 
     text = Text()
 

--- a/docs/testing/test-plan.yaml
+++ b/docs/testing/test-plan.yaml
@@ -1,0 +1,199 @@
+version: 1
+metadata:
+  branch: feat/auto-build-dashboard
+  base: main
+  generated: "2026-01-26"
+  changes_summary: |
+    Auto-build dashboard on `amelia dev` startup. When the dev server starts and
+    the dashboard has not been built yet (no static/index.html), it now runs
+    `pnpm build` automatically before launching the Vite dev server. Also fixes
+    the dev-mode dashboard URL in the banner from port 5173 to 8421.
+
+    Changed files:
+    - amelia/server/banner.py: Update dev-mode dashboard URL from 5173 → 8421
+    - amelia/server/dev.py: Add check_dashboard_built(), run_pnpm_build(), and
+      auto-build step in run_dev_mode()
+    - tests/unit/server/test_banner.py: Tests for updated banner URL
+    - tests/unit/server/test_dev.py: Tests for build check and pnpm build
+
+setup:
+  stack:
+    - type: python
+      package_manager: uv
+    - type: node
+      package_manager: pnpm
+  commands:
+    - uv sync
+    - cd dashboard && pnpm install
+  health_checks:
+    - url: http://localhost:8420/api/live
+      timeout: 30
+    - url: http://localhost:8421
+      timeout: 30
+
+tests:
+  # --- Unit test verification ---
+  - id: TC-01
+    name: Run unit tests for changed files
+    context: |
+      The branch includes new unit tests in test_banner.py and test_dev.py.
+      Verify they pass before proceeding to manual tests.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          uv run pytest tests/unit/server/test_banner.py tests/unit/server/test_dev.py -v
+    expected: |
+      All tests pass, including:
+      - TestGetServiceUrlsDisplay::test_dev_mode_shows_vite_port (port 8421)
+      - TestGetServiceUrlsDisplay::test_user_mode_shows_api_port (port 8420)
+      - TestDependencyChecks::test_check_dashboard_built[built] (True)
+      - TestDependencyChecks::test_check_dashboard_built[not_built] (False)
+      - TestAutoBuild::test_run_pnpm_build[success] (True)
+      - TestAutoBuild::test_run_pnpm_build[failure] (False)
+
+  # --- Auto-build behavior: dashboard not yet built ---
+  - id: TC-02
+    name: "Auto-build triggers when dashboard is not built"
+    context: |
+      amelia/server/dev.py now calls check_dashboard_built() in run_dev_mode().
+      If static/index.html is missing, it should run pnpm build before starting
+      the Vite dev server. This is the primary feature being added.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          rm -f amelia/server/static/index.html
+        note: "Remove built dashboard to simulate first-time setup"
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          timeout 90 uv run amelia dev 2>&1 | head -60
+        note: "Start dev server and capture first 60 lines of output"
+    expected: |
+      Output should show:
+      1. "Building dashboard..." message with dashboard prefix
+      2. pnpm/vite build output lines
+      3. After build completes, "Starting vite on http://localhost:8421"
+      4. The file amelia/server/static/index.html should now exist
+    evidence:
+      screenshot: evidence/tc-02.png
+
+  # --- Auto-build skipped when already built ---
+  - id: TC-03
+    name: "Auto-build skips when dashboard is already built"
+    context: |
+      If static/index.html already exists, the auto-build step should be skipped
+      entirely. This avoids unnecessary rebuilds on normal restarts.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          ls -la amelia/server/static/index.html
+        note: "Confirm dashboard is already built (from TC-02 or prior build)"
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          timeout 30 uv run amelia dev 2>&1 | head -30
+        note: "Start dev server and check output"
+    expected: |
+      Output should NOT contain "Building dashboard..." message.
+      The server should start directly with:
+      1. Banner display
+      2. "Starting vite on http://localhost:8421"
+      3. Uvicorn startup on port 8420
+
+  # --- Banner URL correctness ---
+  - id: TC-04
+    name: "Banner shows correct dashboard URL in dev mode"
+    context: |
+      amelia/server/banner.py was changed to display port 8421 instead of 5173
+      for the dashboard URL in dev mode. This should be visible in the startup banner.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          timeout 15 uv run amelia dev 2>&1 | head -40
+        note: "Capture startup banner output"
+    expected: |
+      The startup banner should display:
+      - Dashboard URL: http://localhost:8421
+      - API URL: http://localhost:8420
+      - Port 5173 should NOT appear anywhere in the output
+
+  # --- Dashboard accessible on correct port ---
+  - id: TC-05
+    name: "Dashboard is accessible on port 8421 in dev mode"
+    context: |
+      With the port change from 5173 to 8421, the Vite dev server should
+      actually be running on port 8421 and serving the dashboard.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          uv run amelia dev &
+          sleep 15
+        note: "Start dev server in background, wait for startup"
+      - action: curl
+        method: GET
+        url: http://localhost:8421
+      - action: curl
+        method: GET
+        url: http://localhost:8420/api/live
+    expected: |
+      - http://localhost:8421 returns HTML content (the dashboard SPA)
+      - http://localhost:8420/api/live returns 200 OK health response
+      - Both services are accessible simultaneously
+    evidence:
+      screenshot: evidence/tc-05.png
+
+  # --- API serves built dashboard ---
+  - id: TC-06
+    name: "API server serves built dashboard on port 8420"
+    context: |
+      In non-dev mode (or when accessing the API port directly), the built
+      dashboard should be served from the API server at port 8420 via the
+      SPA fallback route. This verifies static file serving works with the
+      auto-built output.
+    steps:
+      - action: agent-browser open
+        url: http://localhost:8420
+      - action: agent-browser snapshot
+    expected: |
+      The dashboard UI should load at http://localhost:8420, showing the
+      workflows page (default redirect from /). The page should contain
+      navigation elements for Workflows, History, Logs, Prompts, Settings, etc.
+    evidence:
+      screenshot: evidence/tc-06.png
+
+  # --- Build failure handling ---
+  - id: TC-07
+    name: "Dev server exits gracefully on build failure"
+    context: |
+      If pnpm build fails, run_dev_mode() should print an error and return
+      exit code 1 instead of continuing to start the dashboard. This is tested
+      at unit level but worth verifying end-to-end.
+    steps:
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          rm -f amelia/server/static/index.html &&
+          mv dashboard/package.json dashboard/package.json.bak
+        note: "Remove index.html and break the build by hiding package.json"
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          timeout 30 uv run amelia dev 2>&1; echo "EXIT_CODE=$?"
+        note: "Attempt to start dev server with broken build"
+      - action: shell
+        command: >
+          cd /Users/ka/github/existential-birds/amelia-feature &&
+          mv dashboard/package.json.bak dashboard/package.json
+        note: "Restore package.json"
+    expected: |
+      Output should show:
+      1. "Building dashboard..." message
+      2. Build failure output
+      3. "Failed to build dashboard" error message
+      4. EXIT_CODE=1 (non-zero exit)
+      The Vite dev server should NOT have been started.

--- a/tests/unit/server/test_banner.py
+++ b/tests/unit/server/test_banner.py
@@ -10,6 +10,7 @@ from amelia.server.banner import (
     NAVY,
     get_agi_banner,
     get_gradient_banner,
+    get_service_urls_display,
     print_banner,
 )
 
@@ -76,3 +77,20 @@ class TestGetAgiBanner:
         result = get_agi_banner()
         # Rich Text with styles will have spans
         assert len(result.spans) > 0
+
+
+class TestGetServiceUrlsDisplay:
+    """Tests for service URL display in banner."""
+
+    def test_dev_mode_shows_vite_port(self) -> None:
+        """Dev mode dashboard URL uses Vite port 8421."""
+        result = get_service_urls_display("127.0.0.1", 8420, is_dev_mode=True)
+        text = str(result)
+        assert "http://localhost:8421" in text
+        assert "http://localhost:5173" not in text
+
+    def test_user_mode_shows_api_port(self) -> None:
+        """User mode dashboard URL uses API port."""
+        result = get_service_urls_display("127.0.0.1", 8420, is_dev_mode=False)
+        text = str(result)
+        assert "http://127.0.0.1:8420" in text


### PR DESCRIPTION
## Summary

When `amelia dev` starts in a development repo and the dashboard hasn't been built yet (no `static/index.html`), it now runs `pnpm build` automatically before launching the API server and Vite dev server. This ensures the API server always has built static files to serve, eliminating the manual `pnpm build` step on first checkout.

## Changes

### Added
- `check_dashboard_built()` function to detect whether `amelia/server/static/index.html` exists
- `run_pnpm_build()` async function to execute `pnpm build` with streamed output
- Auto-build step in `run_dev_mode()` that triggers when the dashboard is not yet built
- Unit tests for build detection and `pnpm build` execution
- Unit tests for banner URL correctness
- Manual test plan (`docs/testing/test-plan.yaml`)

### Changed
- Dev-mode dashboard URL in banner from port `5173` → `8421` to match actual Vite config
- Startup order: dependency install and build now happen **before** the API server starts, so `create_app()` picks up the built static files
- Git worktree detection: `.git` check uses `.exists()` instead of `.is_dir()` to support worktrees where `.git` is a file

## Motivation

After a fresh clone or checkout, running `amelia dev` would start the API server before any dashboard build existed, meaning the bundled dashboard route served a 404. Users had to manually run `pnpm build` in the dashboard directory first. This change automates that step and also reorders startup so the API server always has static files available.

The port fix (`5173` → `8421`) corrects the banner to match the actual Vite dev server port configured in `dashboard/vite.config.ts`.

## Testing

- [x] Unit tests added/updated
- [x] Manual test plan created

### Unit Tests

All 51 tests in `test_banner.py` and `test_dev.py` pass, including new tests for:
- `TestGetServiceUrlsDisplay` — verifies banner shows port 8421 in dev mode
- `TestDependencyChecks::test_check_dashboard_built` — verifies build detection
- `TestModeDetection::test_is_amelia_dev_repo_worktree` — verifies worktree support
- `TestAutoBuild::test_run_pnpm_build` — verifies build success/failure handling

### Manual Testing Steps

See `docs/testing/test-plan.yaml` for the full test plan (7 test cases covering auto-build trigger, skip-when-built, banner URLs, port accessibility, and failure handling).

---

Generated with [Claude Code](https://claude.com/claude-code)