### PR TITLE
fix(site): remove dead link breaking VitePress build

### DIFF
--- a/docs/site/reference/roadmap.md
+++ b/docs/site/reference/roadmap.md
@@ -73,8 +73,6 @@ Foundation for agents to query external knowledge sources with codebase context.
 
 **12-Factor Compliance:** F3 (Own Context Window)
 
-See [Oracle Phase 1 Design](../plans/2026-01-26-oracle-phase1-design.md).
-
 ---
 
 ## Phase 4: Knowledge Library [Planned]


### PR DESCRIPTION
## Summary

Fix VitePress build failure caused by a dead link to a nonexistent oracle design plan document introduced in #370.

## Changes

### Fixed
- Removed dead link to `../plans/2026-01-26-oracle-phase1-design.md` in `docs/site/reference/roadmap.md` — the referenced file was never created

## Motivation

The VitePress build fails with `Found dead link` when `ignoreDeadLinks` is not set. This was introduced in the roadmap updates from #370.

## Testing

- [x] `npx vitepress build` succeeds after the fix
- [x] All pre-push checks pass (ruff, mypy, pytest, pnpm build)

---

Generated with [Claude Code](https://claude.com/claude-code)