### PR TITLE
refactor(core): remove dead `or "."` cwd fallbacks

### DIFF
--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -125,7 +125,7 @@ Before planning, discover:
         # Build user prompt from state (simplified - no codebase scan)
         user_prompt = self._build_agentic_prompt(state, profile)
 
-        cwd = profile.repo_root or "."
+        cwd = profile.repo_root
         plan_path = resolve_plan_path(profile.plan_path_pattern, state.issue.id)
         tool_calls: list[ToolCall] = []
         tool_results: list[ToolResult] = []

--- a/amelia/agents/developer.py
+++ b/amelia/agents/developer.py
@@ -89,7 +89,7 @@ class Developer:
         if not state.goal:
             raise ValueError("ImplementationState must have a goal set")
 
-        cwd = profile.repo_root or "."
+        cwd = profile.repo_root
         prompt = self._build_prompt(state)
 
         tool_calls: list[ToolCall] = []

--- a/amelia/agents/reviewer.py
+++ b/amelia/agents/reviewer.py
@@ -277,13 +277,7 @@ The changes are in git - diff against commit: {base_commit}"""
         # Build system prompt with base_commit
         system_prompt = self.agentic_prompt.format(base_commit=base_commit)
 
-        if profile.repo_root is None:
-            logger.warning(
-                "profile.repo_root is None, falling back to current directory",
-                agent=self._agent_name,
-                workflow_id=workflow_id,
-            )
-        cwd = profile.repo_root or "."
+        cwd = profile.repo_root
         # Always start a fresh session — the reviewer must not resume the
         # developer's session (different agent, different system prompt).
         session_id = None

--- a/amelia/pipelines/implementation/external_plan.py
+++ b/amelia/pipelines/implementation/external_plan.py
@@ -252,9 +252,7 @@ async def import_external_plan(
         ValueError: If validation fails, content is empty, or path traversal detected.
     """
     # Establish working directory as security boundary
-    working_dir = (
-        Path(profile.repo_root) if profile.repo_root else Path(".")
-    ).expanduser().resolve()
+    working_dir = Path(profile.repo_root).expanduser().resolve()
 
     # Read content
     content = await read_plan_content(

--- a/amelia/pipelines/implementation/nodes.py
+++ b/amelia/pipelines/implementation/nodes.py
@@ -58,7 +58,7 @@ async def plan_validator_node(
 
     # Resolve plan path - use working_dir to match call_architect_node
     plan_rel_path = resolve_plan_path(profile.plan_path_pattern, state.issue.id)
-    working_dir = Path(profile.repo_root) if profile.repo_root else Path(".")
+    working_dir = Path(profile.repo_root)
     plan_path = working_dir / plan_rel_path
 
     logger.info(
@@ -163,7 +163,7 @@ async def call_architect_node(
 
     # Ensure the plan directory exists before the architect runs
     plan_rel_path = resolve_plan_path(profile.plan_path_pattern, state.issue.id)
-    working_dir = Path(profile.repo_root) if profile.repo_root else Path(".")
+    working_dir = Path(profile.repo_root)
     plan_path = working_dir / plan_rel_path
     await asyncio.to_thread(plan_path.parent.mkdir, parents=True, exist_ok=True)
     logger.debug("Ensured plan directory exists", plan_dir=str(plan_path.parent))

--- a/amelia/pipelines/implementation/utils.py
+++ b/amelia/pipelines/implementation/utils.py
@@ -292,7 +292,7 @@ async def commit_task_changes(state: ImplementationState, config: RunnableConfig
     profile: Profile | None = config.get("configurable", {}).get("profile")
     if not profile:
         raise ValueError("profile is required in config.configurable")
-    working_dir = Path(profile.repo_root) if profile.repo_root else Path.cwd()
+    working_dir = Path(profile.repo_root)
 
     task_number = state.current_task_index + 1
 

--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -635,7 +635,7 @@ class OrchestratorService:
         if request.plan_file is not None or request.plan_content is not None:
             # Resolve target plan path
             plan_rel_path = resolve_plan_path(profile.plan_path_pattern, request.issue_id)
-            working_dir = Path(profile.repo_root) if profile.repo_root else Path(".")
+            working_dir = Path(profile.repo_root)
             target_path = working_dir / plan_rel_path
 
             # Import and validate external plan
@@ -2737,7 +2737,7 @@ class OrchestratorService:
 
         # Resolve target plan path
         plan_rel_path = resolve_plan_path(profile.plan_path_pattern, workflow.issue_id)
-        working_dir = Path(profile.repo_root) if profile.repo_root else Path(".")
+        working_dir = Path(profile.repo_root)
         target_path = working_dir / plan_rel_path
 
         # Fast path: read content, write to target, count tasks (no LLM)


### PR DESCRIPTION
## Summary

Remove dead defensive fallbacks (`or "."`, ternary checks) for `profile.repo_root` across agents and pipeline nodes. `Profile.repo_root` is a non-optional `str` field validated by `OrchestratorService._update_profile_repo_root()` before any agent runs, making these fallbacks unreachable dead code.

## Changes

### Removed
- `or "."` fallbacks in `architect.py`, `developer.py`, `reviewer.py`, `utils.py`
- `if profile.repo_root else Path(".")` ternaries in `nodes.py`, `service.py`, `external_plan.py`
- Dead `logger.warning` block in `reviewer.py` for a condition that can never be true

## Motivation

After #479 renamed `working_dir` to `repo_root` and established it as non-optional, these fallbacks became dead code that obscured the real contract: `repo_root` is always set before agents run.

## Testing

- All 1555 tests pass (pre-push hook verified)
- No behavior change — removed code paths were unreachable

## Related Issues

- Closes #476

---

Generated with [Claude Code](https://claude.com/claude-code)