### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/.claude/commands/gen-release-notes.md
+++ b/.claude/commands/gen-release-notes.md
@@ -165,7 +165,36 @@ Generate a `CHANGELOG.md` entry using this exact format:
 
 1. Read the current `CHANGELOG.md`
 2. Insert new version after the `## [Unreleased]` section
-3. Add version comparison link at the bottom of the file
+3. Update the reference-link footer at the bottom of the file (this drives release-to-release navigation and MUST be kept in sync):
+
+   First, find the real previous tag — the highest existing tag *below* the new version. Patch releases count, so this may not be the second-newest minor:
+
+   ```bash
+   # Highest existing tag below the new version (e.g. v0.20.1, not v0.20.0)
+   git tag --sort=-version:refname | head
+   PREV_TAG="<highest tag below vX.Y.Z>"
+   ```
+
+   Then make BOTH of these footer edits, preserving the existing URL format exactly (base URL `https://github.com/existential-birds/amelia`):
+
+   - **Repoint `[Unreleased]`** to compare from the NEW version tag:
+
+     ```text
+     [Unreleased]: https://github.com/existential-birds/amelia/compare/vX.Y.Z...HEAD
+     ```
+
+   - **Add a new `[X.Y.Z]` line** comparing from the previous tag (place it above the prior version's line, newest-first):
+
+     ```text
+     [X.Y.Z]: https://github.com/existential-birds/amelia/compare/v<previous>...vX.Y.Z
+     ```
+
+   Example: releasing `v0.21.0` when `v0.20.1` is the highest existing tag below it yields:
+
+   ```text
+   [Unreleased]: https://github.com/existential-birds/amelia/compare/v0.21.0...HEAD
+   [0.21.0]: https://github.com/existential-birds/amelia/compare/v0.20.1...v0.21.0
+   ```
 
 ## Step 6: Update Version Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-31
+
+### Added
+
+- **drivers:** Support arbitrary OpenAI-compatible models and providers — point Amelia at any OpenAI-compatible endpoint by specifying a custom model and base URL, beyond the built-in provider list ([#595](https://github.com/existential-birds/amelia/pull/595))
+
+### Changed
+
+- **deps:** Bump mermaid 11.12.2 → 11.15.0 in `dashboard` and postcss in `docs/site` ([#591](https://github.com/existential-birds/amelia/pull/591))
+- **deps:** Bump langchain-core 1.3.2 → 1.3.3 ([#590](https://github.com/existential-birds/amelia/pull/590))
+
+### Security
+
+- **deps:** Bump idna 3.11 → 3.15 ([#593](https://github.com/existential-birds/amelia/pull/593))
+- **deps:** Bump urllib3 in the uv group ([#590](https://github.com/existential-birds/amelia/pull/590))
+- **deps:** Bump python-multipart 0.0.26 → 0.0.27 ([#589](https://github.com/existential-birds/amelia/pull/589))
+
 ## [0.20.1] - 2026-05-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,7 +564,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/existential-birds/amelia/compare/v0.20.1...v0.21.0
+[0.20.1]: https://github.com/existential-birds/amelia/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/existential-birds/amelia/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/existential-birds/amelia/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/existential-birds/amelia/compare/v0.17.0...v0.18.0

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -8,7 +8,7 @@ Exports:
     __version__: Package version string.
 """
 
-__version__ = "0.20.1"
+__version__ = "0.21.0"
 
 __all__ = [
     "__version__",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.20.1",
+  "version": "0.21.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.20.1"
+version = "0.21.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "amelia"
-version = "0.20.1"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- Bump version to 0.21.0
- Update CHANGELOG.md with changes since v0.20.1

### Highlights

- **Added** — arbitrary OpenAI-compatible model/provider support ([#595](https://github.com/existential-birds/amelia/pull/595))
- **Changed** — dependency bumps (mermaid, postcss, langchain-core)
- **Security** — dependency bumps (idna, urllib3, python-multipart)

## Post-merge steps

After merging, run:
```
/release-tag 0.21.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)