### PR TITLE
feat(drivers): arbitrary OpenAI-compatible model/provider support

### DIFF
--- a/amelia/cli/config.py
+++ b/amelia/cli/config.py
@@ -339,6 +339,13 @@ def profile_create(
         )
 
     # Provider configuration applies only to the api driver.
+    if driver != "api" and (
+        provider is not None or base_url is not None or api_key_env_var is not None
+    ):
+        raise typer.BadParameter(
+            "--provider, --base-url, and --api-key-env-var apply only to the 'api' driver."
+        )
+
     agent_options: dict[str, Any] = {}
     if driver == "api":
         if provider is None:
@@ -352,7 +359,12 @@ def profile_create(
                     base_url = typer.prompt("Base URL", show_default=False)
                 if api_key_env_var is None:
                     api_key_env_var = typer.prompt("API key env var", show_default=False)
-        agent_options = {"provider": provider or "openrouter"}
+        resolved_provider = provider or "openrouter"
+        if resolved_provider not in PROVIDER_PRESETS and (base_url is None or api_key_env_var is None):
+            raise typer.BadParameter(
+                f"Custom provider '{resolved_provider}' requires --base-url and --api-key-env-var."
+            )
+        agent_options = {"provider": resolved_provider}
         if base_url is not None:
             agent_options["base_url"] = base_url
         if api_key_env_var is not None:

--- a/amelia/cli/config.py
+++ b/amelia/cli/config.py
@@ -6,13 +6,14 @@ Provides commands for managing profiles and server settings through the CLI.
 import asyncio
 import os
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from amelia.core.types import REQUIRED_AGENTS, AgentConfig, DriverType, Profile, TrackerType
+from amelia.drivers.providers import PROVIDER_PRESETS
 from amelia.server.config import ServerConfig
 from amelia.server.database import (
     Database,
@@ -147,18 +148,28 @@ def _validate_tracker(value: str) -> TrackerType:
     return TrackerType(value)
 
 
-def _build_default_agents(driver: DriverType, model: str) -> dict[str, AgentConfig]:
+def _build_default_agents(
+    driver: DriverType,
+    model: str,
+    options: dict[str, Any] | None = None,
+) -> dict[str, AgentConfig]:
     """Build default agents dict for a profile.
 
     Args:
         driver: Driver to use for all agents (converted to DriverType enum).
         model: Model to use for all agents.
+        options: Provider options (e.g. ``provider``/``base_url``/``api_key_env_var``)
+            applied to every agent. Non-api drivers pass ``None``, which stores an
+            empty options dict, preserving prior behavior.
 
     Returns:
         Dict mapping agent names to AgentConfig.
     """
     driver_type = DriverType(driver)
-    return {name: AgentConfig(driver=driver_type, model=model) for name in REQUIRED_AGENTS}
+    return {
+        name: AgentConfig(driver=driver_type, model=model, options=options or {})
+        for name in REQUIRED_AGENTS
+    }
 
 
 # =============================================================================
@@ -279,6 +290,18 @@ def profile_create(
         str | None,
         typer.Option("--repo-root", "-w", help="Repository root path"),
     ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option("--provider", help="LLM provider for the api driver (e.g. openrouter, deepseek)"),
+    ] = None,
+    base_url: Annotated[
+        str | None,
+        typer.Option("--base-url", help="Custom OpenAI-compatible base URL (custom providers)"),
+    ] = None,
+    api_key_env_var: Annotated[
+        str | None,
+        typer.Option("--api-key-env-var", help="Env var holding the API key (custom providers)"),
+    ] = None,
     activate: Annotated[
         bool,
         typer.Option("--activate", "-a", help="Set as active profile"),
@@ -315,6 +338,26 @@ def profile_create(
             show_default=True,
         )
 
+    # Provider configuration applies only to the api driver.
+    agent_options: dict[str, Any] = {}
+    if driver == "api":
+        if provider is None:
+            provider = typer.prompt(
+                "Provider",
+                default="openrouter",
+                show_default=True,
+            )
+            if provider not in PROVIDER_PRESETS:
+                if base_url is None:
+                    base_url = typer.prompt("Base URL", show_default=False)
+                if api_key_env_var is None:
+                    api_key_env_var = typer.prompt("API key env var", show_default=False)
+        agent_options = {"provider": provider or "openrouter"}
+        if base_url is not None:
+            agent_options["base_url"] = base_url
+        if api_key_env_var is not None:
+            agent_options["api_key_env_var"] = api_key_env_var
+
     async def _run() -> None:
         db, repo = await _get_profile_repository()
         try:
@@ -333,7 +376,7 @@ def profile_create(
             validated_tracker = _validate_tracker(tracker)
 
             # Build default agents configuration
-            agents = _build_default_agents(validated_driver, model)
+            agents = _build_default_agents(validated_driver, model, agent_options)
 
             profile = Profile(
                 name=name,

--- a/amelia/drivers/api/chat_model.py
+++ b/amelia/drivers/api/chat_model.py
@@ -1,0 +1,166 @@
+"""Chat-model construction and model-provider error parsing.
+
+Provider plumbing for the DeepAgents API driver: resolves an
+OpenAI-compatible provider into a configured LangChain chat model and
+classifies ``ValueError``s that originate from the model provider (rather
+than Amelia's own validation) so they can be surfaced as
+:class:`~amelia.core.exceptions.ModelProviderError`.
+"""
+import functools
+import os
+
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models import BaseChatModel
+from loguru import logger
+
+from amelia.drivers.providers import resolve_provider
+
+
+# Patterns in ValueError messages that indicate a model provider error (not Amelia's fault).
+#
+# These patterns are matched case-insensitively against the exception message.
+# When a ValueError contains any of these patterns, it's wrapped in ModelProviderError
+# instead of being raised directly, providing better error UX for transient LLM issues.
+#
+# To add a new pattern:
+# 1. Identify the error message substring from the LLM provider SDK (usually langchain_openai)
+# 2. Add a lowercase pattern that uniquely identifies the provider error
+# 3. Test by triggering the error and verifying ModelProviderError is raised
+#
+# Configurable via AMELIA_PROVIDER_ERROR_PATTERNS env var (comma-separated, lowercase).
+_DEFAULT_PROVIDER_ERROR_PATTERNS = (
+    "midstream error",  # OpenRouter/provider streaming failures
+    "invalid function arguments",  # Bad tool call JSON from provider
+    "provider returned error",  # Generic provider-side errors
+)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_provider_error_patterns() -> tuple[str, ...]:
+    """Get provider error patterns from environment or defaults.
+
+    Reads AMELIA_PROVIDER_ERROR_PATTERNS environment variable dynamically
+    to support runtime configuration and testing with mocked environments.
+
+    Returns:
+        Tuple of lowercase pattern strings to match against error messages.
+    """
+    patterns_str = os.environ.get(
+        "AMELIA_PROVIDER_ERROR_PATTERNS",
+        ",".join(_DEFAULT_PROVIDER_ERROR_PATTERNS),
+    )
+    return tuple(p.strip().lower() for p in patterns_str.split(",") if p.strip())
+
+
+def _is_model_provider_error(exc: ValueError) -> bool:
+    """Check if a ValueError originates from a model provider rather than Amelia validation.
+
+    langchain_openai raises ValueError with a dict arg when the provider returns
+    an error (e.g. bad JSON from Minimax). Amelia's own validation uses string args.
+
+    Args:
+        exc: The ValueError to inspect.
+
+    Returns:
+        True if this looks like a model provider error.
+    """
+    # langchain_openai pattern: ValueError({"error": {...}, "provider": "..."})
+    if exc.args and isinstance(exc.args[0], dict):
+        return True
+    # String-based detection for known provider error patterns
+    msg = str(exc).lower()
+    return any(pattern in msg for pattern in _get_provider_error_patterns())
+
+
+def _extract_provider_info(exc: ValueError) -> tuple[str | None, str]:
+    """Extract provider name and error message from a model provider ValueError.
+
+    Args:
+        exc: The ValueError to extract info from.
+
+    Returns:
+        Tuple of (provider_name, error_message). provider_name may be None.
+    """
+    if exc.args and isinstance(exc.args[0], dict):
+        err_dict = exc.args[0]
+        error_obj = err_dict.get("error", {})
+        provider = err_dict.get("provider")
+
+        # Handle unexpected dict structures with explicit logging
+        if not isinstance(error_obj, dict):
+            logger.debug(
+                "Unexpected error_obj type in provider error",
+                error_obj_type=type(error_obj).__name__,
+                error_obj_value=str(error_obj)[:200],
+                err_dict_keys=list(err_dict.keys()),
+            )
+
+        message = (
+            error_obj.get("message", str(err_dict))
+            if isinstance(error_obj, dict)
+            else str(error_obj)
+        )
+        return provider, message
+    return None, str(exc)
+
+
+def _create_chat_model(
+    model: str,
+    provider: str,
+    base_url: str | None = None,
+    api_key_env_var: str | None = None,
+) -> BaseChatModel:
+    """Create a LangChain chat model for any OpenAI-compatible provider.
+
+    Resolves the provider (built-in preset or fully custom endpoint) via
+    :func:`amelia.drivers.providers.resolve_provider`, then routes the model
+    through ``init_chat_model(model_provider="openai", ...)`` with the
+    resolved base URL, API key, and default headers.
+
+    Args:
+        model: Bare model identifier (e.g., 'minimax/minimax-m2',
+            'deepseek-chat'). Must NOT carry a ``provider:`` prefix —
+            langchain's model parser splits on ``:`` and would misparse it.
+        provider: Provider name. A built-in preset (openrouter, openai,
+            deepseek, groq, together, fireworks) or a custom name paired with
+            ``base_url`` + ``api_key_env_var``.
+        base_url: Overrides the preset base URL when given; required for a
+            custom (non-preset) provider. Also used for proxy routing in
+            sandboxed environments.
+        api_key_env_var: Name of the environment variable holding the API key;
+            required for a custom (non-preset) provider, ignored for presets.
+
+    Returns:
+        Configured BaseChatModel instance.
+
+    Raises:
+        ValueError: If ``model`` carries the legacy ``openrouter:`` prefix.
+        ValueError: If a custom provider omits ``base_url`` or
+            ``api_key_env_var``, or an unknown provider is supplied without
+            custom configuration (propagated from ``resolve_provider``).
+        ValueError: If the resolved API key environment variable is unset.
+    """
+    if model.startswith("openrouter:"):
+        raise ValueError(
+            "The 'openrouter:' prefix in model names is no longer supported. "
+            "Use driver='api' with the model name directly "
+            f"(e.g., model='{model[len('openrouter:'):]}')."
+        )
+
+    resolved = resolve_provider(
+        provider, base_url=base_url, api_key_env_var=api_key_env_var
+    )
+    api_key = os.environ.get(resolved.api_key_env_var)
+    if not api_key:
+        raise ValueError(
+            f"{resolved.api_key_env_var} environment variable is required "
+            f"for provider {provider!r}"
+        )
+
+    return init_chat_model(
+        model=model,
+        model_provider="openai",
+        base_url=resolved.base_url,
+        api_key=api_key,
+        default_headers=resolved.default_headers,
+    )

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -298,6 +298,10 @@ class ApiDriver(DriverInterface):
     Attributes:
         model: The model identifier (e.g., 'minimax/minimax-m2').
         provider: The provider name (e.g., 'openrouter').
+        base_url: Optional base URL override for the provider's OpenAI-compatible
+            endpoint (required for custom, non-preset providers).
+        api_key_env_var: Optional name of the environment variable holding the API
+            key (required for custom, non-preset providers).
         cwd: Working directory for agentic execution.
     """
 
@@ -332,6 +336,8 @@ class ApiDriver(DriverInterface):
         model: str | None = None,
         cwd: str | None = None,
         provider: str = "openrouter",
+        base_url: str | None = None,
+        api_key_env_var: str | None = None,
     ):
         """Initialize the API driver.
 
@@ -339,9 +345,16 @@ class ApiDriver(DriverInterface):
             model: Model identifier for langchain (e.g., 'minimax/minimax-m2').
             cwd: Working directory for agentic execution. Required for execute_agentic().
             provider: Provider name (e.g., 'openrouter'). Defaults to 'openrouter'.
+            base_url: Optional base URL override for the provider's OpenAI-compatible
+                endpoint. Required for custom (non-preset) providers; ignored for the
+                bare back-compat path where provider is None.
+            api_key_env_var: Optional name of the environment variable holding the API
+                key. Required for custom (non-preset) providers; presets supply their own.
         """
         self.model = model or self.DEFAULT_MODEL
         self.provider = provider
+        self.base_url = base_url
+        self.api_key_env_var = api_key_env_var
         self.cwd = cwd
         self._usage: DriverUsage | None = None
 
@@ -399,7 +412,12 @@ class ApiDriver(DriverInterface):
             raise ValueError("Prompt cannot be empty")
 
         try:
-            chat_model = _create_chat_model(self.model, provider=self.provider)
+            chat_model = _create_chat_model(
+                self.model,
+                provider=self.provider,
+                base_url=self.base_url,
+                api_key_env_var=self.api_key_env_var,
+            )
             # Use FilesystemBackend for non-agentic generation - no shell execution needed
             backend = FilesystemBackend(root_dir=self.cwd or ".", virtual_mode=False)
 
@@ -576,7 +594,12 @@ class ApiDriver(DriverInterface):
         seen_message_ids: set[int] = set()
 
         try:
-            chat_model = _create_chat_model(self.model, provider=self.provider)
+            chat_model = _create_chat_model(
+                self.model,
+                provider=self.provider,
+                base_url=self.base_url,
+                api_key_env_var=self.api_key_env_var,
+            )
             # virtual_mode=True ensures paths like "docs/plans/..." resolve relative
             # to cwd (e.g., /project/docs/plans/...) rather than being treated as
             # absolute paths from filesystem root (e.g., /docs/plans/...)

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -1,6 +1,5 @@
 """DeepAgents-based API driver for LLM generation and agentic execution."""
 import asyncio
-import functools
 import json
 import os
 import subprocess
@@ -21,8 +20,6 @@ from deepagents.backends.protocol import (
 )
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ToolStrategy
-from langchain.chat_models import init_chat_model
-from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
 from loguru import logger
@@ -30,6 +27,11 @@ from pydantic import BaseModel
 
 from amelia.core.constants import normalize_tool_name
 from amelia.core.exceptions import ModelProviderError, SchemaValidationError
+from amelia.drivers.api.chat_model import (
+    _create_chat_model,
+    _extract_provider_info,
+    _is_model_provider_error,
+)
 from amelia.drivers.base import (
     AgenticMessage,
     AgenticMessageType,
@@ -38,101 +40,15 @@ from amelia.drivers.base import (
     GenerateResult,
     SubmitToolDef,
 )
-from amelia.drivers.providers import resolve_provider
 from amelia.logging import log_claude_result, log_todos
 
+
+__all__ = ["ApiDriver", "LocalSandbox"]
 
 # Maximum output size before truncation (100KB)
 _MAX_OUTPUT_SIZE = 100_000
 # Default command timeout in seconds
 _DEFAULT_TIMEOUT = 300
-
-# Patterns in ValueError messages that indicate a model provider error (not Amelia's fault).
-#
-# These patterns are matched case-insensitively against the exception message.
-# When a ValueError contains any of these patterns, it's wrapped in ModelProviderError
-# instead of being raised directly, providing better error UX for transient LLM issues.
-#
-# To add a new pattern:
-# 1. Identify the error message substring from the LLM provider SDK (usually langchain_openai)
-# 2. Add a lowercase pattern that uniquely identifies the provider error
-# 3. Test by triggering the error and verifying ModelProviderError is raised
-#
-# Configurable via AMELIA_PROVIDER_ERROR_PATTERNS env var (comma-separated, lowercase).
-_DEFAULT_PROVIDER_ERROR_PATTERNS = (
-    "midstream error",  # OpenRouter/provider streaming failures
-    "invalid function arguments",  # Bad tool call JSON from provider
-    "provider returned error",  # Generic provider-side errors
-)
-
-
-@functools.lru_cache(maxsize=1)
-def _get_provider_error_patterns() -> tuple[str, ...]:
-    """Get provider error patterns from environment or defaults.
-
-    Reads AMELIA_PROVIDER_ERROR_PATTERNS environment variable dynamically
-    to support runtime configuration and testing with mocked environments.
-
-    Returns:
-        Tuple of lowercase pattern strings to match against error messages.
-    """
-    patterns_str = os.environ.get(
-        "AMELIA_PROVIDER_ERROR_PATTERNS",
-        ",".join(_DEFAULT_PROVIDER_ERROR_PATTERNS),
-    )
-    return tuple(p.strip().lower() for p in patterns_str.split(",") if p.strip())
-
-
-def _is_model_provider_error(exc: ValueError) -> bool:
-    """Check if a ValueError originates from a model provider rather than Amelia validation.
-
-    langchain_openai raises ValueError with a dict arg when the provider returns
-    an error (e.g. bad JSON from Minimax). Amelia's own validation uses string args.
-
-    Args:
-        exc: The ValueError to inspect.
-
-    Returns:
-        True if this looks like a model provider error.
-    """
-    # langchain_openai pattern: ValueError({"error": {...}, "provider": "..."})
-    if exc.args and isinstance(exc.args[0], dict):
-        return True
-    # String-based detection for known provider error patterns
-    msg = str(exc).lower()
-    return any(pattern in msg for pattern in _get_provider_error_patterns())
-
-
-def _extract_provider_info(exc: ValueError) -> tuple[str | None, str]:
-    """Extract provider name and error message from a model provider ValueError.
-
-    Args:
-        exc: The ValueError to extract info from.
-
-    Returns:
-        Tuple of (provider_name, error_message). provider_name may be None.
-    """
-    if exc.args and isinstance(exc.args[0], dict):
-        err_dict = exc.args[0]
-        error_obj = err_dict.get("error", {})
-        provider = err_dict.get("provider")
-
-        # Handle unexpected dict structures with explicit logging
-        if not isinstance(error_obj, dict):
-            logger.debug(
-                "Unexpected error_obj type in provider error",
-                error_obj_type=type(error_obj).__name__,
-                error_obj_value=str(error_obj)[:200],
-                err_dict_keys=list(err_dict.keys()),
-            )
-
-        message = (
-            error_obj.get("message", str(err_dict))
-            if isinstance(error_obj, dict)
-            else str(error_obj)
-        )
-        return provider, message
-    return None, str(exc)
 
 
 class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
@@ -201,72 +117,6 @@ class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
     async def aexecute(self, command: str) -> ExecuteResponse:
         """Async wrapper for execute (runs in thread pool)."""
         return await asyncio.to_thread(self.execute, command)
-
-
-def _create_chat_model(
-    model: str,
-    provider: str | None = None,
-    base_url: str | None = None,
-    api_key_env_var: str | None = None,
-) -> BaseChatModel:
-    """Create a LangChain chat model for any OpenAI-compatible provider.
-
-    Resolves the provider (built-in preset or fully custom endpoint) via
-    :func:`amelia.drivers.providers.resolve_provider`, then routes the model
-    through ``init_chat_model(model_provider="openai", ...)`` with the
-    resolved base URL, API key, and default headers.
-
-    Args:
-        model: Bare model identifier (e.g., 'minimax/minimax-m2',
-            'deepseek-chat'). Must NOT carry a ``provider:`` prefix —
-            langchain's model parser splits on ``:`` and would misparse it.
-        provider: Provider name. A built-in preset (openrouter, openai,
-            deepseek, groq, together, fireworks) or a custom name paired with
-            ``base_url`` + ``api_key_env_var``. When ``None``, the model is
-            passed bare to ``init_chat_model`` (legacy back-compat).
-        base_url: Overrides the preset base URL when given; required for a
-            custom (non-preset) provider. Also used for proxy routing in
-            sandboxed environments.
-        api_key_env_var: Name of the environment variable holding the API key;
-            required for a custom (non-preset) provider, ignored for presets.
-
-    Returns:
-        Configured BaseChatModel instance.
-
-    Raises:
-        ValueError: If ``model`` carries the legacy ``openrouter:`` prefix.
-        ValueError: If a custom provider omits ``base_url`` or
-            ``api_key_env_var``, or an unknown provider is supplied without
-            custom configuration (propagated from ``resolve_provider``).
-        ValueError: If the resolved API key environment variable is unset.
-    """
-    if model.startswith("openrouter:"):
-        raise ValueError(
-            "The 'openrouter:' prefix in model names is no longer supported. "
-            "Use driver='api' with the model name directly "
-            f"(e.g., model='{model[len('openrouter:'):]}')."
-        )
-
-    if provider is None:
-        return init_chat_model(model)
-
-    resolved = resolve_provider(
-        provider, base_url=base_url, api_key_env_var=api_key_env_var
-    )
-    api_key = os.environ.get(resolved.api_key_env_var)
-    if not api_key:
-        raise ValueError(
-            f"{resolved.api_key_env_var} environment variable is required "
-            f"for provider {provider!r}"
-        )
-
-    return init_chat_model(
-        model=model,
-        model_provider="openai",
-        base_url=resolved.base_url,
-        api_key=api_key,
-        default_headers=resolved.default_headers,
-    )
 
 
 def _extract_text_content(content: str | list[str | dict[str, Any]]) -> str:
@@ -346,8 +196,7 @@ class ApiDriver(DriverInterface):
             cwd: Working directory for agentic execution. Required for execute_agentic().
             provider: Provider name (e.g., 'openrouter'). Defaults to 'openrouter'.
             base_url: Optional base URL override for the provider's OpenAI-compatible
-                endpoint. Required for custom (non-preset) providers; ignored for the
-                bare back-compat path where provider is None.
+                endpoint. Required for custom (non-preset) providers.
             api_key_env_var: Optional name of the environment variable holding the API
                 key. Required for custom (non-preset) providers; presets supply their own.
         """

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -38,6 +38,7 @@ from amelia.drivers.base import (
     GenerateResult,
     SubmitToolDef,
 )
+from amelia.drivers.providers import resolve_provider
 from amelia.logging import log_claude_result, log_todos
 
 
@@ -206,21 +207,38 @@ def _create_chat_model(
     model: str,
     provider: str | None = None,
     base_url: str | None = None,
+    api_key_env_var: str | None = None,
 ) -> BaseChatModel:
-    """Create a LangChain chat model, handling provider configuration.
+    """Create a LangChain chat model for any OpenAI-compatible provider.
+
+    Resolves the provider (built-in preset or fully custom endpoint) via
+    :func:`amelia.drivers.providers.resolve_provider`, then routes the model
+    through ``init_chat_model(model_provider="openai", ...)`` with the
+    resolved base URL, API key, and default headers.
 
     Args:
-        model: Model identifier (e.g., 'minimax/minimax-m2').
-        provider: Optional provider name. If 'openrouter', configures OpenRouter API.
-        base_url: Optional base URL override. Used for proxy routing when running
-            in sandboxed environments. Only applies to OpenRouter provider.
+        model: Bare model identifier (e.g., 'minimax/minimax-m2',
+            'deepseek-chat'). Must NOT carry a ``provider:`` prefix —
+            langchain's model parser splits on ``:`` and would misparse it.
+        provider: Provider name. A built-in preset (openrouter, openai,
+            deepseek, groq, together, fireworks) or a custom name paired with
+            ``base_url`` + ``api_key_env_var``. When ``None``, the model is
+            passed bare to ``init_chat_model`` (legacy back-compat).
+        base_url: Overrides the preset base URL when given; required for a
+            custom (non-preset) provider. Also used for proxy routing in
+            sandboxed environments.
+        api_key_env_var: Name of the environment variable holding the API key;
+            required for a custom (non-preset) provider, ignored for presets.
 
     Returns:
         Configured BaseChatModel instance.
 
     Raises:
-        ValueError: If model contains 'openrouter:' prefix (use provider param instead).
-        ValueError: If OpenRouter is requested but OPENROUTER_API_KEY is not set.
+        ValueError: If ``model`` carries the legacy ``openrouter:`` prefix.
+        ValueError: If a custom provider omits ``base_url`` or
+            ``api_key_env_var``, or an unknown provider is supplied without
+            custom configuration (propagated from ``resolve_provider``).
+        ValueError: If the resolved API key environment variable is unset.
     """
     if model.startswith("openrouter:"):
         raise ValueError(
@@ -229,32 +247,26 @@ def _create_chat_model(
             f"(e.g., model='{model[len('openrouter:'):]}')."
         )
 
-    if provider == "openrouter":
-        api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "OPENROUTER_API_KEY environment variable is required for OpenRouter models"
-            )
+    if provider is None:
+        return init_chat_model(model)
 
-        site_url = os.environ.get(
-            "OPENROUTER_SITE_URL", "https://github.com/existential-birds/amelia"
-        )
-        site_name = os.environ.get("OPENROUTER_SITE_NAME", "Amelia")
-
-        resolved_url = base_url or "https://openrouter.ai/api/v1"
-
-        return init_chat_model(
-            model=model,
-            model_provider="openai",
-            base_url=resolved_url,
-            api_key=api_key,
-            default_headers={
-                "HTTP-Referer": site_url,
-                "X-Title": site_name,
-            },
+    resolved = resolve_provider(
+        provider, base_url=base_url, api_key_env_var=api_key_env_var
+    )
+    api_key = os.environ.get(resolved.api_key_env_var)
+    if not api_key:
+        raise ValueError(
+            f"{resolved.api_key_env_var} environment variable is required "
+            f"for provider {provider!r}"
         )
 
-    return init_chat_model(model)
+    return init_chat_model(
+        model=model,
+        model_provider="openai",
+        base_url=resolved.base_url,
+        api_key=api_key,
+        default_headers=resolved.default_headers,
+    )
 
 
 def _extract_text_content(content: str | list[str | dict[str, Any]]) -> str:

--- a/amelia/drivers/factory.py
+++ b/amelia/drivers/factory.py
@@ -191,7 +191,13 @@ def get_driver(
         approval_mode = (options or {}).get("approval_mode", "full-auto")
         return CodexCliDriver(model=model, cwd=cwd, approval_mode=approval_mode)
     elif driver_key == "api":
-        return ApiDriver(provider="openrouter", model=model)
+        opts = options or {}
+        return ApiDriver(
+            provider=opts.get("provider", "openrouter"),
+            model=model,
+            base_url=opts.get("base_url"),
+            api_key_env_var=opts.get("api_key_env_var"),
+        )
     else:
         raise ValueError(
             f"Unknown driver key: {driver_key!r}. "

--- a/amelia/drivers/factory.py
+++ b/amelia/drivers/factory.py
@@ -7,6 +7,7 @@ from amelia.drivers.api import ApiDriver
 from amelia.drivers.base import DriverInterface
 from amelia.drivers.cli.claude import ClaudeCliDriver
 from amelia.drivers.cli.codex import CodexCliDriver
+from amelia.drivers.providers import resolve_provider
 
 
 if TYPE_CHECKING:
@@ -61,32 +62,21 @@ def create_daytona_provider(
     # so the worker can call the LLM API from within the sandbox.
     llm_provider = (options or {}).get("provider", "openrouter")
 
-    provider_registry: dict[str, str] = {
-        "openrouter": "https://openrouter.ai/api/v1",
-        "openai": "https://api.openai.com/v1",
-    }
-    api_key_env_vars: dict[str, str] = {
-        "openrouter": "OPENROUTER_API_KEY",
-        "openai": "OPENAI_API_KEY",
-    }
+    resolved = resolve_provider(
+        llm_provider,
+        base_url=(options or {}).get("base_url"),
+        api_key_env_var=(options or {}).get("api_key_env_var"),
+    )
 
-    llm_base_url = provider_registry.get(llm_provider)
-    llm_env_var = api_key_env_vars.get(llm_provider)
-    if llm_base_url is None or llm_env_var is None:
-        raise ValueError(
-            f"Unsupported LLM provider for Daytona sandbox: {llm_provider!r}. "
-            f"Supported: {', '.join(sorted(provider_registry))}."
-        )
-
-    llm_api_key = os.environ.get(llm_env_var, "")
+    llm_api_key = os.environ.get(resolved.api_key_env_var, "")
     if not llm_api_key:
         raise ValueError(
-            f"{llm_env_var} environment variable is required for "
+            f"{resolved.api_key_env_var} environment variable is required for "
             f"Daytona sandbox with provider {llm_provider!r}"
         )
 
     worker_env: dict[str, str] = {
-        "LLM_PROXY_URL": llm_base_url,
+        "LLM_PROXY_URL": resolved.base_url,
         "OPENAI_API_KEY": llm_api_key,
         "OPENROUTER_SITE_URL": os.environ.get(
             "OPENROUTER_SITE_URL",

--- a/amelia/drivers/factory.py
+++ b/amelia/drivers/factory.py
@@ -7,7 +7,11 @@ from amelia.drivers.api import ApiDriver
 from amelia.drivers.base import DriverInterface
 from amelia.drivers.cli.claude import ClaudeCliDriver
 from amelia.drivers.cli.codex import CodexCliDriver
-from amelia.drivers.providers import resolve_provider
+from amelia.drivers.providers import (
+    OPENROUTER_DEFAULT_SITE_NAME,
+    OPENROUTER_DEFAULT_SITE_URL,
+    resolve_provider,
+)
 
 
 if TYPE_CHECKING:
@@ -79,10 +83,11 @@ def create_daytona_provider(
         "LLM_PROXY_URL": resolved.base_url,
         "OPENAI_API_KEY": llm_api_key,
         "OPENROUTER_SITE_URL": os.environ.get(
-            "OPENROUTER_SITE_URL",
-            "https://github.com/existential-birds/amelia",
+            "OPENROUTER_SITE_URL", OPENROUTER_DEFAULT_SITE_URL
         ),
-        "OPENROUTER_SITE_NAME": os.environ.get("OPENROUTER_SITE_NAME", "Amelia"),
+        "OPENROUTER_SITE_NAME": os.environ.get(
+            "OPENROUTER_SITE_NAME", OPENROUTER_DEFAULT_SITE_NAME
+        ),
     }
 
     provider = DaytonaSandboxProvider(

--- a/amelia/drivers/providers.py
+++ b/amelia/drivers/providers.py
@@ -103,10 +103,20 @@ def resolve_provider(
     """
     preset = PROVIDER_PRESETS.get(provider)
     if preset is not None:
+        if base_url is not None and not base_url.strip():
+            raise ValueError("base_url must be a non-empty string when provided.")
+        if api_key_env_var is not None and not api_key_env_var.strip():
+            raise ValueError(
+                "api_key_env_var must be a non-empty string when provided."
+            )
         default_headers = _openrouter_site_headers() if provider == "openrouter" else {}
         return ResolvedProvider(
-            base_url=base_url or preset.base_url,
-            api_key_env_var=api_key_env_var or preset.api_key_env_var,
+            base_url=base_url if base_url is not None else preset.base_url,
+            api_key_env_var=(
+                api_key_env_var
+                if api_key_env_var is not None
+                else preset.api_key_env_var
+            ),
             default_headers=default_headers,
         )
 
@@ -126,6 +136,16 @@ def resolve_provider(
         raise ValueError(
             f"Custom provider {provider!r} requires an API key environment "
             "variable (pass api_key_env_var)."
+        )
+    if not base_url.strip():
+        raise ValueError(
+            f"Custom provider {provider!r} requires a non-empty base URL "
+            "(pass base_url)."
+        )
+    if not api_key_env_var.strip():
+        raise ValueError(
+            f"Custom provider {provider!r} requires a non-empty API key "
+            "environment variable (pass api_key_env_var)."
         )
 
     return ResolvedProvider(

--- a/amelia/drivers/providers.py
+++ b/amelia/drivers/providers.py
@@ -101,14 +101,19 @@ def resolve_provider(
             ``api_key_env_var``, or if an unknown provider is supplied without
             the custom-provider configuration.
     """
-    preset = PROVIDER_PRESETS.get(provider)
-    if preset is not None:
-        if base_url is not None and not base_url.strip():
+    if base_url is not None:
+        base_url = base_url.strip()
+        if not base_url:
             raise ValueError("base_url must be a non-empty string when provided.")
-        if api_key_env_var is not None and not api_key_env_var.strip():
+    if api_key_env_var is not None:
+        api_key_env_var = api_key_env_var.strip()
+        if not api_key_env_var:
             raise ValueError(
                 "api_key_env_var must be a non-empty string when provided."
             )
+
+    preset = PROVIDER_PRESETS.get(provider)
+    if preset is not None:
         default_headers = _openrouter_site_headers() if provider == "openrouter" else {}
         return ResolvedProvider(
             base_url=base_url if base_url is not None else preset.base_url,
@@ -136,16 +141,6 @@ def resolve_provider(
         raise ValueError(
             f"Custom provider {provider!r} requires an API key environment "
             "variable (pass api_key_env_var)."
-        )
-    if not base_url.strip():
-        raise ValueError(
-            f"Custom provider {provider!r} requires a non-empty base URL "
-            "(pass base_url)."
-        )
-    if not api_key_env_var.strip():
-        raise ValueError(
-            f"Custom provider {provider!r} requires a non-empty API key "
-            "environment variable (pass api_key_env_var)."
         )
 
     return ResolvedProvider(

--- a/amelia/drivers/providers.py
+++ b/amelia/drivers/providers.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass
 
 
 # Default OpenRouter site-attribution headers, overridable via env vars.
-_OPENROUTER_DEFAULT_SITE_URL = "https://github.com/existential-birds/amelia"
-_OPENROUTER_DEFAULT_SITE_NAME = "Amelia"
+OPENROUTER_DEFAULT_SITE_URL = "https://github.com/existential-birds/amelia"
+OPENROUTER_DEFAULT_SITE_NAME = "Amelia"
 
 
 @dataclass(frozen=True)
@@ -71,9 +71,9 @@ def _openrouter_site_headers() -> dict[str, str]:
     """Build OpenRouter site-attribution headers from env (with defaults)."""
     return {
         "HTTP-Referer": os.environ.get(
-            "OPENROUTER_SITE_URL", _OPENROUTER_DEFAULT_SITE_URL
+            "OPENROUTER_SITE_URL", OPENROUTER_DEFAULT_SITE_URL
         ),
-        "X-Title": os.environ.get("OPENROUTER_SITE_NAME", _OPENROUTER_DEFAULT_SITE_NAME),
+        "X-Title": os.environ.get("OPENROUTER_SITE_NAME", OPENROUTER_DEFAULT_SITE_NAME),
     }
 
 
@@ -90,8 +90,8 @@ def resolve_provider(
             custom provider name.
         base_url: Overrides the preset base URL when given; required for a
             custom (non-preset) provider.
-        api_key_env_var: Required for a custom provider; ignored for presets
-            (the preset's own env var is used).
+        api_key_env_var: Overrides the preset's key env var when given;
+            required for a custom (non-preset) provider.
 
     Returns:
         The resolved provider configuration.
@@ -106,7 +106,7 @@ def resolve_provider(
         default_headers = _openrouter_site_headers() if provider == "openrouter" else {}
         return ResolvedProvider(
             base_url=base_url or preset.base_url,
-            api_key_env_var=preset.api_key_env_var,
+            api_key_env_var=api_key_env_var or preset.api_key_env_var,
             default_headers=default_headers,
         )
 

--- a/amelia/drivers/providers.py
+++ b/amelia/drivers/providers.py
@@ -1,0 +1,135 @@
+"""Single source of truth for OpenAI-compatible model providers.
+
+Resolves a ``(provider, base_url?, api_key_env_var?)`` triple into a
+``ResolvedProvider`` that both execution paths consume: the local path
+(``ApiDriver`` → ``_create_chat_model``) and the remote Daytona path
+(``create_daytona_provider`` worker_env).
+
+A provider is either a built-in preset (one of :data:`PROVIDER_PRESETS`)
+or a fully custom endpoint declared by supplying ``base_url`` and
+``api_key_env_var`` explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+# Default OpenRouter site-attribution headers, overridable via env vars.
+_OPENROUTER_DEFAULT_SITE_URL = "https://github.com/existential-birds/amelia"
+_OPENROUTER_DEFAULT_SITE_NAME = "Amelia"
+
+
+@dataclass(frozen=True)
+class ProviderPreset:
+    """A built-in OpenAI-compatible provider's base URL and key env var."""
+
+    base_url: str
+    api_key_env_var: str
+
+
+# Starter preset set. URLs/env-vars verified against each provider's docs.
+PROVIDER_PRESETS: dict[str, ProviderPreset] = {
+    "openrouter": ProviderPreset(
+        base_url="https://openrouter.ai/api/v1",
+        api_key_env_var="OPENROUTER_API_KEY",
+    ),
+    "openai": ProviderPreset(
+        base_url="https://api.openai.com/v1",
+        api_key_env_var="OPENAI_API_KEY",
+    ),
+    "deepseek": ProviderPreset(
+        base_url="https://api.deepseek.com/v1",
+        api_key_env_var="DEEPSEEK_API_KEY",
+    ),
+    "groq": ProviderPreset(
+        base_url="https://api.groq.com/openai/v1",
+        api_key_env_var="GROQ_API_KEY",
+    ),
+    "together": ProviderPreset(
+        base_url="https://api.together.ai/v1",
+        api_key_env_var="TOGETHER_API_KEY",
+    ),
+    "fireworks": ProviderPreset(
+        base_url="https://api.fireworks.ai/inference/v1",
+        api_key_env_var="FIREWORKS_API_KEY",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ResolvedProvider:
+    """A fully resolved provider configuration ready for ``init_chat_model``."""
+
+    base_url: str
+    api_key_env_var: str
+    default_headers: dict[str, str]
+
+
+def _openrouter_site_headers() -> dict[str, str]:
+    """Build OpenRouter site-attribution headers from env (with defaults)."""
+    return {
+        "HTTP-Referer": os.environ.get(
+            "OPENROUTER_SITE_URL", _OPENROUTER_DEFAULT_SITE_URL
+        ),
+        "X-Title": os.environ.get("OPENROUTER_SITE_NAME", _OPENROUTER_DEFAULT_SITE_NAME),
+    }
+
+
+def resolve_provider(
+    provider: str,
+    *,
+    base_url: str | None = None,
+    api_key_env_var: str | None = None,
+) -> ResolvedProvider:
+    """Resolve a provider name into a concrete base URL, key env var, and headers.
+
+    Args:
+        provider: A built-in preset name (see :data:`PROVIDER_PRESETS`) or a
+            custom provider name.
+        base_url: Overrides the preset base URL when given; required for a
+            custom (non-preset) provider.
+        api_key_env_var: Required for a custom provider; ignored for presets
+            (the preset's own env var is used).
+
+    Returns:
+        The resolved provider configuration.
+
+    Raises:
+        ValueError: If a custom provider is missing ``base_url`` or
+            ``api_key_env_var``, or if an unknown provider is supplied without
+            the custom-provider configuration.
+    """
+    preset = PROVIDER_PRESETS.get(provider)
+    if preset is not None:
+        default_headers = _openrouter_site_headers() if provider == "openrouter" else {}
+        return ResolvedProvider(
+            base_url=base_url or preset.base_url,
+            api_key_env_var=preset.api_key_env_var,
+            default_headers=default_headers,
+        )
+
+    # Custom provider: both base_url and api_key_env_var must be supplied.
+    if base_url is None:
+        if api_key_env_var is not None:
+            raise ValueError(
+                f"Custom provider {provider!r} requires a base URL "
+                "(pass base_url)."
+            )
+        raise ValueError(
+            f"Unsupported provider {provider!r}. "
+            f"Known presets: {sorted(PROVIDER_PRESETS)}. "
+            "To use a custom provider, supply base_url and api_key_env_var."
+        )
+    if api_key_env_var is None:
+        raise ValueError(
+            f"Custom provider {provider!r} requires an API key environment "
+            "variable (pass api_key_env_var)."
+        )
+
+    return ResolvedProvider(
+        base_url=base_url,
+        api_key_env_var=api_key_env_var,
+        default_headers={},
+    )

--- a/amelia/server/main.py
+++ b/amelia/server/main.py
@@ -56,6 +56,7 @@ from amelia.drivers.factory import (
     cleanup_driver_session,
     get_driver as factory_get_driver,
 )
+from amelia.drivers.providers import resolve_provider
 from amelia.knowledge.embeddings import EmbeddingClient
 from amelia.knowledge.ingestion import IngestionPipeline
 from amelia.knowledge.repository import KnowledgeRepository
@@ -329,6 +330,43 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     clear_config()
 
 
+async def resolve_proxy_provider(
+    profile_name: str, profile_repo: ProfileRepository
+) -> ProviderConfig | None:
+    """Resolve the sandbox proxy upstream config from a profile name.
+
+    Looks up the profile, reads the developer agent's provider settings, and
+    returns the upstream URL and API key. Only OpenAI-compatible providers
+    (``/chat/completions``) are supported; Anthropic uses ``/messages`` with
+    different auth headers. Unknown or misconfigured providers resolve to
+    ``None`` so the proxy returns a 404 rather than forwarding blindly.
+    """
+    profile = await profile_repo.get_profile(profile_name)
+    if profile is None:
+        return None
+
+    try:
+        agent_config = profile.get_agent_config("developer")
+    except ValueError:
+        return None
+
+    provider = agent_config.options.get("provider", "openrouter")
+    try:
+        resolved = resolve_provider(
+            provider,
+            base_url=agent_config.options.get("base_url"),
+            api_key_env_var=agent_config.options.get("api_key_env_var"),
+        )
+    except ValueError:
+        return None
+
+    api_key = os.environ.get(resolved.api_key_env_var, "")
+    if not api_key:
+        return None
+
+    return ProviderConfig(base_url=resolved.base_url, api_key=api_key)
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -440,46 +478,7 @@ def create_app() -> FastAPI:
 
     # Mount sandbox proxy routes
     async def _resolve_provider(profile_name: str) -> ProviderConfig | None:
-        """Resolve LLM provider config from profile name.
-
-        Looks up the profile in the database, finds the developer agent's
-        provider setting, and returns the corresponding upstream URL and API key.
-        """
-        profile_repo = get_profile_repository()
-        profile = await profile_repo.get_profile(profile_name)
-        if profile is None:
-            return None
-
-        # Use developer agent config to determine provider
-        try:
-            agent_config = profile.get_agent_config("developer")
-        except ValueError:
-            return None
-
-        provider = agent_config.options.get("provider", "openrouter")
-
-        # Map provider to upstream config
-        # NOTE: Only OpenAI-compatible providers (using /chat/completions endpoint)
-        # are supported. Anthropic uses /messages and requires different auth headers.
-        provider_registry: dict[str, str] = {
-            "openrouter": "https://openrouter.ai/api/v1",
-            "openai": "https://api.openai.com/v1",
-        }
-        api_key_env_vars: dict[str, str] = {
-            "openrouter": "OPENROUTER_API_KEY",
-            "openai": "OPENAI_API_KEY",
-        }
-
-        base_url = provider_registry.get(provider)
-        env_var = api_key_env_vars.get(provider)
-        if base_url is None or env_var is None:
-            return None
-
-        api_key = os.environ.get(env_var, "")
-        if not api_key:
-            return None
-
-        return ProviderConfig(base_url=base_url, api_key=api_key)
+        return await resolve_proxy_provider(profile_name, get_profile_repository())
 
     # Token registry: maps proxy tokens to container names.
     # Populated when sandbox providers register tokens via register_proxy_token().

--- a/dashboard/src/components/model-picker/ApiModelSelect.tsx
+++ b/dashboard/src/components/model-picker/ApiModelSelect.tsx
@@ -41,7 +41,8 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [manualModelId, setManualModelId] = useState(value);
   const [isLookingUp, setIsLookingUp] = useState(false);
-  const [compatibilityWarning, setCompatibilityWarning] = useState<string | null>(null);
+  const [requirementsWarning, setRequirementsWarning] = useState<string | null>(null);
+  const [unverifiedWarning, setUnverifiedWarning] = useState<string | null>(null);
 
   // Eagerly fetch models on mount (idempotent — fetchModels checks models.length and lastFetched, skips if already loaded)
   useEffect(() => {
@@ -66,16 +67,16 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
   // Whether we have a fallback item for a value not yet in the store (e.g. during loading)
   const valueNotYetInStore = value && !displayModels.some((m) => m.id === value);
 
-  const updateCompatibilityWarning = useCallback(
+  const updateRequirementsWarning = useCallback(
     (model: ModelInfo | undefined) => {
       const requirements = AGENT_MODEL_REQUIREMENTS[agentKey];
       if (!requirements || !model) {
-        setCompatibilityWarning(null);
+        setRequirementsWarning(null);
         return;
       }
 
       const matchesRequirements = filterModelsByRequirements([model], requirements).length > 0;
-      setCompatibilityWarning(
+      setRequirementsWarning(
         matchesRequirements ? null : `May not meet ${agentKey} requirements`
       );
     },
@@ -84,8 +85,11 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
 
   useEffect(() => {
     const selectedModel = models.find((model) => model.id === value);
-    updateCompatibilityWarning(selectedModel);
-  }, [models, value, updateCompatibilityWarning]);
+    updateRequirementsWarning(selectedModel);
+    if (selectedModel) {
+      setUnverifiedWarning(null);
+    }
+  }, [models, value, updateRequirementsWarning]);
 
   const handleSelect = (modelId: string) => {
     if (!modelId) return;
@@ -109,22 +113,24 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
     }
 
     setIsLookingUp(true);
-    setCompatibilityWarning(null);
+    setUnverifiedWarning(null);
 
     try {
       const model = await lookupModelById(modelId);
       addRecentModel(model.id);
       onChange(model.id);
       setManualModelId(model.id);
-      updateCompatibilityWarning(model);
-    } catch {
-      // The store cannot distinguish a 404 from a transport failure, so any
-      // lookup failure accepts the typed ID with a non-blocking warning. A
-      // genuinely invalid model still fails fast at run time on the backend.
+      updateRequirementsWarning(model);
+    } catch (error) {
+      console.error(`Model lookup failed for "${modelId}":`, error);
+      // Any verification failure — 404, network, or timeout — still accepts the
+      // typed ID with a non-blocking warning; a genuinely invalid model fails
+      // fast at run time on the backend.
       addRecentModel(modelId);
       onChange(modelId);
       setManualModelId(modelId);
-      setCompatibilityWarning(
+      setRequirementsWarning(null);
+      setUnverifiedWarning(
         "Couldn't verify this model — it may not exist or support tools"
       );
     } finally {
@@ -208,10 +214,10 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
         </Button>
       </div>
 
-      {compatibilityWarning && (
+      {(unverifiedWarning ?? requirementsWarning) && (
         <p className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span>{compatibilityWarning}</span>
+          <span>{unverifiedWarning ?? requirementsWarning}</span>
         </p>
       )}
 

--- a/dashboard/src/components/model-picker/ApiModelSelect.tsx
+++ b/dashboard/src/components/model-picker/ApiModelSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import {
   Select,
@@ -41,7 +41,6 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [manualModelId, setManualModelId] = useState(value);
   const [isLookingUp, setIsLookingUp] = useState(false);
-  const [lookupError, setLookupError] = useState<string | null>(null);
   const [compatibilityWarning, setCompatibilityWarning] = useState<string | null>(null);
 
   // Eagerly fetch models on mount (idempotent — fetchModels checks models.length and lastFetched, skips if already loaded)
@@ -67,23 +66,26 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
   // Whether we have a fallback item for a value not yet in the store (e.g. during loading)
   const valueNotYetInStore = value && !displayModels.some((m) => m.id === value);
 
-  const updateCompatibilityWarning = (model: ModelInfo | undefined) => {
-    const requirements = AGENT_MODEL_REQUIREMENTS[agentKey];
-    if (!requirements || !model) {
-      setCompatibilityWarning(null);
-      return;
-    }
+  const updateCompatibilityWarning = useCallback(
+    (model: ModelInfo | undefined) => {
+      const requirements = AGENT_MODEL_REQUIREMENTS[agentKey];
+      if (!requirements || !model) {
+        setCompatibilityWarning(null);
+        return;
+      }
 
-    const matchesRequirements = filterModelsByRequirements([model], requirements).length > 0;
-    setCompatibilityWarning(
-      matchesRequirements ? null : `May not meet ${agentKey} requirements`
-    );
-  };
+      const matchesRequirements = filterModelsByRequirements([model], requirements).length > 0;
+      setCompatibilityWarning(
+        matchesRequirements ? null : `May not meet ${agentKey} requirements`
+      );
+    },
+    [agentKey]
+  );
 
   useEffect(() => {
     const selectedModel = models.find((model) => model.id === value);
     updateCompatibilityWarning(selectedModel);
-  }, [agentKey, models, value]);
+  }, [models, value, updateCompatibilityWarning]);
 
   const handleSelect = (modelId: string) => {
     if (!modelId) return;
@@ -107,7 +109,7 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
     }
 
     setIsLookingUp(true);
-    setLookupError(null);
+    setCompatibilityWarning(null);
 
     try {
       const model = await lookupModelById(modelId);
@@ -115,9 +117,15 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
       onChange(model.id);
       setManualModelId(model.id);
       updateCompatibilityWarning(model);
-    } catch (lookupFailure) {
-      setLookupError(
-        lookupFailure instanceof Error ? lookupFailure.message : 'Failed to look up model'
+    } catch {
+      // The store cannot distinguish a 404 from a transport failure, so any
+      // lookup failure accepts the typed ID with a non-blocking warning. A
+      // genuinely invalid model still fails fast at run time on the backend.
+      addRecentModel(modelId);
+      onChange(modelId);
+      setManualModelId(modelId);
+      setCompatibilityWarning(
+        "Couldn't verify this model — it may not exist or support tools"
       );
     } finally {
       setIsLookingUp(false);
@@ -181,13 +189,9 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
           value={manualModelId}
           onChange={(event) => {
             setManualModelId(event.target.value);
-            if (lookupError) {
-              setLookupError(null);
-            }
           }}
           onKeyDown={handleManualKeyDown}
-          placeholder="Type OpenRouter model ID"
-          aria-invalid={lookupError ? 'true' : undefined}
+          placeholder="Type any model ID"
           className="h-8 text-xs sm:w-[180px]"
         />
         <Button
@@ -204,13 +208,7 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
         </Button>
       </div>
 
-      {lookupError && (
-        <p className="text-xs text-destructive" role="alert">
-          {lookupError}
-        </p>
-      )}
-
-      {!lookupError && compatibilityWarning && (
+      {compatibilityWarning && (
         <p className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
           <span>{compatibilityWarning}</span>

--- a/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ApiModelSelect } from '../ApiModelSelect';
@@ -6,6 +7,28 @@ import { useModelsStore } from '@/store/useModelsStore';
 import { useRecentModels } from '@/hooks/useRecentModels';
 import { makeMockModelsStore } from '@/test/mocks/modelsStore';
 import type { ModelInfo } from '../types';
+
+function ControlledApiModelSelect({
+  agentKey,
+  initialValue,
+  onChange,
+}: {
+  agentKey: string;
+  initialValue: string;
+  onChange: (modelId: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <ApiModelSelect
+      agentKey={agentKey}
+      value={value}
+      onChange={(modelId) => {
+        setValue(modelId);
+        onChange(modelId);
+      }}
+    />
+  );
+}
 
 // Mock the store
 vi.mock('@/store/useModelsStore');
@@ -232,22 +255,27 @@ describe('ApiModelSelect', () => {
     });
   });
 
-  it('accepts a typed model id even when lookup fails, with a non-blocking warning', async () => {
+  it('accepts a typed model id even when lookup fails, and the warning survives the value round-trip', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     mockLookupModelById.mockRejectedValue(new Error('Model not found'));
 
-    render(<ApiModelSelect agentKey="architect" value="" onChange={onChange} />);
+    render(
+      <ControlledApiModelSelect agentKey="architect" initialValue="" onChange={onChange} />
+    );
 
     await user.type(screen.getByPlaceholderText(/type any model id/i), 'unknown/not-real');
     await user.click(screen.getByRole('button', { name: /use model code/i }));
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith('unknown/not-real');
-      expect(addRecentModel).toHaveBeenCalledWith('unknown/not-real');
-      expect(screen.getByText(/couldn't verify/i)).toBeInTheDocument();
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    });
+    // onChange round-trips the typed id into `value`, which the trigger reflects.
+    await screen.findByText('unknown/not-real');
+    expect(onChange).toHaveBeenCalledWith('unknown/not-real');
+    expect(addRecentModel).toHaveBeenCalledWith('unknown/not-real');
+
+    // After the round-trip re-runs the component's value effect, the unverified
+    // warning must still be present, not clobbered to null.
+    expect(screen.getByText(/couldn't verify/i)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('warns when a resolved model does not meet agent requirements but still selects it', async () => {

--- a/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
@@ -220,7 +220,7 @@ describe('ApiModelSelect', () => {
     );
 
     await user.type(
-      screen.getByPlaceholderText(/type openrouter model id/i),
+      screen.getByPlaceholderText(/type any model id/i),
       'meta-llama/llama-4-scout'
     );
     await user.click(screen.getByRole('button', { name: /use model code/i }));
@@ -232,24 +232,21 @@ describe('ApiModelSelect', () => {
     });
   });
 
-  it('shows an inline error when typed model lookup fails', async () => {
+  it('accepts a typed model id even when lookup fails, with a non-blocking warning', async () => {
     const user = userEvent.setup();
+    const onChange = vi.fn();
     mockLookupModelById.mockRejectedValue(new Error('Model not found'));
 
-    render(
-      <ApiModelSelect
-        agentKey="architect"
-        value="claude-sonnet-4"
-        onChange={vi.fn()}
-      />
-    );
+    render(<ApiModelSelect agentKey="architect" value="" onChange={onChange} />);
 
-    await user.clear(screen.getByPlaceholderText(/type openrouter model id/i));
-    await user.type(screen.getByPlaceholderText(/type openrouter model id/i), 'unknown/not-real');
-    await user.keyboard('{Enter}');
+    await user.type(screen.getByPlaceholderText(/type any model id/i), 'unknown/not-real');
+    await user.click(screen.getByRole('button', { name: /use model code/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Model not found')).toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledWith('unknown/not-real');
+      expect(addRecentModel).toHaveBeenCalledWith('unknown/not-real');
+      expect(screen.getByText(/couldn't verify/i)).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
   });
 
@@ -274,7 +271,7 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    await user.type(screen.getByPlaceholderText(/type openrouter model id/i), 'openai/gpt-4o');
+    await user.type(screen.getByPlaceholderText(/type any model id/i), 'openai/gpt-4o');
     await user.click(screen.getByRole('button', { name: /use model code/i }));
 
     await waitFor(() => {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,7 +359,7 @@ def _deepagents_mock_context(sandbox_class: str) -> Generator[MagicMock, None, N
 
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-api-key"}), \
          patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create_agent, \
-         patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init_model, \
+         patch("amelia.drivers.api.chat_model.init_chat_model") as mock_init_model, \
          patch(f"amelia.drivers.api.deepagents.{sandbox_class}") as mock_backend_class:
 
         agent_result: dict[str, Any] = {"messages": []}
@@ -436,7 +436,7 @@ def mock_deepagents_both() -> Generator[MagicMock, None, None]:
 
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-api-key"}), \
          patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create_agent, \
-         patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init_model, \
+         patch("amelia.drivers.api.chat_model.init_chat_model") as mock_init_model, \
          patch("amelia.drivers.api.deepagents.FilesystemBackend") as mock_fs_backend, \
          patch("amelia.drivers.api.deepagents.LocalSandbox") as mock_local_sandbox:
 

--- a/tests/integration/test_api_driver_token_tracking.py
+++ b/tests/integration/test_api_driver_token_tracking.py
@@ -22,7 +22,7 @@ class TestApiDriverTokenTrackingIntegration:
     def mock_http_boundary(self) -> Generator[dict[str, MagicMock], None, None]:
         """Mock at the HTTP boundary - the LangChain model layer."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}), \
-             patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init, \
+             patch("amelia.drivers.api.chat_model.init_chat_model") as mock_init, \
              patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create:
 
             # Create mock chat model

--- a/tests/unit/cli/test_config_cli.py
+++ b/tests/unit/cli/test_config_cli.py
@@ -254,6 +254,36 @@ class TestProfileCreate:
         assert "created successfully" in result.stdout
         mock_repo.create_profile.assert_called_once()
 
+    def test_profile_create_api_custom_provider_stores_options(
+        self, runner: CliRunner, mock_db: MagicMock
+    ) -> None:
+        """'amelia config profile create' stores custom provider options on agents."""
+        mock_repo = MagicMock()
+        mock_repo.get_profile = AsyncMock(return_value=None)
+        captured: dict[str, Profile] = {}
+
+        async def _create(profile: Profile) -> Profile:
+            captured["profile"] = profile
+            return profile
+
+        mock_repo.create_profile = AsyncMock(side_effect=_create)
+
+        with patch("amelia.cli.config.get_database", return_value=mock_db), \
+             patch("amelia.cli.config.ProfileRepository", return_value=mock_repo):
+            result = runner.invoke(app, [
+                "config", "profile", "create", "p1",
+                "--driver", "api", "--model", "my-model",
+                "--provider", "vllm", "--base-url", "http://localhost:8000/v1",
+                "--api-key-env-var", "VLLM_KEY",
+                "--tracker", "noop", "--repo-root", "/tmp/x",
+            ])
+
+        assert result.exit_code == 0
+        agent = next(iter(captured["profile"].agents.values()))
+        assert agent.options["provider"] == "vllm"
+        assert agent.options["base_url"] == "http://localhost:8000/v1"
+        assert agent.options["api_key_env_var"] == "VLLM_KEY"
+
     def test_profile_create_rejects_legacy_cli_driver(
         self, runner: CliRunner, mock_db: MagicMock
     ) -> None:

--- a/tests/unit/cli/test_config_cli.py
+++ b/tests/unit/cli/test_config_cli.py
@@ -284,6 +284,27 @@ class TestProfileCreate:
         assert agent.options["base_url"] == "http://localhost:8000/v1"
         assert agent.options["api_key_env_var"] == "VLLM_KEY"
 
+    def test_profile_create_api_custom_provider_without_flags_rejected(
+        self, runner: CliRunner, mock_db: MagicMock
+    ) -> None:
+        """Non-interactive custom provider without base_url/api_key_env_var is rejected."""
+        mock_repo = MagicMock()
+        mock_repo.get_profile = AsyncMock(return_value=None)
+        mock_repo.create_profile = AsyncMock()
+
+        with patch("amelia.cli.config.get_database", return_value=mock_db), \
+             patch("amelia.cli.config.ProfileRepository", return_value=mock_repo):
+            result = runner.invoke(app, [
+                "config", "profile", "create", "p1",
+                "--driver", "api", "--model", "my-model",
+                "--provider", "madeupprovider",
+                "--tracker", "noop", "--repo-root", "/tmp/x",
+            ])
+
+        assert result.exit_code == 2
+        assert "madeupprovider" in result.stderr
+        mock_repo.create_profile.assert_not_called()
+
     def test_profile_create_rejects_legacy_cli_driver(
         self, runner: CliRunner, mock_db: MagicMock
     ) -> None:
@@ -303,6 +324,27 @@ class TestProfileCreate:
 
         assert result.exit_code == 2
         assert "Invalid driver" in result.stderr
+
+    def test_profile_create_rejects_provider_flags_for_non_api_driver(
+        self, runner: CliRunner, mock_db: MagicMock
+    ) -> None:
+        """Provider-only flags with a non-api driver are rejected, not silently dropped."""
+        mock_repo = MagicMock()
+        mock_repo.get_profile = AsyncMock(return_value=None)
+        mock_repo.create_profile = AsyncMock()
+
+        with patch("amelia.cli.config.get_database", return_value=mock_db), \
+             patch("amelia.cli.config.ProfileRepository", return_value=mock_repo):
+            result = runner.invoke(app, [
+                "config", "profile", "create", "p1",
+                "--driver", "claude", "--model", "sonnet",
+                "--base-url", "http://x",
+                "--tracker", "noop", "--repo-root", "/tmp",
+            ])
+
+        assert result.exit_code == 2
+        assert "api" in result.stderr
+        mock_repo.create_profile.assert_not_called()
 
 
 class TestProfileCreateDriverAwareDefaults:

--- a/tests/unit/drivers/api/test_deepagents_transient_errors.py
+++ b/tests/unit/drivers/api/test_deepagents_transient_errors.py
@@ -23,7 +23,7 @@ def mock_create_deep_agent() -> Generator[MagicMock, None, None]:
     with (
         patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
         patch("amelia.drivers.api.deepagents.create_deep_agent") as mock_create,
-        patch("amelia.drivers.api.deepagents.init_chat_model"),
+        patch("amelia.drivers.api.chat_model.init_chat_model"),
         patch("amelia.drivers.api.deepagents.LocalSandbox"),
     ):
         yield mock_create

--- a/tests/unit/drivers/test_create_chat_model.py
+++ b/tests/unit/drivers/test_create_chat_model.py
@@ -9,14 +9,14 @@ from amelia.drivers.api.deepagents import ApiDriver, _create_chat_model
 
 
 class TestCreateChatModelBaseUrl:
-    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    @patch("amelia.drivers.api.chat_model.init_chat_model")
     def test_openrouter_uses_default_base_url(self, mock_init, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
         _create_chat_model("test-model", provider="openrouter")
         _, kwargs = mock_init.call_args
         assert kwargs["base_url"] == "https://openrouter.ai/api/v1"
 
-    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    @patch("amelia.drivers.api.chat_model.init_chat_model")
     def test_openrouter_accepts_custom_base_url(self, mock_init, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
         _create_chat_model(
@@ -27,12 +27,7 @@ class TestCreateChatModelBaseUrl:
         _, kwargs = mock_init.call_args
         assert kwargs["base_url"] == "http://host.docker.internal:8430/proxy/v1"
 
-    @patch("amelia.drivers.api.deepagents.init_chat_model")
-    def test_non_openrouter_ignores_base_url(self, mock_init):
-        _create_chat_model("gpt-4")
-        mock_init.assert_called_once_with("gpt-4")
-
-    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    @patch("amelia.drivers.api.chat_model.init_chat_model")
     def test_preset_provider_uses_registry_url_and_key(self, mock_init, monkeypatch):
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds")
         _create_chat_model("deepseek-chat", provider="deepseek")
@@ -41,7 +36,7 @@ class TestCreateChatModelBaseUrl:
         assert kwargs["api_key"] == "sk-ds"
         assert kwargs["model_provider"] == "openai"
 
-    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    @patch("amelia.drivers.api.chat_model.init_chat_model")
     def test_custom_provider_resolves(self, mock_init, monkeypatch):
         monkeypatch.setenv("VLLM_KEY", "local-key")
         _create_chat_model(

--- a/tests/unit/drivers/test_create_chat_model.py
+++ b/tests/unit/drivers/test_create_chat_model.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from amelia.drivers.api.deepagents import _create_chat_model
 
 
@@ -28,3 +30,30 @@ class TestCreateChatModelBaseUrl:
     def test_non_openrouter_ignores_base_url(self, mock_init):
         _create_chat_model("gpt-4")
         mock_init.assert_called_once_with("gpt-4")
+
+    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    def test_preset_provider_uses_registry_url_and_key(self, mock_init, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds")
+        _create_chat_model("deepseek-chat", provider="deepseek")
+        _, kwargs = mock_init.call_args
+        assert kwargs["base_url"] == "https://api.deepseek.com/v1"
+        assert kwargs["api_key"] == "sk-ds"
+        assert kwargs["model_provider"] == "openai"
+
+    @patch("amelia.drivers.api.deepagents.init_chat_model")
+    def test_custom_provider_resolves(self, mock_init, monkeypatch):
+        monkeypatch.setenv("VLLM_KEY", "local-key")
+        _create_chat_model(
+            "my-model",
+            provider="vllm",
+            base_url="http://localhost:8000/v1",
+            api_key_env_var="VLLM_KEY",
+        )
+        _, kwargs = mock_init.call_args
+        assert kwargs["base_url"] == "http://localhost:8000/v1"
+        assert kwargs["api_key"] == "local-key"
+
+    def test_missing_key_env_var_raises_naming_provider_and_var(self, monkeypatch):
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="DEEPSEEK_API_KEY.*deepseek"):
+            _create_chat_model("deepseek-chat", provider="deepseek")

--- a/tests/unit/drivers/test_create_chat_model.py
+++ b/tests/unit/drivers/test_create_chat_model.py
@@ -3,8 +3,9 @@
 from unittest.mock import patch
 
 import pytest
+from langchain_core.messages import AIMessage
 
-from amelia.drivers.api.deepagents import _create_chat_model
+from amelia.drivers.api.deepagents import ApiDriver, _create_chat_model
 
 
 class TestCreateChatModelBaseUrl:
@@ -57,3 +58,24 @@ class TestCreateChatModelBaseUrl:
         monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
         with pytest.raises(ValueError, match="DEEPSEEK_API_KEY.*deepseek"):
             _create_chat_model("deepseek-chat", provider="deepseek")
+
+
+@patch("amelia.drivers.api.deepagents._create_chat_model")
+async def test_apidriver_threads_provider_config_to_chat_model(
+    mock_ccm, monkeypatch, mock_deepagents_filesystem
+):
+    monkeypatch.setenv("VLLM_KEY", "k")
+    mock_deepagents_filesystem.agent_result["messages"] = [AIMessage(content="ok")]
+    driver = ApiDriver(
+        model="m",
+        provider="vllm",
+        base_url="http://localhost:8000/v1",
+        api_key_env_var="VLLM_KEY",
+    )
+    await driver.generate(prompt="hi")
+    mock_ccm.assert_called_with(
+        "m",
+        provider="vllm",
+        base_url="http://localhost:8000/v1",
+        api_key_env_var="VLLM_KEY",
+    )

--- a/tests/unit/drivers/test_factory.py
+++ b/tests/unit/drivers/test_factory.py
@@ -37,7 +37,29 @@ class TestGetDriverExistingBehavior:
         with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
             mock_cls.return_value = MagicMock()
             _driver = get_driver("api", model="test-model")
-            mock_cls.assert_called_once_with(provider="openrouter", model="test-model")
+            mock_cls.assert_called_once_with(
+                provider="openrouter", model="test-model",
+                base_url=None, api_key_env_var=None,
+            )
+
+    def test_api_driver_reads_provider_options(self) -> None:
+        with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            get_driver("api", model="deepseek-chat",
+                       options={"provider": "deepseek", "base_url": None, "api_key_env_var": None})
+            mock_cls.assert_called_once_with(
+                provider="deepseek", model="deepseek-chat",
+                base_url=None, api_key_env_var=None,
+            )
+
+    def test_api_driver_custom_provider_options(self) -> None:
+        with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            get_driver("api", model="m",
+                       options={"provider": "vllm", "base_url": "http://x/v1", "api_key_env_var": "VLLM_KEY"})
+            mock_cls.assert_called_once_with(
+                provider="vllm", model="m", base_url="http://x/v1", api_key_env_var="VLLM_KEY",
+            )
 
     def test_unknown_driver_raises(self) -> None:
         with pytest.raises(ValueError, match=r"Unknown driver key: 'unknown'\."):
@@ -79,13 +101,19 @@ class TestGetDriverContainerBranch:
         with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
             mock_cls.return_value = MagicMock()
             _driver = get_driver("api", model="test-model", sandbox_config=sandbox)
-            mock_cls.assert_called_once_with(provider="openrouter", model="test-model")
+            mock_cls.assert_called_once_with(
+                provider="openrouter", model="test-model",
+                base_url=None, api_key_env_var=None,
+            )
 
     def test_no_sandbox_config_returns_normal_driver(self) -> None:
         with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
             mock_cls.return_value = MagicMock()
             _driver = get_driver("api", model="test-model")
-            mock_cls.assert_called_once_with(provider="openrouter", model="test-model")
+            mock_cls.assert_called_once_with(
+                provider="openrouter", model="test-model",
+                base_url=None, api_key_env_var=None,
+            )
 
 
 class TestLegacyDriverRejection:
@@ -349,7 +377,10 @@ class TestGetDriverWithSharedProvider:
         with patch("amelia.drivers.factory.ApiDriver") as mock_cls:
             mock_cls.return_value = MagicMock()
             get_driver("api", model="test-model", sandbox_provider=None)
-            mock_cls.assert_called_once_with(provider="openrouter", model="test-model")
+            mock_cls.assert_called_once_with(
+                provider="openrouter", model="test-model",
+                base_url=None, api_key_env_var=None,
+            )
 
 
 class TestCreateDaytonaProvider:

--- a/tests/unit/drivers/test_factory.py
+++ b/tests/unit/drivers/test_factory.py
@@ -315,6 +315,20 @@ class TestGetDriverDaytonaBranch:
                 },
             )
 
+    def test_daytona_mode_deepseek_preset_resolves(self) -> None:
+        """Preset provider option should resolve to correct URL and env var."""
+        sandbox = SandboxConfig(mode=SandboxMode.DAYTONA,
+                                repo_url="https://github.com/org/repo.git", network_allowlist_enabled=False)
+        with patch("amelia.sandbox.daytona.DaytonaSandboxProvider") as mock_provider_cls, \
+             patch("amelia.sandbox.driver.ContainerDriver") as mock_driver_cls, \
+             patch.dict(os.environ, {"DAYTONA_API_KEY": "dk", "DEEPSEEK_API_KEY": "sk-ds"}, clear=True):
+            mock_driver_cls.return_value = MagicMock()
+            get_driver("api", model="deepseek-chat", sandbox_config=sandbox,
+                       profile_name="work", options={"provider": "deepseek"})
+            env = mock_provider_cls.call_args.kwargs["worker_env"]
+            assert env["LLM_PROXY_URL"] == "https://api.deepseek.com/v1"
+            assert env["OPENAI_API_KEY"] == "sk-ds"
+
     def test_daytona_mode_unsupported_provider_raises(self) -> None:
         """Unsupported LLM provider should raise ValueError."""
         sandbox = SandboxConfig(
@@ -325,7 +339,7 @@ class TestGetDriverDaytonaBranch:
         with patch("amelia.sandbox.daytona.DaytonaSandboxProvider"), \
              patch("amelia.sandbox.driver.ContainerDriver"), \
              patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"}, clear=True), \
-             pytest.raises(ValueError, match="Unsupported LLM provider"):
+             pytest.raises(ValueError, match="Unsupported provider"):
             get_driver(
                 "api", model="test-model",
                 sandbox_config=sandbox, profile_name="work",

--- a/tests/unit/drivers/test_model_provider_error.py
+++ b/tests/unit/drivers/test_model_provider_error.py
@@ -61,7 +61,7 @@ class TestIsModelProviderError:
 
     def test_is_model_provider_error_with_custom_env_pattern(self) -> None:
         """Custom patterns via AMELIA_PROVIDER_ERROR_PATTERNS should be detected."""
-        from amelia.drivers.api.deepagents import _get_provider_error_patterns
+        from amelia.drivers.api.chat_model import _get_provider_error_patterns
 
         with patch.dict(os.environ, {"AMELIA_PROVIDER_ERROR_PATTERNS": "custom error,another pattern"}):
             # Clear the LRU cache so the function re-reads the environment variable

--- a/tests/unit/drivers/test_providers.py
+++ b/tests/unit/drivers/test_providers.py
@@ -1,0 +1,44 @@
+import pytest
+
+from amelia.drivers.providers import PROVIDER_PRESETS, resolve_provider
+
+
+def test_preset_resolves_base_url_and_env_var():
+    r = resolve_provider("deepseek")
+    assert r.base_url == "https://api.deepseek.com/v1"
+    assert r.api_key_env_var == "DEEPSEEK_API_KEY"
+    assert r.default_headers == {}
+
+
+def test_openrouter_preset_carries_site_headers(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_SITE_URL", raising=False)
+    r = resolve_provider("openrouter")
+    assert r.base_url == "https://openrouter.ai/api/v1"
+    assert r.api_key_env_var == "OPENROUTER_API_KEY"
+    assert r.default_headers["HTTP-Referer"] == "https://github.com/existential-birds/amelia"
+    assert r.default_headers["X-Title"] == "Amelia"
+
+
+def test_base_url_override_wins_over_preset():
+    r = resolve_provider("openrouter", base_url="http://proxy.internal/v1")
+    assert r.base_url == "http://proxy.internal/v1"
+
+
+def test_custom_provider_requires_base_url():
+    with pytest.raises(ValueError, match="requires a base URL"):
+        resolve_provider("vllm", api_key_env_var="VLLM_KEY")
+
+
+def test_custom_provider_with_base_url_and_env_var_resolves():
+    r = resolve_provider("vllm", base_url="http://localhost:8000/v1", api_key_env_var="VLLM_KEY")
+    assert r.base_url == "http://localhost:8000/v1"
+    assert r.api_key_env_var == "VLLM_KEY"
+
+
+def test_unknown_provider_without_custom_config_lists_presets():
+    with pytest.raises(ValueError, match="Unsupported provider 'anthropic'.*deepseek"):
+        resolve_provider("anthropic")
+
+
+def test_all_six_presets_present():
+    assert set(PROVIDER_PRESETS) == {"openrouter", "openai", "deepseek", "groq", "together", "fireworks"}

--- a/tests/unit/drivers/test_providers.py
+++ b/tests/unit/drivers/test_providers.py
@@ -51,13 +51,23 @@ def test_custom_provider_requires_base_url():
 
 
 def test_custom_provider_rejects_blank_base_url():
-    with pytest.raises(ValueError, match="requires a non-empty base URL"):
+    with pytest.raises(ValueError, match="base_url must be a non-empty string"):
         resolve_provider("vllm", base_url="  ", api_key_env_var="VLLM_KEY")
 
 
 def test_custom_provider_rejects_blank_api_key_env_var():
-    with pytest.raises(ValueError, match="requires a non-empty API key environment"):
+    with pytest.raises(ValueError, match="api_key_env_var must be a non-empty string"):
         resolve_provider("vllm", base_url="http://localhost:8000/v1", api_key_env_var="")
+
+
+def test_overrides_are_stripped_of_surrounding_whitespace():
+    r = resolve_provider(
+        "vllm",
+        base_url="  http://localhost:8000/v1  ",
+        api_key_env_var="  VLLM_KEY  ",
+    )
+    assert r.base_url == "http://localhost:8000/v1"
+    assert r.api_key_env_var == "VLLM_KEY"
 
 
 def test_custom_provider_with_base_url_and_env_var_resolves():

--- a/tests/unit/drivers/test_providers.py
+++ b/tests/unit/drivers/test_providers.py
@@ -24,6 +24,16 @@ def test_base_url_override_wins_over_preset():
     assert r.base_url == "http://proxy.internal/v1"
 
 
+def test_api_key_env_var_override_wins_over_preset():
+    r = resolve_provider("openrouter", api_key_env_var="MY_CUSTOM_KEY")
+    assert r.api_key_env_var == "MY_CUSTOM_KEY"
+
+
+def test_api_key_env_var_defaults_to_preset_when_omitted():
+    r = resolve_provider("openrouter")
+    assert r.api_key_env_var == "OPENROUTER_API_KEY"
+
+
 def test_custom_provider_requires_base_url():
     with pytest.raises(ValueError, match="requires a base URL"):
         resolve_provider("vllm", api_key_env_var="VLLM_KEY")

--- a/tests/unit/drivers/test_providers.py
+++ b/tests/unit/drivers/test_providers.py
@@ -12,6 +12,7 @@ def test_preset_resolves_base_url_and_env_var():
 
 def test_openrouter_preset_carries_site_headers(monkeypatch):
     monkeypatch.delenv("OPENROUTER_SITE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_SITE_NAME", raising=False)
     r = resolve_provider("openrouter")
     assert r.base_url == "https://openrouter.ai/api/v1"
     assert r.api_key_env_var == "OPENROUTER_API_KEY"
@@ -34,9 +35,29 @@ def test_api_key_env_var_defaults_to_preset_when_omitted():
     assert r.api_key_env_var == "OPENROUTER_API_KEY"
 
 
+def test_preset_rejects_blank_base_url_override():
+    with pytest.raises(ValueError, match="base_url must be a non-empty string"):
+        resolve_provider("openrouter", base_url="   ")
+
+
+def test_preset_rejects_blank_api_key_env_var_override():
+    with pytest.raises(ValueError, match="api_key_env_var must be a non-empty string"):
+        resolve_provider("openrouter", api_key_env_var="")
+
+
 def test_custom_provider_requires_base_url():
     with pytest.raises(ValueError, match="requires a base URL"):
         resolve_provider("vllm", api_key_env_var="VLLM_KEY")
+
+
+def test_custom_provider_rejects_blank_base_url():
+    with pytest.raises(ValueError, match="requires a non-empty base URL"):
+        resolve_provider("vllm", base_url="  ", api_key_env_var="VLLM_KEY")
+
+
+def test_custom_provider_rejects_blank_api_key_env_var():
+    with pytest.raises(ValueError, match="requires a non-empty API key environment"):
+        resolve_provider("vllm", base_url="http://localhost:8000/v1", api_key_env_var="")
 
 
 def test_custom_provider_with_base_url_and_env_var_resolves():

--- a/tests/unit/sandbox/test_proxy.py
+++ b/tests/unit/sandbox/test_proxy.py
@@ -8,7 +8,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from amelia.core.types import AgentConfig, DriverType, Profile
 from amelia.sandbox.proxy import PROXY_MAX_BODY_BYTES, ProviderConfig, create_proxy_router
+from amelia.server.main import resolve_proxy_provider
 
 
 @pytest.fixture
@@ -489,6 +491,82 @@ class TestProxyBodyLimitConfigurable:
         finally:
             monkeypatch.delenv("AMELIA_PROXY_MAX_BODY_MB", raising=False)
             importlib.reload(proxy_module)
+
+
+class _FakeProfileRepository:
+    """Stub repo that returns canned profiles, standing in for the DB boundary."""
+
+    def __init__(self, profiles: dict[str, "Profile"]) -> None:
+        self._profiles = profiles
+
+    async def get_profile(self, profile_id: str) -> "Profile | None":
+        return self._profiles.get(profile_id)
+
+
+def _profile_with_developer_options(name: str, options: dict[str, Any]) -> "Profile":
+    return Profile(
+        name=name,
+        repo_root="/tmp/repo",
+        agents={
+            "developer": AgentConfig(
+                driver=DriverType.API, model="some-model", options=options
+            )
+        },
+    )
+
+
+class TestResolveProxyProvider:
+    """``resolve_proxy_provider`` must support every preset and custom providers.
+
+    Regression guard: the proxy path previously hardcoded only openrouter/openai,
+    so non-openrouter presets and custom providers 404'd in container-sandbox mode.
+    """
+
+    async def test_non_openrouter_preset_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+        repo = _FakeProfileRepository(
+            {"ds": _profile_with_developer_options("ds", {"provider": "deepseek"})}
+        )
+
+        config = await resolve_proxy_provider("ds", repo)  # type: ignore[arg-type]
+
+        assert config is not None
+        assert config.base_url == "https://api.deepseek.com/v1"
+        assert config.api_key == "sk-deepseek-test"
+
+    async def test_custom_provider_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MY_LLM_KEY", "sk-custom-test")
+        repo = _FakeProfileRepository(
+            {
+                "custom": _profile_with_developer_options(
+                    "custom",
+                    {
+                        "provider": "my-llm",
+                        "base_url": "https://llm.example.com/v1",
+                        "api_key_env_var": "MY_LLM_KEY",
+                    },
+                )
+            }
+        )
+
+        config = await resolve_proxy_provider("custom", repo)  # type: ignore[arg-type]
+
+        assert config is not None
+        assert config.base_url == "https://llm.example.com/v1"
+        assert config.api_key == "sk-custom-test"
+
+    async def test_unknown_provider_resolves_to_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _FakeProfileRepository(
+            {"bad": _profile_with_developer_options("bad", {"provider": "nope"})}
+        )
+
+        assert await resolve_proxy_provider("bad", repo) is None  # type: ignore[arg-type]
 
 
 class TestProxyCleanup:

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -174,7 +174,10 @@ class TestGenerate:
             mock_create.return_value = MagicMock()
             await driver.generate(prompt="test")
 
-            mock_create.assert_called_once_with("test/model", provider="openrouter")
+            mock_create.assert_called_once_with(
+                "test/model", provider="openrouter",
+                base_url=None, api_key_env_var=None,
+            )
 
 
 class TestExecuteAgentic:
@@ -202,7 +205,10 @@ class TestExecuteAgentic:
             async for _ in driver.execute_agentic(prompt="test", cwd="/test"):
                 pass
 
-            mock_create.assert_called_once_with("test/model", provider="openrouter")
+            mock_create.assert_called_once_with(
+                "test/model", provider="openrouter",
+                base_url=None, api_key_env_var=None,
+            )
 
     async def test_yields_agentic_messages_from_stream(
         self, mock_deepagents_filesystem: MagicMock

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -246,7 +246,10 @@ class TestCreateChatModel:
     def test_openrouter_prefix_raises_error(self) -> None:
         """Should raise ValueError for deprecated openrouter: prefix."""
         with pytest.raises(ValueError, match="no longer supported"):
-            _create_chat_model("openrouter:anthropic/claude-sonnet-4-20250514")
+            _create_chat_model(
+                "openrouter:anthropic/claude-sonnet-4-20250514",
+                provider="openrouter",
+            )
 
     def test_openrouter_provider_uses_custom_attribution(self) -> None:
         """Should use custom attribution headers from environment."""
@@ -256,7 +259,7 @@ class TestCreateChatModel:
                 "OPENROUTER_SITE_URL": "https://example.com",
                 "OPENROUTER_SITE_NAME": "CustomApp",
             }),
-            patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init,
+            patch("amelia.drivers.api.chat_model.init_chat_model") as mock_init,
         ):
             mock_init.return_value = MagicMock()
 
@@ -274,20 +277,11 @@ class TestCreateChatModel:
         ):
             _create_chat_model("test/model", provider="openrouter")
 
-    def test_non_openrouter_model_uses_default(self) -> None:
-        """Should use default init_chat_model for non-openrouter models."""
-        with patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init:
-            mock_init.return_value = MagicMock()
-
-            _create_chat_model("gpt-4")
-
-            mock_init.assert_called_once_with("gpt-4")
-
     def test_openrouter_provider_without_prefix(self) -> None:
         """Should configure OpenRouter when provider param is 'openrouter'."""
         with (
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-api-key"}),
-            patch("amelia.drivers.api.deepagents.init_chat_model") as mock_init,
+            patch("amelia.drivers.api.chat_model.init_chat_model") as mock_init,
         ):
             mock_init.return_value = MagicMock()
 


### PR DESCRIPTION
## Summary

Adds support for arbitrary OpenAI-compatible model providers (OpenRouter, OpenAI, DeepSeek, Groq, Together, Fireworks, and fully custom endpoints) across the local `ApiDriver` path, the remote Daytona path, the CLI, and the dashboard. Provider resolution now flows through a single source of truth so presets and custom `base_url`/`api_key_env_var` overrides behave identically everywhere.

## Changes

### Added
- `amelia/drivers/providers.py` — provider registry (`PROVIDER_PRESETS`) and `resolve_provider()` resolving a `(provider, base_url?, api_key_env_var?)` triple into a `ResolvedProvider` consumed by both execution paths.
- `amelia/drivers/api/chat_model.py` — extracted chat-model/provider plumbing out of `deepagents.py`.
- CLI flags on `profile create` to configure custom providers, with validation that rejects api-only flags supplied to non-api drivers.
- Freeform model-ID entry in the dashboard `ApiModelSelect` with a non-blocking "couldn't verify" warning.

### Changed
- `_create_chat_model` now resolves any OpenAI-compatible provider via the shared registry; `provider` is required (the unreachable `provider is None` branch was dropped).
- `ApiDriver` threads `base_url` and `api_key_env_var` through from profile provider options.
- Daytona worker_env resolves its LLM provider via the shared registry and reuses the OpenRouter site-attribution constants from `providers.py`.
- The sandbox proxy (`server/main.py`) resolves providers via `resolve_provider`, so all presets and custom providers work in container-sandbox mode instead of 404ing.
- OpenRouter site-attribution headers and the preset `api_key_env_var` override are now honored consistently.

## Motivation

Amelia was previously limited to a fixed set of model providers. This lets users point Amelia at any OpenAI-compatible endpoint — built-in presets or fully custom — through one resolution path shared by local and remote (Daytona) execution, avoiding the prior drift where the sandbox proxy 404'd on providers the local path supported.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

New/updated regression tests cover the provider registry/resolver, factory wiring, `_create_chat_model`, CLI config validation, the sandbox proxy path, and the dashboard `ApiModelSelect` component. Each review-feedback fix landed with a real-path regression test.

## Related Issues

- Closes #592

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)