### PR TITLE
refactor(server): remove planned_at field from ServerExecutionState (#381)

### DIFF
--- a/amelia/server/models/state.py
+++ b/amelia/server/models/state.py
@@ -122,10 +122,6 @@ class ServerExecutionState(BaseModel):
         default=None,
         description="When workflow ended",
     )
-    planned_at: datetime | None = Field(
-        default=None,
-        description="When workflow planning (architect stage) completed",
-    )
     current_stage: str | None = Field(
         default=None,
         description="Currently executing stage",
@@ -149,11 +145,6 @@ class ServerExecutionState(BaseModel):
             ]
         }
     }
-
-    @property
-    def is_planned(self) -> bool:
-        """Return True if the workflow has completed planning."""
-        return self.planned_at is not None
 
 
 def rebuild_server_execution_state() -> None:

--- a/docs/site/architecture/data-model.md
+++ b/docs/site/architecture/data-model.md
@@ -186,7 +186,6 @@ The central state object for the LangGraph orchestrator. This model is frozen (i
 | `tool_results` | `Annotated[list[ToolResult], operator.add]` | `[]` | History of tool results from agentic execution. Uses reducer. |
 | `agentic_status` | `AgenticStatus` | `"running"` | Current agentic execution status. |
 | `created_at` | `datetime` | — | When the workflow was created/queued. |
-| `planned_at` | `datetime \| None` | `None` | When Architect completed planning (null if not yet planned). |
 | `final_response` | `str \| None` | `None` | Final response from the agent when complete. |
 | `error` | `str \| None` | `None` | Error message if status is 'failed'. |
 | `review_iteration` | `int` | `0` | Current iteration in review-fix loop. |
@@ -206,7 +205,6 @@ The central state object for the LangGraph orchestrator. This model is frozen (i
 
 | Property | Return Type | Description |
 |----------|-------------|-------------|
-| `is_planned` | `bool` | `True` if Architect has run and `planned_at` is set. |
 | `is_queued` | `bool` | `True` if workflow is in `pending` status (not yet started). |
 
 ## Streaming Entities

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -13,7 +13,7 @@ Issue → [Queue] → Architect (plan) → Human Approval → Developer (execute
    pending state
 ```
 
-**Queue Step (Optional):** With `--queue` flag, workflows enter `pending` state instead of immediate execution. Use `amelia run` to start queued workflows. The `--plan` flag runs the Architect while queued, setting `planned_at` when complete.
+**Queue Step (Optional):** With `--queue` flag, workflows enter `pending` state instead of immediate execution. Use `amelia run` to start queued workflows. The `--plan` flag runs the Architect while queued.
 
 **Phase 2 (Complete):** Observable orchestration through a local web dashboard. FastAPI server with SQLite persistence, REST API for workflow management, React dashboard with real-time WebSocket updates, and agentic execution with streaming tool calls.
 

--- a/docs/site/guide/troubleshooting.md
+++ b/docs/site/guide/troubleshooting.md
@@ -188,7 +188,7 @@ curl http://127.0.0.1:8420/api/workflows/<workflow-id>
 3. Check if the workflow has a plan ready:
    ```bash
    curl http://127.0.0.1:8420/api/workflows/<workflow-id>
-   # Look for planned_at field
+   # Look for workflow_status field
    ```
 
 #### Cannot start queued workflow (409)
@@ -250,7 +250,7 @@ WorkflowConflictError: Cannot start workflow - another workflow is active on thi
    gh issue view <issue-id>
    ```
 
-3. Note: If planning fails, the workflow transitions back to `pending` state (or fails). Check the `planned_at` field to see if planning completed.
+3. Note: If planning fails, the workflow transitions back to `pending` state (or fails). Check the `workflow_status` field to see if planning completed.
 
 ### Invalid worktree (400)
 

--- a/docs/site/guide/usage.md
+++ b/docs/site/guide/usage.md
@@ -145,7 +145,7 @@ Options:
 #### Queue Workflow Lifecycle
 
 1. **Queue** - Workflow created in `pending` state, not executing
-2. **Plan (optional)** - Architect runs, `planned_at` set when complete
+2. **Plan (optional)** - Architect runs while workflow remains queued
 3. **Start** - Workflow transitions to `in_progress` and begins execution
 4. **Complete** - Normal completion flow
 

--- a/tests/integration/test_plan_now_approve_flow.py
+++ b/tests/integration/test_plan_now_approve_flow.py
@@ -68,7 +68,6 @@ class TestPlanNowApproveFlow:
         assert workflow.workflow_status == "blocked", (
             f"Expected 'blocked' but got '{workflow.workflow_status}'"
         )
-        assert workflow.planned_at is not None, "planned_at should be set after planning"
 
     async def test_plan_now_and_approve_completes_successfully(
         self,

--- a/tests/integration/test_replan_flow.py
+++ b/tests/integration/test_replan_flow.py
@@ -62,12 +62,9 @@ class TestReplanFlow:
         workflow = await test_repository.get(workflow_id)
         assert workflow is not None
         assert workflow.workflow_status == WorkflowStatus.BLOCKED
-        assert workflow.planned_at is not None
         assert workflow.execution_state is not None
         assert workflow.execution_state.goal == "Original goal from architect"
         assert "Original Plan" in (workflow.execution_state.plan_markdown or "")
-
-        original_planned_at = workflow.planned_at
 
         # Phase 2: replan -> PENDING -> BLOCKED (with new plan)
         async with mock_langgraph_for_planning(
@@ -84,8 +81,6 @@ class TestReplanFlow:
         workflow = await test_repository.get(workflow_id)
         assert workflow is not None
         assert workflow.workflow_status == WorkflowStatus.BLOCKED
-        assert workflow.planned_at is not None
-        assert workflow.planned_at != original_planned_at  # New timestamp
         assert workflow.execution_state is not None
         assert workflow.execution_state.goal == "New goal after replan"
         assert "Revised Plan" in (workflow.execution_state.plan_markdown or "")

--- a/tests/unit/server/models/test_state.py
+++ b/tests/unit/server/models/test_state.py
@@ -150,28 +150,3 @@ class TestServerExecutionStateComposition:
         assert server_state.execution_state is not None
         assert server_state.execution_state.profile_id == "test"
 
-
-class TestServerExecutionStatePlannedAt:
-    """Tests for planned_at field."""
-
-    def test_planned_at_defaults_to_none(self) -> None:
-        """planned_at should default to None for new workflows."""
-        state = make_state()
-        assert state.planned_at is None
-
-    def test_planned_at_can_be_set(self) -> None:
-        """planned_at can be set to a datetime."""
-        now = datetime.now(UTC)
-        state = make_state(planned_at=now)
-        assert state.planned_at == now
-
-    def test_is_planned_property_false_when_no_plan(self) -> None:
-        """is_planned should return False when planned_at is None."""
-        state = make_state()
-        assert state.is_planned is False
-
-    def test_is_planned_property_true_when_planned(self) -> None:
-        """is_planned should return True when planned_at is set."""
-        state = make_state(planned_at=datetime.now(UTC))
-        assert state.is_planned is True
-

--- a/tests/unit/server/orchestrator/test_queue_and_plan.py
+++ b/tests/unit/server/orchestrator/test_queue_and_plan.py
@@ -217,7 +217,6 @@ class TestQueueAndPlanWorkflow:
 
         assert workflow_id is not None
 
-        # Check state was saved with plan and planned_at
         # create() is called once for initial workflow creation
         # update() may be called multiple times (_sync_plan_from_checkpoint + status update)
         mock_repository.create.assert_called_once()
@@ -226,7 +225,6 @@ class TestQueueAndPlanWorkflow:
         # Check the final updated state (last call to update)
         updated_state = mock_repository.update.call_args[0][0]
         assert updated_state.workflow_status == "blocked"
-        assert updated_state.planned_at is not None
         # execution_state is synced from checkpoint via _sync_plan_from_checkpoint
         assert updated_state.execution_state is not None
 

--- a/tests/unit/server/orchestrator/test_replan.py
+++ b/tests/unit/server/orchestrator/test_replan.py
@@ -92,7 +92,6 @@ def make_blocked_workflow(
         worktree_path="/tmp/test-repo",
         workflow_status=WorkflowStatus.BLOCKED,
         current_stage=None,
-        planned_at=datetime.now(UTC),
         execution_state=ImplementationState(
             workflow_id=workflow_id,
             created_at=datetime.now(UTC),
@@ -160,7 +159,6 @@ class TestReplanWorkflow:
         updated = mock_repository.update.call_args[0][0]
         assert updated.workflow_status == WorkflowStatus.PENDING
         assert updated.current_stage == "architect"
-        assert updated.planned_at is None
         assert updated.execution_state is not None
         assert updated.execution_state.goal is None
         assert updated.execution_state.plan_markdown is None


### PR DESCRIPTION
## Summary

Remove the write-only `planned_at` timestamp and `is_planned` derived property from `ServerExecutionState`. The `workflow_status` field (PENDING → BLOCKED transition) already tracks whether planning has completed, making `planned_at` redundant.

## Changes

### Removed
- `planned_at` field from `ServerExecutionState` model
- `is_planned` computed property that derived from `planned_at`
- All references in orchestrator service (`_run_planning_task`, `replan_workflow`)
- Documentation references in data model, architecture overview, troubleshooting, and usage guides
- Unit tests for `planned_at` field and `is_planned` property
- Assertions on `planned_at` in integration tests

### Changed
- Updated troubleshooting and usage docs to reference `workflow_status` instead of `planned_at`
- Simplified comments in orchestrator service that mentioned `planned_at`

## Motivation

Part of the ongoing cleanup of write-only fields from `ServerExecutionState`. The `planned_at` timestamp was set during planning and cleared during replan, but was never read by any business logic — `workflow_status` already encodes whether planning is complete (BLOCKED = plan ready for approval). This follows the same pattern as #383 (remove `stage_timestamps`) and #384 (remove `last_error_context`/`consecutive_errors`).

## Testing

- [x] Unit tests updated (removed `planned_at`-specific tests, verified remaining pass)
- [x] Integration tests updated (removed `planned_at` assertions from plan-now-approve and replan flows)
- [x] All 1302 tests pass
- [x] Linting and type checking pass

## Related Issues

- Closes #381

---

Generated with [Claude Code](https://claude.com/claude-code)