### PR TITLE
fix(test): isolate server config tests from shell environment

### DIFF
--- a/tests/unit/server/test_server_config.py
+++ b/tests/unit/server/test_server_config.py
@@ -10,6 +10,14 @@ from amelia.server.config import ServerConfig
 from amelia.server.dependencies import get_config
 
 
+@pytest.fixture(autouse=True)
+def _clean_amelia_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all AMELIA_-prefixed env vars to isolate tests from the shell."""
+    for key in list(os.environ):
+        if key.startswith("AMELIA_"):
+            monkeypatch.delenv(key)
+
+
 class TestServerConfig:
     """Tests for ServerConfig (bootstrap-only fields).
 


### PR DESCRIPTION
## Summary
- Add `autouse` fixture to `test_server_config.py` that clears all `AMELIA_`-prefixed env vars before each test
- Fixes flaky test failures when `AMELIA_DATABASE_URL` (or other `AMELIA_*` vars) are set in the developer's shell
- `ServerConfig` is a Pydantic `BaseSettings` model that reads env vars automatically, causing tests asserting defaults to fail

## Test plan
- [x] All tests pass with `AMELIA_DATABASE_URL` set: `AMELIA_DATABASE_URL="postgresql://fake:5432/fake" uv run pytest tests/unit/server/test_server_config.py`
- [x] All tests pass with multiple `AMELIA_*` vars set simultaneously
- [x] Tests that explicitly set env vars (e.g. `test_env_override_port`) still work correctly
- [x] Full test suite passes (1180 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)