### PR TITLE
fix(agents): prevent checkpoint bloat from tool_calls/tool_results double-counting

### DIFF
--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -126,8 +126,8 @@ Before planning, discover:
 
         cwd = profile.working_dir or "."
         plan_path = resolve_plan_path(profile.plan_path_pattern, state.issue.id)
-        tool_calls: list[ToolCall] = list(state.tool_calls)
-        tool_results: list[ToolResult] = list(state.tool_results)
+        tool_calls: list[ToolCall] = []
+        tool_results: list[ToolResult] = []
         raw_output = ""
         current_state = state
 

--- a/amelia/agents/developer.py
+++ b/amelia/agents/developer.py
@@ -91,8 +91,8 @@ class Developer:
         cwd = profile.working_dir or "."
         prompt = self._build_prompt(state)
 
-        tool_calls: list[ToolCall] = list(state.tool_calls)
-        tool_results: list[ToolResult] = list(state.tool_results)
+        tool_calls: list[ToolCall] = []
+        tool_results: list[ToolResult] = []
         current_state = state
         session_id = state.driver_session_id
 

--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -883,7 +883,14 @@ class OrchestratorService:
         config: RunnableConfig = {
             "configurable": {"thread_id": workflow_id},
         }
-        checkpoint_state = await graph.aget_state(config)
+        try:
+            checkpoint_state = await graph.aget_state(config)
+        except Exception as exc:
+            raise InvalidStateError(
+                f"Cannot resume: checkpoint data is corrupted ({type(exc).__name__}: {exc})",
+                workflow_id=workflow_id,
+                current_status=workflow.workflow_status,
+            ) from exc
         if checkpoint_state is None or not checkpoint_state.values:
             raise InvalidStateError(
                 "Cannot resume: no checkpoint found for workflow",

--- a/tests/unit/agents/test_architect_agentic.py
+++ b/tests/unit/agents/test_architect_agentic.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from amelia.agents.architect import Architect
+from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.core.types import AgentConfig, Profile, SandboxConfig
 from amelia.drivers.base import AgenticMessage, AgenticMessageType
 from amelia.pipelines.implementation.state import ImplementationState
@@ -332,3 +333,70 @@ class TestArchitectDesignDocumentInPrompt:
 
         assert captured_prompt is not None
         assert "## Design Document" not in captured_prompt
+
+
+class TestArchitectPlanNoDoubleCount:
+    """Tests that Architect.plan() returns only NEW tool calls/results, not accumulated ones from state."""
+
+    async def test_plan_returns_only_new_tool_data(
+        self,
+        mock_driver,
+        mock_issue_factory,
+        mock_profile_factory,
+    ) -> None:
+        """plan() should not copy pre-existing tool_calls/tool_results from state."""
+        issue = mock_issue_factory()
+        profile = mock_profile_factory()
+        state = ImplementationState(
+            workflow_id="test-workflow",
+            created_at=datetime.now(UTC),
+            status="running",
+            profile_id="test",
+            issue=issue,
+            tool_calls=[
+                ToolCall(id="old-1", tool_name="read_file", tool_input={"path": "x.py"}),
+            ],
+            tool_results=[
+                ToolResult(call_id="old-1", tool_name="read_file", output="content", success=True),
+            ],
+        )
+        config = AgentConfig(driver="cli", model="sonnet")
+
+        async def mock_stream(*args, **kwargs):
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_CALL,
+                tool_name="list_dir",
+                tool_input={"path": "."},
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_RESULT,
+                tool_name="list_dir",
+                tool_output="src/",
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(
+                type=AgenticMessageType.RESULT,
+                content="**Goal:** Test",
+            )
+
+        mock_driver.execute_agentic = mock_stream
+
+        with patch("amelia.agents.architect.get_driver", return_value=mock_driver):
+            architect = Architect(config)
+
+            final_state = None
+            async for new_state, _ in architect.plan(state, profile, workflow_id="wf-1"):
+                final_state = new_state
+
+        assert final_state is not None
+        assert len(final_state.tool_calls) == 1, (
+            f"Expected 1 new tool call, got {len(final_state.tool_calls)} "
+            "(pre-existing tool calls should not be copied)"
+        )
+        assert final_state.tool_calls[0].tool_name == "list_dir"
+        assert len(final_state.tool_results) == 1, (
+            f"Expected 1 new tool result, got {len(final_state.tool_results)} "
+            "(pre-existing tool results should not be copied)"
+        )
+        assert final_state.tool_results[0].tool_name == "list_dir"

--- a/tests/unit/agents/test_developer.py
+++ b/tests/unit/agents/test_developer.py
@@ -1,8 +1,16 @@
 """Unit tests for Developer agent initialization."""
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from amelia.agents.developer import Developer
+from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.core.types import AgentConfig, SandboxConfig
+from amelia.drivers.base import AgenticMessage, AgenticMessageType
+from amelia.pipelines.implementation.state import ImplementationState
 
 
 def test_developer_init_with_agent_config() -> None:
@@ -65,3 +73,96 @@ def test_developer_init_passes_sandbox_config() -> None:
             profile_name="work",
             options={"max_iterations": 5},
         )
