### PR TITLE
refactor(dashboard): remove most-recently-completed fallback from active workflows view (#556)

### DIFF
--- a/dashboard/src/loaders/__tests__/workflows.test.ts
+++ b/dashboard/src/loaders/__tests__/workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { workflowsLoader, workflowDetailLoader, historyLoader } from '../workflows';
 import { api } from '../../api/client';
-import { getActiveWorkflow, getMostRecentCompleted } from '../../utils/workflow';
+import { getActiveWorkflow } from '../../utils/workflow';
 import { createMockWorkflowSummary, createMockWorkflowDetail } from '@/__tests__/fixtures';
 import type { LoaderFunctionArgs } from 'react-router-dom';
 
@@ -43,15 +43,13 @@ describe('Workflow Loaders', () => {
       });
 
       vi.mocked(api.getWorkflows).mockResolvedValueOnce([mockWorkflowSummary]);
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([]);
-      vi.mocked(getMostRecentCompleted).mockReturnValueOnce(null);
       vi.mocked(getActiveWorkflow).mockReturnValueOnce(mockWorkflowSummary);
       vi.mocked(api.getWorkflow).mockResolvedValueOnce(mockWorkflowDetail);
 
       const result = await workflowsLoader(createLoaderArgs({}));
 
       expect(api.getWorkflows).toHaveBeenCalledTimes(1);
-      expect(api.getWorkflowHistory).toHaveBeenCalledTimes(1);
+      expect(api.getWorkflowHistory).not.toHaveBeenCalled();
       expect(result).toHaveProperty('workflows');
       expect(result).toHaveProperty('detail');
       expect(result.workflows).toEqual([mockWorkflowSummary]);
@@ -60,8 +58,6 @@ describe('Workflow Loaders', () => {
 
     it('should return null detail when no workflows exist', async () => {
       vi.mocked(api.getWorkflows).mockResolvedValueOnce([]);
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([]);
-      vi.mocked(getMostRecentCompleted).mockReturnValueOnce(null);
       vi.mocked(getActiveWorkflow).mockReturnValueOnce(null);
 
       const result = await workflowsLoader(createLoaderArgs({}));
@@ -81,8 +77,6 @@ describe('Workflow Loaders', () => {
       });
 
       vi.mocked(api.getWorkflows).mockResolvedValueOnce([mockWorkflowSummary]);
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([]);
-      vi.mocked(getMostRecentCompleted).mockReturnValueOnce(null);
       vi.mocked(getActiveWorkflow).mockReturnValueOnce(mockWorkflowSummary);
       vi.mocked(api.getWorkflow).mockRejectedValueOnce(new Error('Detail fetch failed'));
 
@@ -103,8 +97,6 @@ describe('Workflow Loaders', () => {
       });
 
       vi.mocked(api.getWorkflows).mockResolvedValueOnce([runningWorkflow]);
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([]);
-      vi.mocked(getMostRecentCompleted).mockReturnValueOnce(null);
       vi.mocked(getActiveWorkflow).mockReturnValueOnce(runningWorkflow);
       vi.mocked(api.getWorkflow).mockResolvedValueOnce(runningDetail);
 
@@ -115,33 +107,8 @@ describe('Workflow Loaders', () => {
       expect(result.detail).toEqual(runningDetail);
     });
 
-    it('should include most recently completed workflow in list when no active workflows', async () => {
-      const completedWorkflow = createMockWorkflowSummary({
-        id: 'wf-completed',
-        status: 'completed',
-        started_at: '2025-12-01T10:00:00Z',
-      });
-      const completedDetail = createMockWorkflowDetail({
-        id: 'wf-completed',
-        status: 'completed',
-      });
-
-      vi.mocked(api.getWorkflows).mockResolvedValueOnce([]);
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([completedWorkflow]);
-      vi.mocked(getMostRecentCompleted).mockReturnValueOnce(completedWorkflow);
-      vi.mocked(getActiveWorkflow).mockReturnValueOnce(completedWorkflow);
-      vi.mocked(api.getWorkflow).mockResolvedValueOnce(completedDetail);
-
-      const result = await workflowsLoader(createLoaderArgs({}));
-
-      // Should include the completed workflow in the list
-      expect(result.workflows).toEqual([completedWorkflow]);
-      expect(result.detail).toEqual(completedDetail);
-    });
-
     it('should propagate API errors from getWorkflows', async () => {
       vi.mocked(api.getWorkflows).mockRejectedValueOnce(new Error('Network error'));
-      vi.mocked(api.getWorkflowHistory).mockResolvedValueOnce([]);
 
       await expect(workflowsLoader(createLoaderArgs({}))).rejects.toThrow('Network error');
     });

--- a/dashboard/src/loaders/workflows.ts
+++ b/dashboard/src/loaders/workflows.ts
@@ -1,5 +1,5 @@
 import { api } from '@/api/client';
-import { getActiveWorkflow, getMostRecentCompleted } from '@/utils/workflow';
+import { getActiveWorkflow } from '@/utils/workflow';
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import type { WorkflowsLoaderData } from '@/types/api';
 import { getDemoMode } from '@/hooks/useDemoMode';
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 
 /**
  * Loader for the active workflows page.
- * Fetches all in_progress and blocked workflows from the API,
+ * Fetches all active (in_progress, blocked, pending) workflows from the API,
  * plus pre-loads the workflow detail based on URL parameter or active workflow.
  *
  * @param args - React Router loader arguments containing request URL and optional route params.
@@ -36,18 +36,7 @@ export async function workflowsLoader({ request, params }: LoaderFunctionArgs): 
     return { workflows, detail };
   }
 
-  // Fetch active workflows and history in parallel
-  const [activeWorkflows, historyWorkflows] = await Promise.all([
-    api.getWorkflows(),
-    api.getWorkflowHistory(),
-  ]);
-
-  // Include the most recently completed workflow in the list so the canvas
-  // doesn't immediately clear when a workflow completes
-  const recentCompleted = getMostRecentCompleted(historyWorkflows);
-  const workflows = recentCompleted
-    ? [...activeWorkflows, recentCompleted]
-    : activeWorkflows;
+  const workflows = await api.getWorkflows();
 
   const active = getActiveWorkflow(workflows);
 

--- a/dashboard/src/pages/WorkflowsPage.tsx
+++ b/dashboard/src/pages/WorkflowsPage.tsx
@@ -33,10 +33,6 @@ import type { workflowsLoader } from '@/loaders/workflows';
  * - Top: Workflow header (full width)
  * - Bottom: Job queue
  *
- * The active workflow is determined by priority:
- * 1. Running workflow (status === 'in_progress')
- * 2. Most recently started completed workflow
- *
  * Selection is managed via URL:
  * - /workflows - shows active workflow
  * - /workflows/:id - shows specific workflow

--- a/dashboard/src/utils/__tests__/workflow.test.ts
+++ b/dashboard/src/utils/__tests__/workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getActiveWorkflow, getMostRecentCompleted, formatTokens, formatCost, formatDuration } from '../workflow';
+import { getActiveWorkflow, formatTokens, formatCost, formatDuration } from '../workflow';
 import { createMockWorkflowSummary } from '@/__tests__/fixtures';
 
 describe('getActiveWorkflow', () => {
@@ -12,13 +12,12 @@ describe('getActiveWorkflow', () => {
     expect(getActiveWorkflow(workflows)?.id).toBe('2');
   });
 
-  it('should return most recent completed workflow when no running', () => {
+  it('should return null when only completed workflows exist', () => {
     const workflows = [
       createMockWorkflowSummary({ id: '1', status: 'completed', started_at: '2025-01-01T00:00:00Z' }),
       createMockWorkflowSummary({ id: '2', status: 'completed', started_at: '2025-01-03T00:00:00Z' }),
-      createMockWorkflowSummary({ id: '3', status: 'completed', started_at: '2025-01-02T00:00:00Z' }),
     ];
-    expect(getActiveWorkflow(workflows)?.id).toBe('2');
+    expect(getActiveWorkflow(workflows)).toBeNull();
   });
 
   it('should return null when no workflows exist', () => {
@@ -31,15 +30,6 @@ describe('getActiveWorkflow', () => {
       createMockWorkflowSummary({ id: '2', status: 'in_progress', started_at: '2025-01-01T00:00:00Z' }),
     ];
     expect(getActiveWorkflow(workflows)?.id).toBe('2');
-  });
-
-  it('should sort completed by started_at descending', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: 'oldest', status: 'completed', started_at: '2024-01-01T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'newest', status: 'completed', started_at: '2025-06-01T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'middle', status: 'completed', started_at: '2025-03-01T00:00:00Z' }),
-    ];
-    expect(getActiveWorkflow(workflows)?.id).toBe('newest');
   });
 
   it('should return blocked workflow when no running exists', () => {
@@ -64,17 +54,6 @@ describe('getActiveWorkflow', () => {
       createMockWorkflowSummary({ id: '2', status: 'blocked', started_at: '2025-01-01T00:00:00Z' }),
     ];
     expect(getActiveWorkflow(workflows)?.id).toBe('2');
-  });
-
-  it('should handle null started_at in completed workflows', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: '1', status: 'completed', started_at: null }),
-      createMockWorkflowSummary({ id: '2', status: 'completed', started_at: '2025-01-01T00:00:00Z' }),
-      createMockWorkflowSummary({ id: '3', status: 'completed', started_at: null }),
-    ];
-    // Should not throw, should return one of them
-    const result = getActiveWorkflow(workflows);
-    expect(result).not.toBeNull();
   });
 
   it('should return most recently started running workflow when multiple are in progress', () => {
@@ -106,48 +85,6 @@ describe('getActiveWorkflow', () => {
     ];
     // Should select the most recent running workflow (running-oldest), not the first in array
     expect(getActiveWorkflow(workflows)?.id).toBe('running-oldest');
-  });
-});
-
-describe('getMostRecentCompleted', () => {
-  it('should return the most recently completed workflow', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: 'oldest', status: 'completed', started_at: '2025-01-01T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'newest', status: 'completed', started_at: '2025-01-03T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'middle', status: 'completed', started_at: '2025-01-02T00:00:00Z' }),
-    ];
-    expect(getMostRecentCompleted(workflows)?.id).toBe('newest');
-  });
-
-  it('should return null when no completed workflows exist', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: '1', status: 'in_progress' }),
-      createMockWorkflowSummary({ id: '2', status: 'blocked' }),
-    ];
-    expect(getMostRecentCompleted(workflows)).toBeNull();
-  });
-
-  it('should return null for empty array', () => {
-    expect(getMostRecentCompleted([])).toBeNull();
-  });
-
-  it('should ignore non-completed workflows', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: 'completed', status: 'completed', started_at: '2025-01-01T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'running', status: 'in_progress', started_at: '2025-01-03T00:00:00Z' }),
-      createMockWorkflowSummary({ id: 'failed', status: 'failed', started_at: '2025-01-02T00:00:00Z' }),
-    ];
-    expect(getMostRecentCompleted(workflows)?.id).toBe('completed');
-  });
-
-  it('should handle workflows with null started_at', () => {
-    const workflows = [
-      createMockWorkflowSummary({ id: '1', status: 'completed', started_at: null }),
-      createMockWorkflowSummary({ id: '2', status: 'completed', started_at: '2025-01-01T00:00:00Z' }),
-    ];
-    // Should return one of them without throwing
-    const result = getMostRecentCompleted(workflows);
-    expect(result).not.toBeNull();
   });
 });
 

--- a/dashboard/src/utils/workflow.ts
+++ b/dashboard/src/utils/workflow.ts
@@ -76,7 +76,6 @@ function sortByStartTimeDesc(a: WorkflowSummary, b: WorkflowSummary): number {
  * 1. Most recently started running workflow (status === 'in_progress')
  * 2. Most recently started blocked workflow (status === 'blocked')
  * 3. Most recently created pending workflow
- * 4. Most recently started completed workflow
  *
  * @param workflows - List of workflow summaries
  * @returns The active workflow or null if none exist
@@ -100,29 +99,7 @@ export function getActiveWorkflow(workflows: WorkflowSummary[]): WorkflowSummary
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
   if (pending[0]) return pending[0];
 
-  // Priority 4: Most recently started completed workflow
-  const completed = workflows
-    .filter(w => w.status === 'completed')
-    .sort(sortByStartTimeDesc);
-
-  return completed[0] ?? null;
-}
-
-/**
- * Gets the most recently completed workflow from a list.
- *
- * Used to keep a completed workflow visible in the active workflows view
- * so the canvas doesn't immediately clear when a workflow finishes.
- *
- * @param workflows - List of workflow summaries (typically from history)
- * @returns The most recently completed workflow or null if none exist
- */
-export function getMostRecentCompleted(workflows: WorkflowSummary[]): WorkflowSummary | null {
-  const completed = workflows
-    .filter(w => w.status === 'completed')
-    .sort(sortByStartTimeDesc);
-
-  return completed[0] ?? null;
+  return null;
 }
 
 /**

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -635,6 +635,20 @@ DATABASE_URL = os.environ.get(
 )
 
 
+@pytest.fixture(autouse=True)
+def _align_app_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the in-process app config at the integration test database.
+
+    ``ServerConfig`` reads its connection string from ``AMELIA_DATABASE_URL``
+    (env_prefix ``AMELIA_``), but CI only exports ``DATABASE_URL``. Integration
+    tests that boot the real app (e.g. the ``server`` / ``server_with_real_db``
+    fixtures, which run the FastAPI lifespan) would otherwise fall back to the
+    ``localhost:5434/amelia`` default and fail to connect. Aligning the two
+    ensures the booted app and the direct ``test_db`` fixtures share one DB.
+    """
+    monkeypatch.setenv("AMELIA_DATABASE_URL", DATABASE_URL)
+
+
 @pytest.fixture
 async def test_db() -> AsyncGenerator[Database, None]:
     """Create and initialize test database with PostgreSQL."""


### PR DESCRIPTION
## Summary

Implements #556: removes the feature that kept the most-recently-completed workflow visible in the active workflows view. When the last active workflow finishes, the view now shows the empty state instead of falling back to a completed workflow.

## Changes

### Removed
- `getMostRecentCompleted()` from `utils/workflow.ts` and its test block.
- Priority 4 ("most recently started completed workflow") fallback from `getActiveWorkflow()` — it now returns `null` when no running/blocked/pending workflow exists.
- The `getWorkflowHistory()` fetch and completed-row merge from `workflowsLoader` — the active workflows loader no longer pulls history just to find a recent completed job.

### Kept
- `api.getWorkflowHistory()` stays — it is still used by `historyLoader`/`HistoryPage`. Per #556, it is deleted only if used solely for this feature, which is not the case.

## Motivation

The completed-workflow fallback is no longer wanted (#556). The active view should reflect only genuinely active work (in_progress, blocked, pending) and show an empty state otherwise.

> Note for future readers: an intermediate commit on this branch restored the fallback (treating the blank-on-completion as a regression). That reverted #556's intent and has been dropped — the blank/empty state is the intended behavior per the issue's acceptance criteria.

## Testing

- [x] Unit tests updated (getActiveWorkflow expects `null` fallback; loader asserts `getWorkflowHistory` not called)
- [x] Tests pass locally
- [x] Linting passes

Verified locally:
- `pnpm build` — clean
- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm test:run` — 901 tests passed (84 files)

## Related Issues

- Closes #556