### PR TITLE
test: fix three integration test fixtures drifting from production

### DIFF
--- a/tests/integration/server/test_condense_description.py
+++ b/tests/integration/server/test_condense_description.py
@@ -174,7 +174,9 @@ class TestCondenseDescriptionIntegration:
 
         assert resp.status_code == 200
         # Developer agent uses gpt-4o-mini in our fixture
-        mock_get_driver.assert_called_once_with("api", model="openai/gpt-4o-mini", cwd=".")
+        mock_get_driver.assert_called_once_with(
+            "api", model="openai/gpt-4o-mini", cwd=github_profile.repo_root
+        )
 
     async def test_rejects_non_github_profile(
         self, client: httpx.AsyncClient, noop_profile: Profile

--- a/tests/integration/test_evaluation_node.py
+++ b/tests/integration/test_evaluation_node.py
@@ -263,7 +263,11 @@ class TestEvaluationNodeToolCapture:
         review_result = ReviewResult(
             reviewer_persona="Code Reviewer",
             approved=False,
-            comments=["[test.py:10] Missing error handling"],
+            comments=[
+                "[test.py:10] Missing error handling",
+                "[x.py:1] Other",
+                "[y.py:2] Later",
+            ],
             severity=Severity.MAJOR,
         )
         state = make_execution_state(
@@ -337,7 +341,9 @@ class TestEvaluationNodeToolCapture:
         mock_generate.assert_not_called()
 
         assert len(captured_kwargs) >= 1
-        assert captured_kwargs[0]["allowed_tools"] == ["submit_evaluation"]
+        submit_tools = captured_kwargs[0]["submit_tools"]
+        assert len(submit_tools) == 1
+        assert submit_tools[0].name == "submit_evaluation"
 
         assert result["evaluation_result"] is not None
         ev = result["evaluation_result"]


### PR DESCRIPTION
## Summary
Three integration test assertions had drifted from production:

- `test_evaluation_node_uses_execute_agentic_with_submit_evaluation` — review had 1 comment but mock returned 3 evaluated items, tripping the count guard at `amelia/agents/evaluator.py:364`. The same test also asserted on a removed `allowed_tools` kwarg; production now passes `submit_tools=[SubmitToolDef(...)]`. Fixed both.
- `test_uses_specified_agent_type_config` — asserted `cwd="."` but production at `amelia/server/routes/descriptions.py:49` passes `cwd=profile.repo_root`. Updated assertion to use the fixture's `repo_root`.

Production code is correct in all cases. Test-only changes.

## Test plan
- [x] `uv run ruff check` on touched files
- [x] `uv run mypy` on touched files (pre-existing fixture-level noise excluded — pre-push runs `mypy amelia` only)
- [x] All three targeted tests pass with `-m integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)