+
+
+class TestDeveloperRunNoDoubleCount:
+    """Verify Developer.run() returns only NEW tool calls/results, not accumulated ones from state.
+
+    The bug was that Developer.run() used to initialize tool_calls = list(state.tool_calls)
+    which copied existing state entries, causing double-counting when LangGraph's operator.add
+    reducer appends the returned list to existing state. The fix changed it to tool_calls = []
+    so only new entries are returned.
+    """
+
+    @pytest.fixture
+    def state_with_existing_tool_data(
+        self, mock_issue_factory, mock_profile_factory
+    ) -> tuple[ImplementationState, Any]:
+        """ImplementationState with pre-existing tool_calls and tool_results."""
+        issue = mock_issue_factory(title="Implement feature", description="Feature desc")
+        profile = mock_profile_factory()
+        state = ImplementationState(
+            workflow_id="test-workflow",
+            created_at=datetime.now(UTC),
+            status="running",
+            profile_id="test",
+            issue=issue,
+            goal="implement feature",
+            plan_markdown="# Plan\n\nImplement the feature.",
+            tool_calls=[
+                ToolCall(id="old-1", tool_name="read_file", tool_input={"path": "x.py"}),
+            ],
+            tool_results=[
+                ToolResult(call_id="old-1", tool_name="read_file", output="content", success=True),
+            ],
+        )
+        return state, profile
+
+    async def test_run_returns_only_new_tool_calls_and_results(
+        self,
+        mock_driver,
+        state_with_existing_tool_data,
+    ) -> None:
+        """Developer.run() should return only new tool calls/results, not pre-existing ones.
+
+        When LangGraph uses operator.add to merge returned state into existing state,
+        returning pre-existing entries would cause them to be duplicated.
+        """
+        state, profile = state_with_existing_tool_data
+        config = AgentConfig(driver="cli", model="sonnet")
+
+        async def mock_stream(*args: Any, **kwargs: Any) -> AsyncIterator[AgenticMessage]:
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_CALL,
+                tool_name="bash",
+                tool_input={"command": "ls"},
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_RESULT,
+                tool_name="bash",
+                tool_output="file.py",
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(
+                type=AgenticMessageType.RESULT,
+                content="Done",
+                session_id="sess-1",
+            )
+
+        mock_driver.execute_agentic = mock_stream
+
+        with patch("amelia.agents.developer.get_driver", return_value=mock_driver):
+            developer = Developer(config)
+
+            final_state = None
+            async for new_state, _event in developer.run(state, profile, workflow_id="wf-1"):
+                final_state = new_state
+
+        assert final_state is not None
+
+        # Must contain ONLY the new tool call, not the pre-existing "old-1"
+        assert len(final_state.tool_calls) == 1, (
+            f"Expected 1 new tool call, got {len(final_state.tool_calls)}. "
+            "Developer.run() may be copying pre-existing state.tool_calls."
+        )
+        assert final_state.tool_calls[0].id == "new-1"
+        assert final_state.tool_calls[0].tool_name == "bash"
+
+        # Must contain ONLY the new tool result, not the pre-existing "old-1"
+        assert len(final_state.tool_results) == 1, (
+            f"Expected 1 new tool result, got {len(final_state.tool_results)}. "
+            "Developer.run() may be copying pre-existing state.tool_results."
+        )
+        assert final_state.tool_results[0].call_id == "new-1"
+        assert final_state.tool_results[0].tool_name == "bash"

