### PR TITLE
refactor(server): remove stage_timestamps from ServerExecutionState

### DIFF
--- a/amelia/server/models/state.py
+++ b/amelia/server/models/state.py
@@ -90,7 +90,6 @@ class ServerExecutionState(BaseModel):
         workflow_status: Current workflow status.
         started_at: When workflow started.
         completed_at: When workflow ended (success or failure).
-        stage_timestamps: When each stage started.
         current_stage: Currently executing stage.
         failure_reason: Error message when status is "failed".
         consecutive_errors: Number of consecutive transient errors (resets on success).
@@ -128,10 +127,6 @@ class ServerExecutionState(BaseModel):
     planned_at: datetime | None = Field(
         default=None,
         description="When workflow planning (architect stage) completed",
-    )
-    stage_timestamps: dict[str, datetime] = Field(
-        default_factory=dict,
-        description="When each stage started",
     )
     current_stage: str | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

Remove the unused `stage_timestamps` field from `ServerExecutionState`. This field became dead code after the planning workflow status refactor in #375.

## Changes

### Removed
- `stage_timestamps: dict[str, datetime]` field from `ServerExecutionState`
- Corresponding docstring entry

## Motivation

Cleanup of dead code left over from the planning workflow status refactor (#375). The `stage_timestamps` field was no longer populated or consumed by any code path.

## Related Issues

- Follows up on #375

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)