### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-07
+
+### Added
+
+- **descriptions:** AI-powered issue description condensation ([#568](https://github.com/existential-birds/amelia/pull/568))
+- **models:** Manual model code entry with DB-backed cache ([#565](https://github.com/existential-birds/amelia/pull/565))
+- **review:** `write_plan` tool, review-fix pipeline, and tool-based submission ([#562](https://github.com/existential-birds/amelia/pull/562))
+
+### Changed
+
+- **dashboard:** Remove activity log and clean up dashboard ([#555](https://github.com/existential-birds/amelia/pull/555))
+
+### Fixed
+
+- **evaluator:** Surface driver errors and fetch diffs on-demand ([#570](https://github.com/existential-birds/amelia/pull/570))
+- **dashboard:** Fix `AskUserQuestionCard` option button text wrapping ([#567](https://github.com/existential-birds/amelia/pull/567))
+
+### Security
+
+- **deps:** Bump vite to patched version ([#569](https://github.com/existential-birds/amelia/pull/569))
+- **deps:** Bump lodash to patched version ([#564](https://github.com/existential-birds/amelia/pull/564))
+- **deps:** Bump aiohttp to patched version ([#563](https://github.com/existential-birds/amelia/pull/563))
+
 ## [0.19.0] - 2026-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,7 +520,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/existential-birds/amelia/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/existential-birds/amelia/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/existential-birds/amelia/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/existential-birds/amelia/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/existential-birds/amelia/compare/v0.15.0...v0.16.0

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -8,7 +8,7 @@ Exports:
     __version__: Package version string.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 __all__ = [
     "__version__",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.19.0"
+version = "0.20.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "amelia"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- Bump version to 0.20.0
- Update CHANGELOG.md with changes since v0.19.0

## Post-merge steps

After merging, run:
```
/release-tag 0.20.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)