--- a/tests/unit/server/orchestrator/test_service.py
+++ b/tests/unit/server/orchestrator/test_service.py
@@ -1618,3 +1618,38 @@ class TestExponentialBackoff:
         for i in range(4, 10):
             assert delays[i] == 300.0
 
+
+# =============================================================================
+# Resume Workflow Tests
+# =============================================================================
+
+
+async def test_resume_workflow_corrupted_checkpoint_raises_invalid_state(
+    orchestrator: OrchestratorService,
+    mock_repository: AsyncMock,
+) -> None:
+    """resume_workflow should raise InvalidStateError when graph.aget_state() throws a database error."""
+    workflow = ServerExecutionState(
+        id="test-wf",
+        issue_id="ISSUE-123",
+        created_at=datetime.now(UTC),
+        profile_id="test",
+        workflow_status=WorkflowStatus.FAILED,
+        worktree_path="/tmp/test-worktree",
+    )
+    mock_repository.get.return_value = workflow
+
+    # Mock graph whose aget_state raises a database error
+    mock_graph = MagicMock()
+    mock_graph.aget_state = AsyncMock(
+        side_effect=Exception("invalid memory alloc request size 1227985520")
+    )
+
+    with (
+        patch.object(orchestrator, "_create_server_graph", return_value=mock_graph),
+        pytest.raises(InvalidStateError) as exc_info,
+    ):
+        await orchestrator.resume_workflow("test-wf")
+
+    assert "corrupted" in str(exc_info.value).lower()
+


### PR DESCRIPTION
## Summary

Fix exponential checkpoint growth caused by Developer and Architect agents copying existing `tool_calls`/`tool_results` from state before appending new entries. Since LangGraph's `operator.add` reducer appends the returned list onto existing state, this doubled all prior entries on each pass — eventually crashing PostgreSQL with "invalid memory alloc request size" on resume.

## Changes

### Fixed
- **Architect.plan()** and **Developer.run()** now initialize `tool_calls` and `tool_results` as empty lists instead of copying from state, preventing double-counting by the `operator.add` reducer
- **OrchestratorService.resume_workflow()** wraps `graph.aget_state()` with error handling so corrupted checkpoints raise `InvalidStateError` instead of unhandled 500 errors

## Motivation

When workflows ran for many iterations, each agent pass doubled all prior tool call/result entries in the checkpoint. This caused exponential growth in checkpoint size, eventually hitting PostgreSQL's memory allocation limits and making workflows unresumable. The fix ensures only new entries are returned from each agent pass.

## Testing

- [x] Unit tests added/updated

### Tests Added
- `TestArchitectPlanNoDoubleCount` — verifies `plan()` returns only new tool data, not accumulated state
- `TestDeveloperRunNoDoubleCount` — verifies `run()` returns only new tool data, not accumulated state
- `test_resume_workflow_corrupted_checkpoint_raises_invalid_state` — verifies corrupted checkpoints produce a clear `InvalidStateError`

## Related Issues

- Closes #457

---

Generated with [Claude Code](https://claude.com/claude-code)