### PR TITLE
fix(server): add console-event filtering and AGENT_MESSAGE level promotion

### DIFF
--- a/amelia/server/events/log_subscriber.py
+++ b/amelia/server/events/log_subscriber.py
@@ -4,17 +4,58 @@ from __future__ import annotations
 
 from loguru import logger
 
-from amelia.server.models.events import EventLevel, WorkflowEvent
+from amelia.server.models.events import EventLevel, EventType, WorkflowEvent
+
+
+# Events worth showing in server console. Excludes trace-level noise
+# (claude_thinking, claude_tool_call, claude_tool_result, stream, etc.)
+# which would flood the console — those belong in the dashboard only.
+_CONSOLE_EVENT_TYPES: frozenset[EventType] = frozenset(
+    {
+        # Workflow lifecycle
+        EventType.WORKFLOW_STARTED,
+        EventType.WORKFLOW_COMPLETED,
+        EventType.WORKFLOW_FAILED,
+        EventType.WORKFLOW_CANCELLED,
+        # Stage transitions
+        EventType.STAGE_STARTED,
+        EventType.STAGE_COMPLETED,
+        # Agent output
+        EventType.AGENT_MESSAGE,
+        # Task progress
+        EventType.TASK_STARTED,
+        EventType.TASK_COMPLETED,
+        EventType.TASK_FAILED,
+        # Approval flow
+        EventType.APPROVAL_REQUIRED,
+        EventType.APPROVAL_GRANTED,
+        EventType.APPROVAL_REJECTED,
+        # Review
+        EventType.REVIEW_COMPLETED,
+        # Errors
+        EventType.SYSTEM_ERROR,
+        EventType.SYSTEM_WARNING,
+    }
+)
 
 
 def log_event_to_console(event: WorkflowEvent) -> None:
     """Log a workflow event to the server console via loguru.
 
     Must be non-blocking — called synchronously by EventBus.emit().
-    Uses the event's natural EventLevel so that AMELIA_LOG_LEVEL controls
-    which events are visible on the console.
+    Only logs console-worthy event types; trace-level events are skipped.
+    Promotes AGENT_MESSAGE from DEBUG to INFO for visibility.
     """
+    if event.event_type not in _CONSOLE_EVENT_TYPES:
+        return
+
     level = (event.level or EventLevel.INFO).value.upper()
+
+    # Promote AGENT_MESSAGE to INFO when it would otherwise be DEBUG,
+    # so agent output is always visible on the console.
+    if event.event_type == EventType.AGENT_MESSAGE and level == "DEBUG":
+        level = "INFO"
+
     agent = event.agent or "system"
     logger.log(
         level,

--- a/tests/unit/server/events/test_log_subscriber.py
+++ b/tests/unit/server/events/test_log_subscriber.py
@@ -45,12 +45,6 @@ class TestLogEventToConsole:
         assert mock_logger.log.call_args[0][0] == "ERROR"
 
     @patch("amelia.server.events.log_subscriber.logger")
-    def test_logs_debug_event_at_debug_level(self, mock_logger: MagicMock) -> None:
-        event = _make_event(EventType.CLAUDE_TOOL_CALL, "Calling EditFile")
-        log_event_to_console(event)
-        assert mock_logger.log.call_args[0][0] == "DEBUG"
-
-    @patch("amelia.server.events.log_subscriber.logger")
     def test_logs_warning_event_at_warning_level(self, mock_logger: MagicMock) -> None:
         event = _make_event(EventType.SYSTEM_WARNING, "Rate limit approaching")
         log_event_to_console(event)
@@ -87,3 +81,65 @@ class TestLogEventToConsole:
         )
         log_event_to_console(event)
         assert mock_logger.log.call_args[0][0] == "INFO"
+
+
+class TestConsoleEventFiltering:
+    """Tests for console-event-type filtering."""
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_skips_claude_tool_call(self, mock_logger: MagicMock) -> None:
+        event = _make_event(EventType.CLAUDE_TOOL_CALL, "Calling EditFile")
+        log_event_to_console(event)
+        mock_logger.log.assert_not_called()
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_skips_claude_thinking(self, mock_logger: MagicMock) -> None:
+        event = _make_event(EventType.CLAUDE_THINKING, "Thinking...")
+        log_event_to_console(event)
+        mock_logger.log.assert_not_called()
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_skips_stream_events(self, mock_logger: MagicMock) -> None:
+        event = _make_event(EventType.STREAM, "streaming chunk")
+        log_event_to_console(event)
+        mock_logger.log.assert_not_called()
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_allows_agent_message(self, mock_logger: MagicMock) -> None:
+        event = _make_event(EventType.AGENT_MESSAGE, "Planning architecture")
+        log_event_to_console(event)
+        mock_logger.log.assert_called_once()
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_allows_workflow_lifecycle(self, mock_logger: MagicMock) -> None:
+        event = _make_event(EventType.WORKFLOW_COMPLETED, "Done")
+        log_event_to_console(event)
+        mock_logger.log.assert_called_once()
+
+
+class TestAgentMessageLevelPromotion:
+    """Tests for AGENT_MESSAGE DEBUG -> INFO promotion."""
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_promotes_debug_agent_message_to_info(self, mock_logger: MagicMock) -> None:
+        event = _make_event(
+            EventType.AGENT_MESSAGE, "Planning", level=EventLevel.DEBUG
+        )
+        log_event_to_console(event)
+        assert mock_logger.log.call_args[0][0] == "INFO"
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_preserves_info_agent_message(self, mock_logger: MagicMock) -> None:
+        event = _make_event(
+            EventType.AGENT_MESSAGE, "Planning", level=EventLevel.INFO
+        )
+        log_event_to_console(event)
+        assert mock_logger.log.call_args[0][0] == "INFO"
+
+    @patch("amelia.server.events.log_subscriber.logger")
+    def test_preserves_warning_agent_message(self, mock_logger: MagicMock) -> None:
+        event = _make_event(
+            EventType.AGENT_MESSAGE, "Retrying", level=EventLevel.WARNING
+        )
+        log_event_to_console(event)
+        assert mock_logger.log.call_args[0][0] == "WARNING"


### PR DESCRIPTION
## Summary
- Filter `log_event_to_console` to only log console-worthy event types, preventing trace-level noise (`claude_thinking`, `claude_tool_call`, `stream`) from flooding the server console
- Promote `AGENT_MESSAGE` from DEBUG to INFO for visibility
- Add 8 new tests covering filtering and level promotion

Addresses CodeRabbit feedback on #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)