### PR TITLE
fix(architect): remove git commit step from plan template

### DIFF
--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -46,7 +46,7 @@ DO NOT use real filesystem absolute paths like /Users/... or C:\\... - these wil
 All paths are relative to the working directory but must start with /.
 
 ## Principles
-- DRY, YAGNI, TDD, frequent commits
+- DRY, YAGNI, TDD
 - Assume executor is skilled but knows nothing about this toolset or problem domain
 - Assume executor doesn't know good test design very well
 
@@ -376,12 +376,9 @@ def function(input):
 Run: `pytest tests/path/test.py::test_name -v`
 Expected: PASS
 
-**Step 5: Commit**
+**Step 5: Verify**
 
-```bash
-git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
-```
+Run the full test suite or linter if relevant to confirm nothing is broken.
 ```
 
 ## What to Include


### PR DESCRIPTION
## Summary
- Removed the "Step 5: Commit" instruction from the Architect's plan template, replacing it with a verification step
- Removed "frequent commits" from the Architect's principles list
- The orchestration layer already auto-commits after each task via `commit_task_changes()` in `next_task_node`, making these instructions redundant

## Problem
When using the Codex driver, the developer agent follows the Architect's plan and attempts to run `git add` + `git commit`. This fails because Codex CLI's sandbox blocks `.git/index.lock` creation:
```
fatal: Unable to create '.git/index.lock': Operation not permitted
```

## Test plan
- [x] All 1611 tests pass
- [x] mypy clean
- [x] ruff clean
- [ ] Run an implementation workflow with the Codex driver and confirm no commit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)