### PR TITLE
refactor(dashboard): remove Roundtable/Capacity placeholders, move Costs to Agent Ops

### DIFF
--- a/dashboard/src/components/DashboardSidebar.test.tsx
+++ b/dashboard/src/components/DashboardSidebar.test.tsx
@@ -32,6 +32,7 @@ describe('DashboardSidebar', () => {
     ['Past Runs', '/history'],
     ['Logs', '/logs'],
     ['Agent Prompts', '/prompts'],
+    ['Costs', '/costs'],
   ])('renders %s navigation link to %s', (label, href) => {
     renderSidebar();
     const link = screen.getByRole('link', { name: new RegExp(label) });
@@ -44,7 +45,6 @@ describe('DashboardSidebar', () => {
     expect(screen.getByText('WORKFLOWS')).toBeInTheDocument();
     expect(screen.getByText('TOOLS')).toBeInTheDocument();
     expect(screen.getByText('AGENT OPS')).toBeInTheDocument();
-    expect(screen.getByText('USAGE')).toBeInTheDocument();
     expect(screen.getByText('CONFIGURE')).toBeInTheDocument();
   });
 

--- a/dashboard/src/components/DashboardSidebar.tsx
+++ b/dashboard/src/components/DashboardSidebar.tsx
@@ -28,11 +28,9 @@ import {
   History,
   Radio,
   BookOpen,
-  Zap,
   Library,
   Target,
   MessageSquare,
-  Gauge,
   Coins,
   Settings,
   Bolt,
@@ -254,12 +252,6 @@ export function DashboardSidebar() {
                 label="Spec Builder"
               />
               <SidebarNavLink
-                to="/roundtable"
-                icon={Zap}
-                label="Roundtable"
-                comingSoon
-              />
-              <SidebarNavLink
                 to="/knowledge"
                 icon={Library}
                 label="Knowledge"
@@ -284,23 +276,6 @@ export function DashboardSidebar() {
                 to="/benchmarks"
                 icon={Target}
                 label="Benchmarks"
-                comingSoon
-              />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {/* Usage Section - Costs and resource tracking */}
-        <SidebarGroup>
-          <SidebarGroupLabel className="text-xs font-heading text-muted-foreground/60 font-semibold tracking-wider">
-            USAGE
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarNavLink
-                to="/capacity"
-                icon={Gauge}
-                label="Capacity"
                 comingSoon
               />
               <SidebarNavLink


### PR DESCRIPTION
## Summary
- Remove unused "coming soon" sidebar items (Roundtable, Capacity) and the empty USAGE section
- Move Costs nav link into the AGENT OPS section (after Benchmarks)
- Clean up unused `Gauge` and `Zap` icon imports
- Update sidebar tests to match new structure

## Test plan
- [x] `pnpm vitest run DashboardSidebar` — all 12 tests pass
- [x] `pnpm build` — builds clean
- [ ] Visual check: sidebar shows Costs under AGENT OPS, no Roundtable/Capacity/USAGE section

🤖 Generated with [Claude Code](https://claude.com/claude-code)