### PR TITLE
fix(db): add missing TEXT→UUID migration

### DIFF
--- a/amelia/server/database/migrations/005_text_to_uuid_columns.sql
+++ b/amelia/server/database/migrations/005_text_to_uuid_columns.sql
@@ -1,0 +1,34 @@
+-- Migration 005: Convert TEXT columns to UUID type
+-- Affects: brainstorm_sessions, brainstorm_messages, brainstorm_artifacts,
+--          prompt_versions, prompts, workflow_prompt_versions
+
+-- 1. brainstorm tables: drop FKs, alter columns, re-add FKs
+
+ALTER TABLE brainstorm_messages DROP CONSTRAINT IF EXISTS brainstorm_messages_session_id_fkey;
+ALTER TABLE brainstorm_artifacts DROP CONSTRAINT IF EXISTS brainstorm_artifacts_session_id_fkey;
+
+ALTER TABLE brainstorm_sessions ALTER COLUMN id TYPE UUID USING id::uuid;
+ALTER TABLE brainstorm_messages ALTER COLUMN id TYPE UUID USING id::uuid;
+ALTER TABLE brainstorm_messages ALTER COLUMN session_id TYPE UUID USING session_id::uuid;
+ALTER TABLE brainstorm_artifacts ALTER COLUMN id TYPE UUID USING id::uuid;
+ALTER TABLE brainstorm_artifacts ALTER COLUMN session_id TYPE UUID USING session_id::uuid;
+
+ALTER TABLE brainstorm_messages
+    ADD CONSTRAINT brainstorm_messages_session_id_fkey
+    FOREIGN KEY (session_id) REFERENCES brainstorm_sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE brainstorm_artifacts
+    ADD CONSTRAINT brainstorm_artifacts_session_id_fkey
+    FOREIGN KEY (session_id) REFERENCES brainstorm_sessions(id) ON DELETE CASCADE;
+
+-- 2. prompt tables: drop FK, alter columns, re-add FK
+
+ALTER TABLE workflow_prompt_versions DROP CONSTRAINT IF EXISTS workflow_prompt_versions_version_id_fkey;
+
+ALTER TABLE prompt_versions ALTER COLUMN id TYPE UUID USING id::uuid;
+ALTER TABLE prompts ALTER COLUMN current_version_id TYPE UUID USING current_version_id::uuid;
+ALTER TABLE workflow_prompt_versions ALTER COLUMN version_id TYPE UUID USING version_id::uuid;
+
+ALTER TABLE workflow_prompt_versions
+    ADD CONSTRAINT workflow_prompt_versions_version_id_fkey
+    FOREIGN KEY (version_id) REFERENCES prompt_versions(id);


### PR DESCRIPTION
## Summary
- Adds migration `005_text_to_uuid_columns.sql` that was missed in the UUID type refactor (#459)
- Converts remaining TEXT primary/foreign key columns to UUID in `brainstorm_sessions`, `brainstorm_messages`, `brainstorm_artifacts`, `prompt_versions`, `prompts`, and `workflow_prompt_versions`

## Context
PR #459 changed Python types from `str` to `uuid.UUID` but didn't include the SQL migration for existing databases. The initial schema (`001`) creates these columns as TEXT, so this migration is needed for anyone with an existing database.

## Test plan
- [ ] Run migration against a database with existing brainstorm/prompt data
- [ ] Verify foreign key constraints are preserved after migration
- [ ] Confirm no errors when inserting new records via the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)