### PR TITLE
fix(agents): correct skill name references in reviewer prompts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,9 @@ For PRs with significant changes, create a manual test plan at `docs/testing/pr-
 If you're using [Claude Code](https://claude.ai/code), install the [beagle](https://github.com/anderskev/beagle) plugin for PR workflow commands:
 
 ```bash
-/beagle:create-pr        # Create PR with standardized description
-/beagle:commit-push      # Commit and push with proper format
-/beagle:review-backend   # Review Python/FastAPI code
-/beagle:review-frontend  # Review React/TypeScript code
+/beagle-core:create-pr        # Create PR with standardized description
+/beagle-core:commit-push      # Commit and push with proper format
+/beagle-python:review-python  # Review Python/FastAPI code
+/beagle-react:review-frontend # Review React/TypeScript code
 /amelia:gen-test-plan    # Generate manual test plan
 ```

--- a/amelia/agents/evaluator.py
+++ b/amelia/agents/evaluator.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 class Evaluator:
     """Evaluates review feedback against codebase.
 
-    Applies decision matrix from beagle:receive-feedback pattern:
+    Applies decision matrix from beagle-core:receive-feedback pattern:
     - Correct & In Scope -> implement
     - Technically Incorrect -> reject with evidence
     - Out of Scope -> defer

--- a/amelia/agents/prompts/defaults.py
+++ b/amelia/agents/prompts/defaults.py
@@ -149,10 +149,10 @@ Guidelines:
    - TypeScript/React (.tsx, .ts): Look for React Router, shadcn/ui, Zustand, React Flow
 
 3. **Load Review Skills**: Use the `Skill` tool to load appropriate review skills:
-   - Python: `beagle:review-python` (FastAPI, pytest, Pydantic)
-   - Go: `beagle:review-go` (error handling, concurrency, interfaces)
-   - Frontend: `beagle:review-frontend` (React, TypeScript, CSS)
-   - TUI: `beagle:review-tui` (BubbleTea terminal apps)
+   - Python: `beagle-python:review-python` (FastAPI, pytest, Pydantic)
+   - Go: `beagle-go:review-go` (error handling, concurrency, interfaces)
+   - Frontend: `beagle-react:review-frontend` (React, TypeScript, CSS)
+   - TUI: `beagle-go:review-tui` (BubbleTea terminal apps)
 
 4. **Get the Diff**: Run `git diff {{base_commit}}` to get the full diff
 

--- a/amelia/agents/reviewer.py
+++ b/amelia/agents/reviewer.py
@@ -84,10 +84,10 @@ class Reviewer:
    - TypeScript/React (.tsx, .ts): Look for React Router, shadcn/ui, Zustand, React Flow
 
 3. **Load Review Skills**: Use the `Skill` tool to load appropriate review skills:
-   - Python: `beagle:review-python` (FastAPI, pytest, Pydantic)
-   - Go: `beagle:review-go` (error handling, concurrency, interfaces)
-   - Frontend: `beagle:review-frontend` (React, TypeScript, CSS)
-   - TUI: `beagle:review-tui` (BubbleTea terminal apps)
+   - Python: `beagle-python:review-python` (FastAPI, pytest, Pydantic)
+   - Go: `beagle-go:review-go` (error handling, concurrency, interfaces)
+   - Frontend: `beagle-react:review-frontend` (React, TypeScript, CSS)
+   - TUI: `beagle-go:review-tui` (BubbleTea terminal apps)
 
 4. **Get the Diff**: Run `git diff {{base_commit}}` to get the full diff
 
@@ -238,7 +238,7 @@ class Reviewer:
 
         This method uses agentic execution to:
         1. Auto-detect technologies in the changed files
-        2. Load appropriate review skills (beagle:review-python, etc.)
+        2. Load appropriate review skills (beagle-python:review-python, etc.)
         3. Fetch the diff using git tools
         4. Review the code following the loaded skills
 


### PR DESCRIPTION
## Summary

Reviewer agent prompts referenced skills with a shorthand `beagle:` prefix (e.g. `beagle:review-frontend`), but actual installed skill names use language-specific package prefixes (e.g. `beagle-react:review-frontend`). This caused "Unknown skill" errors during reviewer runs.

## Changes

### Fixed
- `amelia/agents/reviewer.py` — corrected 5 skill name references in prompt text and docstring
- `amelia/agents/prompts/defaults.py` — corrected 4 skill name references in default reviewer prompt
- `amelia/agents/evaluator.py` — corrected 1 skill name reference in docstring
- `CONTRIBUTING.md` — corrected 4 skill name references in user-facing examples

### Mapping

| Before (broken) | After (correct) |
|---|---|
| `beagle:review-python` | `beagle-python:review-python` |
| `beagle:review-go` | `beagle-go:review-go` |
| `beagle:review-frontend` | `beagle-react:review-frontend` |
| `beagle:review-tui` | `beagle-go:review-tui` |
| `beagle:receive-feedback` | `beagle-core:receive-feedback` |
| `beagle:create-pr` | `beagle-core:create-pr` |
| `beagle:commit-push` | `beagle-core:commit-push` |

## Testing

- [x] Unit tests pass (1484 passed)
- [x] Full pre-push suite passes (1505 passed, linting, mypy)

---

Generated with [Claude Code](https://claude.com/claude-code)