### PR TITLE
fix(server): make set_status atomic with row-locked terminal precedence (#604)

### DIFF
--- a/amelia/server/database/connection.py
+++ b/amelia/server/database/connection.py
@@ -223,6 +223,16 @@ class Database:
             asyncpg.Connection: The connection with an active transaction.
 
         Commits on success, rolls back on exception.
+
+        Isolation level: asyncpg defaults to **Read Committed** (PostgreSQL's
+        default).  The ``set_status`` override logic in the repository layer
+        depends on this level — it relies on ``SELECT … FOR UPDATE`` acquiring
+        a row lock without the non-repeatable-read protection that Repeatable
+        Read / Serializable would add, and the CANCELLED→COMPLETED precedence
+        rule is designed around that behaviour.  Do not change the isolation
+        level here without auditing ``repository.set_status`` first.
         """
+        # Isolation is intentionally left at asyncpg's default (Read Committed).
+        # See the docstring above before changing this.
         async with self.pool.acquire() as conn, conn.transaction():
             yield conn

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -5,6 +5,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import asyncpg
+from loguru import logger
 
 from amelia.server.database.connection import Database, in_clause_placeholders
 from amelia.server.exceptions import WorkflowNotFoundError
@@ -221,10 +222,20 @@ class WorkflowRepository:
         inside a transaction, so concurrent transitions can never corrupt the row.
 
         Terminal precedence (#604): a completion overrides a concurrent
-        cancellation (``CANCELLED`` → ``COMPLETED``). A terminal row is otherwise
-        immutable — any other transition against it (a duplicate terminal or a
-        non-terminal target) is absorbed as a no-op. Non-terminal source rows go
-        through the usual ``validate_transition`` state-machine check.
+        cancellation (``CANCELLED`` → ``COMPLETED``). An immutable terminal row
+        (``COMPLETED`` or ``CANCELLED``) is otherwise frozen — any other
+        transition against it is absorbed as a no-op. ``FAILED`` is *not*
+        immutable: ``VALID_TRANSITIONS[FAILED] = {IN_PROGRESS}`` (resumable via
+        recovery — see the orchestrator resume path), so ``FAILED`` rows and all
+        non-terminal source rows go through the usual ``validate_transition``
+        state-machine check (a duplicate ``FAILED`` therefore raises rather than
+        being absorbed).
+
+        Silent absorption note: if the row is already in an immutable terminal
+        state and the caller supplies a ``failure_reason`` that will be dropped by
+        the no-op, a ``WARNING`` is emitted so the lost diagnostic is visible in
+        logs; no exception is raised. Callers that must guarantee failure
+        diagnostics are persisted should check the current status first.
 
         Args:
             workflow_id: Workflow to update.
@@ -249,7 +260,17 @@ class WorkflowRepository:
             if current == WorkflowStatus.CANCELLED and new_status == WorkflowStatus.COMPLETED:
                 pass  # a completion overrides a concurrent cancellation (#604) — apply it
             elif current in (WorkflowStatus.COMPLETED, WorkflowStatus.CANCELLED):
-                return  # terminal row is otherwise immutable — absorb as a no-op
+                # Terminal row is otherwise immutable — absorb as a no-op. Surface
+                # any diagnostic that the no-op would silently discard.
+                if failure_reason is not None:
+                    logger.warning(
+                        "status update absorbed (workflow already terminal); failure_reason dropped",
+                        workflow_id=workflow_id,
+                        current_status=current,
+                        new_status=new_status,
+                        failure_reason=failure_reason,
+                    )
+                return
             else:
                 validate_transition(current, new_status)  # non-terminal: state machine rules
 

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -19,15 +19,6 @@ from amelia.server.models.state import (
 from amelia.server.models.tokens import TokenSummary, TokenUsage
 
 
-# Precedence for concurrent terminal-vs-terminal race resolution. COMPLETED is the
-# highest-ranked terminal because it reflects real side effects and must never be
-# lost (#604): a completion always overrides a concurrent cancellation. This is NOT
-# a transition map and must not be used to bypass validate_transition for
-# non-terminal sources; it only governs which terminal wins when the locked row is
-# already terminal.
-_TERMINAL_RANK = {WorkflowStatus.CANCELLED: 1, WorkflowStatus.COMPLETED: 2}
-
-
 class WorkflowRepository:
     """Repository for workflow CRUD operations.
 
@@ -229,13 +220,11 @@ class WorkflowRepository:
         Atomic: reads the current status under a ``SELECT … FOR UPDATE`` row lock
         inside a transaction, so concurrent transitions can never corrupt the row.
 
-        Terminal precedence (#604): when the locked row is already terminal, the
-        new status is applied only if it is a strictly-higher-ranked terminal
-        (COMPLETED rank 2 > CANCELLED rank 1) — so a completion overrides a
-        concurrent cancellation. Any other transition against a terminal row (a
-        duplicate terminal, a lower-ranked terminal, or any non-terminal target)
-        is absorbed as a no-op. Non-terminal source rows go through the usual
-        ``validate_transition`` state-machine check.
+        Terminal precedence (#604): a completion overrides a concurrent
+        cancellation (``CANCELLED`` → ``COMPLETED``). A terminal row is otherwise
+        immutable — any other transition against it (a duplicate terminal or a
+        non-terminal target) is absorbed as a no-op. Non-terminal source rows go
+        through the usual ``validate_transition`` state-machine check.
 
         Args:
             workflow_id: Workflow to update.
@@ -256,13 +245,13 @@ class WorkflowRepository:
 
             current = WorkflowStatus(row["status"])
 
-            if current in _TERMINAL_RANK:
-                # Terminal source: only a strictly-higher-ranked terminal overrides;
-                # everything else is absorbed as a no-op.
-                if _TERMINAL_RANK.get(new_status, 0) <= _TERMINAL_RANK[current]:
-                    return
+            # Resolve against the locked status, in priority order:
+            if current == WorkflowStatus.CANCELLED and new_status == WorkflowStatus.COMPLETED:
+                pass  # a completion overrides a concurrent cancellation (#604) — apply it
+            elif current in (WorkflowStatus.COMPLETED, WorkflowStatus.CANCELLED):
+                return  # terminal row is otherwise immutable — absorb as a no-op
             else:
-                validate_transition(current, new_status)
+                validate_transition(current, new_status)  # non-terminal: state machine rules
 
             # Set completed_at for terminal states
             completed_at = None

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -19,6 +19,15 @@ from amelia.server.models.state import (
 from amelia.server.models.tokens import TokenSummary, TokenUsage
 
 
+# Precedence for concurrent terminal-vs-terminal race resolution. COMPLETED is the
+# highest-ranked terminal because it reflects real side effects and must never be
+# lost (#604): a completion always overrides a concurrent cancellation. This is NOT
+# a transition map and must not be used to bypass validate_transition for
+# non-terminal sources; it only governs which terminal wins when the locked row is
+# already terminal.
+_TERMINAL_RANK = {WorkflowStatus.CANCELLED: 1, WorkflowStatus.COMPLETED: 2}
+
+
 class WorkflowRepository:
     """Repository for workflow CRUD operations.
 
@@ -217,6 +226,17 @@ class WorkflowRepository:
     ) -> None:
         """Update workflow status with state machine validation.
 
+        Atomic: reads the current status under a ``SELECT … FOR UPDATE`` row lock
+        inside a transaction, so concurrent transitions can never corrupt the row.
+
+        Terminal precedence (#604): when the locked row is already terminal, the
+        new status is applied only if it is a strictly-higher-ranked terminal
+        (COMPLETED rank 2 > CANCELLED rank 1) — so a completion overrides a
+        concurrent cancellation. Any other transition against a terminal row (a
+        duplicate terminal, a lower-ranked terminal, or any non-terminal target)
+        is absorbed as a no-op. Non-terminal source rows go through the usual
+        ``validate_transition`` state-machine check.
+
         Args:
             workflow_id: Workflow to update.
             new_status: Target status.
@@ -224,32 +244,44 @@ class WorkflowRepository:
 
         Raises:
             WorkflowNotFoundError: If workflow doesn't exist.
-            InvalidStateTransitionError: If transition is invalid.
+            InvalidStateTransitionError: If a non-terminal transition is invalid.
         """
-        workflow = await self.get(workflow_id)
-        if workflow is None:
-            raise WorkflowNotFoundError(workflow_id)
+        async with self._db.transaction() as conn:
+            row = await conn.fetchrow(
+                "SELECT status FROM workflows WHERE id = $1 FOR UPDATE",
+                workflow_id,
+            )
+            if row is None:
+                raise WorkflowNotFoundError(workflow_id)
 
-        validate_transition(workflow.workflow_status, new_status)
+            current = WorkflowStatus(row["status"])
 
-        # Set completed_at for terminal states
-        completed_at = None
-        if new_status in (WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED):
-            completed_at = datetime.now(UTC)
+            if current in _TERMINAL_RANK:
+                # Terminal source: only a strictly-higher-ranked terminal overrides;
+                # everything else is absorbed as a no-op.
+                if _TERMINAL_RANK.get(new_status, 0) <= _TERMINAL_RANK[current]:
+                    return
+            else:
+                validate_transition(current, new_status)
 
-        await self._db.execute(
-            """
-            UPDATE workflows SET
-                status = $1,
-                completed_at = $2,
-                failure_reason = $3
-            WHERE id = $4
-            """,
-            new_status,
-            completed_at,
-            failure_reason,
-            workflow_id,
-        )
+            # Set completed_at for terminal states
+            completed_at = None
+            if new_status in (WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED):
+                completed_at = datetime.now(UTC)
+
+            await conn.execute(
+                """
+                UPDATE workflows SET
+                    status = $1,
+                    completed_at = $2,
+                    failure_reason = $3
+                WHERE id = $4
+                """,
+                new_status,
+                completed_at,
+                failure_reason,
+                workflow_id,
+            )
 
     async def update_plan_cache(
         self,

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -301,17 +301,12 @@ class WorkflowRepository:
         Raises:
             WorkflowNotFoundError: If workflow doesn't exist.
         """
-        result = await self._db.fetch_one(
-            "SELECT id FROM workflows WHERE id = $1",
-            workflow_id,
-        )
-        if result is None:
-            raise WorkflowNotFoundError(workflow_id)
-
-        await self._db.execute(
+        rows_affected = await self._db.execute(
             "UPDATE workflows SET plan_cache = $1 WHERE id = $2",
             plan_cache.model_dump(), workflow_id,
         )
+        if rows_affected == 0:
+            raise WorkflowNotFoundError(workflow_id)
 
     async def list_active(
         self, worktree_path: str | None = None

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -268,7 +268,7 @@ class WorkflowRepository:
                         workflow_id=workflow_id,
                         current_status=current,
                         new_status=new_status,
-                        failure_reason=failure_reason,
+                        has_failure_reason=True,
                     )
                 return
             else:

--- a/tests/integration/server/database/test_repository.py
+++ b/tests/integration/server/database/test_repository.py
@@ -1,5 +1,6 @@
 """Tests for WorkflowRepository."""
 
+import asyncio
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -11,6 +12,7 @@ from amelia.server.models.events import EventLevel, WorkflowEvent
 from amelia.server.models.state import (
     InvalidStateTransitionError,
     ServerExecutionState,
+    WorkflowStatus,
 )
 
 
@@ -183,6 +185,87 @@ class TestWorkflowRepository:
         retrieved = await repository.get(state.id)
         assert retrieved.workflow_status == "failed"
         assert retrieved.failure_reason == "Something went wrong"
+
+    async def test_set_status_noop_on_terminal_workflow(self, repository) -> None:
+        """A completed row absorbs a lower-precedence transition as a no-op."""
+        state = ServerExecutionState(
+            id=uuid4(), issue_id="ISSUE-DONE",
+            worktree_path="/p", workflow_status="in_progress",
+        )
+        await repository.create(state)
+        await repository.set_status(state.id, "completed")
+        snapshot = await repository.get(state.id)
+
+        # cancelled (rank 1) cannot override completed (rank 2): no-op.
+        await repository.set_status(state.id, "cancelled")
+
+        final = await repository.get(state.id)
+        assert final.workflow_status == WorkflowStatus.COMPLETED
+        assert final.completed_at == snapshot.completed_at
+
+    async def test_set_status_completion_overrides_cancellation(self, repository) -> None:
+        """COMPLETED (rank 2) overrides a CANCELLED (rank 1) row (terminal precedence)."""
+        state = ServerExecutionState(
+            id=uuid4(), issue_id="ISSUE-OVERRIDE",
+            worktree_path="/p", workflow_status="in_progress",
+        )
+        await repository.create(state)
+        await repository.set_status(state.id, "cancelled")
+
+        # Pre-fix this raises InvalidStateTransitionError; post-fix completion wins.
+        await repository.set_status(state.id, "completed")
+
+        final = await repository.get(state.id)
+        assert final.workflow_status == WorkflowStatus.COMPLETED
+        assert final.completed_at is not None
+
+    async def test_set_status_concurrent_complete_vs_cancel(self, repository) -> None:
+        """Concurrent complete+cancel on one workflow always resolves to completed.
+
+        Pre-fix (non-atomic read+validate+write) the last UPDATE wins, so the row
+        can silently end 'cancelled', losing the completion. Atomic FOR UPDATE +
+        terminal precedence (COMPLETED rank 2 > CANCELLED rank 1) make 'completed'
+        win regardless of lock order. Neither call raises (cancel from in_progress
+        is legal; the losing call is absorbed/overridden).
+        """
+        for _ in range(20):
+            state = ServerExecutionState(
+                id=uuid4(), issue_id="ISSUE-RACE",
+                worktree_path="/p", workflow_status="in_progress",
+            )
+            await repository.create(state)
+
+            await asyncio.gather(
+                repository.set_status(state.id, "completed"),
+                repository.set_status(state.id, "cancelled"),
+            )
+
+            final = await repository.get(state.id)
+            assert final.workflow_status == WorkflowStatus.COMPLETED
+            assert final.completed_at is not None
+
+    async def test_set_status_concurrent_cancel_vs_blocked(self, repository) -> None:
+        """Concurrent cancel+block always resolves to cancelled, never raises.
+
+        If cancel locks first the row is terminal and absorbs the block (rank 0);
+        if block locks first, cancel is a legal BLOCKED->CANCELLED transition.
+        Either lock order -> cancelled, deterministically (spec should-have #5,
+        the 'ideally cancel-vs-blocked' shape).
+        """
+        for _ in range(20):
+            state = ServerExecutionState(
+                id=uuid4(), issue_id="ISSUE-RACE-CB",
+                worktree_path="/p", workflow_status="in_progress",
+            )
+            await repository.create(state)
+
+            await asyncio.gather(
+                repository.set_status(state.id, "cancelled"),
+                repository.set_status(state.id, "blocked"),
+            )
+
+            final = await repository.get(state.id)
+            assert final.workflow_status == WorkflowStatus.CANCELLED
 
     async def test_list_active_workflows(self, repository) -> None:
         """Can list all active workflows."""

--- a/tests/integration/server/database/test_repository.py
+++ b/tests/integration/server/database/test_repository.py
@@ -390,6 +390,8 @@ class TestWorkflowRepository:
         Sequence:
           1. Tx-A: BEGIN, SELECT … FOR UPDATE (acquires lock), signals B.
           2. Tx-B: BEGIN, SELECT … FOR UPDATE (blocks on lock held by A).
+          2a. Test verifies via pg_stat_activity that Tx-B is genuinely
+              blocked on the lock before releasing Tx-A.
           3. Tx-A: UPDATE status='completed', COMMIT (releases lock).
           4. Tx-B: unblocks, reads status='completed' (terminal), no-ops, COMMIT.
           5. Final row must be 'completed'.
@@ -432,13 +434,41 @@ class TestWorkflowRepository:
             # status='completed' and silently no-ops (terminal absorption).
             await repository.set_status(state.id, "cancelled")
 
-        # Run both tasks concurrently; release Tx-A after a brief yield so
-        # Tx-B has had a chance to issue its own FOR UPDATE and queue behind A.
+        async def wait_until_tx_b_blocks_on_lock() -> None:
+            """Poll pg_stat_activity until a backend is blocked on a row lock.
+
+            Proves Tx-B has actually issued its FOR UPDATE and is waiting on the
+            lock held by Tx-A — not merely that Tx-A committed first. Without
+            this, proceed.set() could release Tx-A before Tx-B ever contends,
+            and the test would no-op via terminal absorption without exercising
+            the blocking path. Fails loudly if Tx-B never reaches its lock wait.
+            """
+            async with repository.db.pool.acquire() as conn:
+                for _ in range(200):  # ~2s at 10ms intervals
+                    blocked = await conn.fetchval(
+                        """
+                        SELECT count(*) FROM pg_stat_activity
+                        WHERE wait_event_type = 'Lock'
+                          AND state = 'active'
+                          AND query ILIKE '%FOR UPDATE%'
+                          AND pid <> pg_backend_pid()
+                        """,
+                    )
+                    if blocked:
+                        return
+                    await asyncio.sleep(0.01)
+            raise AssertionError(
+                "Tx-B never blocked on the row lock; "
+                "the FOR UPDATE contention path was not exercised."
+            )
+
         async def orchestrate() -> None:
             task_a = asyncio.create_task(tx_a_hold_then_complete())
             task_b = asyncio.create_task(tx_b_attempt_cancel())
-            await lock_held.wait()   # A has the lock; B is now blocking on it
-            proceed.set()            # release A → it commits → B unblocks
+            await lock_held.wait()             # A has the lock
+            await wait_until_tx_b_blocks_on_lock()  # B is provably blocked on it
+            assert not task_b.done()           # B is still waiting, not no-op'd
+            proceed.set()                      # release A → commits → B unblocks
             await asyncio.gather(task_a, task_b)
 
         await orchestrate()

--- a/tests/integration/server/database/test_repository.py
+++ b/tests/integration/server/database/test_repository.py
@@ -7,10 +7,12 @@ from uuid import uuid4
 import pytest
 
 from amelia.server.database.repository import WorkflowRepository
+from amelia.server.exceptions import WorkflowNotFoundError
 from amelia.server.models import EventType
 from amelia.server.models.events import EventLevel, WorkflowEvent
 from amelia.server.models.state import (
     InvalidStateTransitionError,
+    PlanCache,
     ServerExecutionState,
     WorkflowStatus,
 )
@@ -591,6 +593,23 @@ class TestWorkflowRepository:
 
         with pytest.raises(WorkflowNotFoundError):
             await repository.update_plan_cache(uuid4(), plan_cache)
+
+    async def test_update_plan_cache_persists(self, repository) -> None:
+        """update_plan_cache writes the cache for an existing workflow."""
+        state = ServerExecutionState(
+            id=uuid4(), issue_id="ISSUE-PC", worktree_path="/p",
+        )
+        await repository.create(state)
+
+        await repository.update_plan_cache(state.id, PlanCache(goal="cache me"))
+
+        final = await repository.get(state.id)
+        assert final.plan_cache is not None
+
+    async def test_update_plan_cache_missing_workflow_raises(self, repository) -> None:
+        """update_plan_cache raises WorkflowNotFoundError for an unknown id (never a silent no-op)."""
+        with pytest.raises(WorkflowNotFoundError):
+            await repository.update_plan_cache(uuid4(), PlanCache(goal="cache me"))
 
     async def test_create_workflow_writes_new_columns(self, repository) -> None:
         """create() dual-writes to new columns (workflow_type, profile_id, plan_cache)."""

--- a/tests/integration/server/database/test_repository.py
+++ b/tests/integration/server/database/test_repository.py
@@ -188,6 +188,98 @@ class TestWorkflowRepository:
         assert retrieved.workflow_status == "failed"
         assert retrieved.failure_reason == "Something went wrong"
 
+    async def test_set_status_failed_workflow_persists_failure_reason(
+        self, repository
+    ) -> None:
+        """set_status(in_progress→FAILED, failure_reason=...) persists reason and timestamp.
+
+        Pins the contract exercised by service.py lines 1376, 1414, 1801, 1830, 1871.
+        The failure_reason must be written to the DB row and completed_at must be set.
+        """
+        state = ServerExecutionState(
+            id=uuid4(),
+            issue_id="ISSUE-FAIL",
+            worktree_path="/path/to/repo",
+            workflow_status="in_progress",
+        )
+        await repository.create(state)
+
+        await repository.set_status(
+            state.id,
+            WorkflowStatus.FAILED,
+            failure_reason="Failed after 3 attempts: ConnectionError",
+        )
+
+        retrieved = await repository.get(state.id)
+        assert retrieved.workflow_status == WorkflowStatus.FAILED
+        assert retrieved.failure_reason == "Failed after 3 attempts: ConnectionError"
+        assert retrieved.completed_at is not None
+
+    async def test_set_status_already_failed_workflow_raises(self, repository) -> None:
+        """set_status(already-FAILED, FAILED, failure_reason=...) raises InvalidStateTransitionError.
+
+        FAILED is not in the COMPLETED/CANCELLED terminal-absorption guard, so a
+        duplicate FAILED call goes through validate_transition(FAILED, FAILED) and
+        is rejected — the state machine forbids it (VALID_TRANSITIONS[FAILED] = {IN_PROGRESS}).
+        Pins the contract as "state-machine error", not "log-the-drop" or "silent noop".
+        """
+        state = ServerExecutionState(
+            id=uuid4(),
+            issue_id="ISSUE-ALREADY-FAILED",
+            worktree_path="/path/to/repo",
+            workflow_status="in_progress",
+        )
+        await repository.create(state)
+        await repository.set_status(
+            state.id,
+            WorkflowStatus.FAILED,
+            failure_reason="first failure",
+        )
+
+        with pytest.raises(InvalidStateTransitionError):
+            await repository.set_status(
+                state.id,
+                WorkflowStatus.FAILED,
+                failure_reason="second failure attempt",
+            )
+
+        # Row must be unchanged — first failure_reason is preserved
+        final = await repository.get(state.id)
+        assert final.workflow_status == WorkflowStatus.FAILED
+        assert final.failure_reason == "first failure"
+
+    async def test_set_status_failed_workflow_resumes_to_in_progress(
+        self, repository
+    ) -> None:
+        """set_status(FAILED -> IN_PROGRESS) recovers the workflow, not a no-op.
+
+        FAILED is resumable (VALID_TRANSITIONS[FAILED] = {IN_PROGRESS}) and must
+        NOT be in the immutable-terminal absorption set. This pins the recovery
+        path used by orchestrator service.py (set_status(..., IN_PROGRESS) when a
+        previously-failed workflow is resumed). If FAILED were treated as an
+        immutable terminal state, this transition would be silently swallowed and
+        the workflow could never be resumed — observe the persisted row, not the
+        call return.
+        """
+        state = ServerExecutionState(
+            id=uuid4(),
+            issue_id="ISSUE-RESUME-FROM-FAILED",
+            worktree_path="/path/to/repo",
+            workflow_status="in_progress",
+        )
+        await repository.create(state)
+        await repository.set_status(
+            state.id,
+            WorkflowStatus.FAILED,
+            failure_reason="transient failure",
+        )
+
+        # Recovery: resume the failed workflow back to in_progress.
+        await repository.set_status(state.id, WorkflowStatus.IN_PROGRESS)
+
+        resumed = await repository.get(state.id)
+        assert resumed.workflow_status == WorkflowStatus.IN_PROGRESS
+
     async def test_set_status_noop_on_terminal_workflow(self, repository) -> None:
         """A completed row absorbs a lower-precedence transition as a no-op."""
         state = ServerExecutionState(
@@ -222,13 +314,21 @@ class TestWorkflowRepository:
         assert final.completed_at is not None
 
     async def test_set_status_concurrent_complete_vs_cancel(self, repository) -> None:
-        """Concurrent complete+cancel on one workflow always resolves to completed.
+        """Precedence logic is order-independent: completed always beats cancelled.
+
+        NOTE: asyncio.gather on a single-threaded event loop does NOT guarantee
+        true FOR UPDATE lock contention — one transaction typically completes
+        before the other acquires its connection.  What this test actually
+        verifies is that the precedence/state-machine logic produces the correct
+        result regardless of which call runs first (A-then-B or B-then-A).
+        See test_set_status_for_update_blocks_concurrent_writer for the lock
+        contention proof.
 
         Pre-fix (non-atomic read+validate+write) the last UPDATE wins, so the row
         can silently end 'cancelled', losing the completion. Atomic FOR UPDATE +
         terminal precedence (COMPLETED rank 2 > CANCELLED rank 1) make 'completed'
-        win regardless of lock order. Neither call raises (cancel from in_progress
-        is legal; the losing call is absorbed/overridden).
+        win regardless of scheduling order. Neither call raises (cancel from
+        in_progress is legal; the losing call is absorbed/overridden).
         """
         for _ in range(20):
             state = ServerExecutionState(
@@ -247,12 +347,20 @@ class TestWorkflowRepository:
             assert final.completed_at is not None
 
     async def test_set_status_concurrent_cancel_vs_blocked(self, repository) -> None:
-        """Concurrent cancel+block always resolves to cancelled, never raises.
+        """Precedence logic is order-independent: cancelled always beats blocked.
+
+        NOTE: asyncio.gather on a single-threaded event loop does NOT guarantee
+        true FOR UPDATE lock contention — one transaction typically completes
+        before the other acquires its connection.  What this test actually
+        verifies is that the precedence/state-machine logic produces the correct
+        result regardless of which call runs first (A-then-B or B-then-A).
+        See test_set_status_for_update_blocks_concurrent_writer for the lock
+        contention proof.
 
         If cancel locks first the row is terminal and absorbs the block (rank 0);
         if block locks first, cancel is a legal BLOCKED->CANCELLED transition.
-        Either lock order -> cancelled, deterministically (spec should-have #5,
-        the 'ideally cancel-vs-blocked' shape).
+        Either scheduling order -> cancelled, deterministically (spec should-have
+        #5, the 'ideally cancel-vs-blocked' shape).
         """
         for _ in range(20):
             state = ServerExecutionState(
@@ -268,6 +376,75 @@ class TestWorkflowRepository:
 
             final = await repository.get(state.id)
             assert final.workflow_status == WorkflowStatus.CANCELLED
+
+    async def test_set_status_for_update_blocks_concurrent_writer(
+        self, repository
+    ) -> None:
+        """SELECT … FOR UPDATE actually serializes two overlapping transactions.
+
+        Uses asyncio.Event barriers to force true lock contention: Transaction A
+        holds the FOR UPDATE row lock while Transaction B is blocked waiting for
+        it.  This proves the locking path works end-to-end, not just that the
+        precedence logic is correct for sequential calls.
+
+        Sequence:
+          1. Tx-A: BEGIN, SELECT … FOR UPDATE (acquires lock), signals B.
+          2. Tx-B: BEGIN, SELECT … FOR UPDATE (blocks on lock held by A).
+          3. Tx-A: UPDATE status='completed', COMMIT (releases lock).
+          4. Tx-B: unblocks, reads status='completed' (terminal), no-ops, COMMIT.
+          5. Final row must be 'completed'.
+        """
+        state = ServerExecutionState(
+            id=uuid4(), issue_id="ISSUE-LOCK",
+            worktree_path="/p", workflow_status="in_progress",
+        )
+        await repository.create(state)
+
+        # Event that Tx-A signals once it holds the FOR UPDATE lock.
+        lock_held = asyncio.Event()
+        # Event that the test signals to let Tx-A proceed with its UPDATE/COMMIT.
+        proceed = asyncio.Event()
+
+        async def tx_a_hold_then_complete() -> None:
+            """Acquires FOR UPDATE, pauses until proceed is set, then commits."""
+            async with repository.db.pool.acquire() as conn, conn.transaction():
+                await conn.fetchrow(
+                    "SELECT status FROM workflows WHERE id = $1 FOR UPDATE",
+                    state.id,
+                )
+                lock_held.set()          # signal: lock is now held
+                await proceed.wait()     # hold the lock until the test says go
+                await conn.execute(
+                    "UPDATE workflows SET status = $1 WHERE id = $2",
+                    "completed",
+                    state.id,
+                )
+
+        async def tx_b_attempt_cancel() -> None:
+            """Waits until Tx-A holds the lock, then tries set_status('cancelled').
+
+            set_status opens its own transaction and will block on FOR UPDATE
+            until Tx-A commits.  After unblocking it reads status='completed'
+            (terminal) and absorbs the call as a no-op.
+            """
+            await lock_held.wait()           # wait until A holds the lock
+            # This call blocks inside DB until Tx-A commits, then reads
+            # status='completed' and silently no-ops (terminal absorption).
+            await repository.set_status(state.id, "cancelled")
+
+        # Run both tasks concurrently; release Tx-A after a brief yield so
+        # Tx-B has had a chance to issue its own FOR UPDATE and queue behind A.
+        async def orchestrate() -> None:
+            task_a = asyncio.create_task(tx_a_hold_then_complete())
+            task_b = asyncio.create_task(tx_b_attempt_cancel())
+            await lock_held.wait()   # A has the lock; B is now blocking on it
+            proceed.set()            # release A → it commits → B unblocks
+            await asyncio.gather(task_a, task_b)
+
+        await orchestrate()
+
+        final = await repository.get(state.id)
+        assert final.workflow_status == WorkflowStatus.COMPLETED
 
     async def test_list_active_workflows(self, repository) -> None:
         """Can list all active workflows."""


### PR DESCRIPTION
## Summary

Fixes a workflow state-transition race (#604) where concurrent `set_status` calls could corrupt a workflow's terminal state. The status read and write are now a single row-locked transaction, with an explicit precedence rule for the one legitimate terminal override (a completion winning over a concurrent cancellation).

## Changes

### Fixed
- `set_status` is now atomic: the current status is read under `SELECT … FOR UPDATE` inside a transaction, so concurrent transitions can no longer interleave between the read and the write.
- `update_plan_cache` collapsed to a single guarded `UPDATE` — the existence check and the write are one statement, with `WorkflowNotFoundError` raised when `rows_affected == 0` (previously a separate non-atomic `SELECT` + `UPDATE`).

### Changed
- Terminal precedence is now an explicit override condition (`CANCELLED → COMPLETED`) rather than a `_TERMINAL_RANK` lookup table. Immutable terminal rows (`COMPLETED`/`CANCELLED`) absorb other transitions as no-ops; `FAILED` remains resumable (`FAILED → IN_PROGRESS`) and still flows through `validate_transition`.
- A `WARNING` is emitted when an immutable terminal row absorbs an update carrying a `failure_reason`, so the dropped diagnostic is visible in logs instead of vanishing silently.
- Documented in `Database.transaction()` that `set_status` depends on asyncpg's default Read Committed isolation; changing it requires auditing `set_status` first.

## Motivation

Under concurrency, the previous `get()` + `validate_transition()` + `execute()` sequence had a window where two transitions could both read a non-terminal status and then both write, clobbering each other or violating the state machine. Locking the row for the duration of the read-decide-write closes that window. The `CANCELLED → COMPLETED` override preserves the intended behavior that a workflow finishing should win over an in-flight cancellation.

## Testing

- [x] Integration tests added (real Postgres, real repository)
- [x] Lint / type check

### What's covered

`tests/integration/server/database/test_repository.py` adds:
- `FAILED → IN_PROGRESS` recovery driven through the real repository, asserting the persisted row (guards against `FAILED` being wrongly absorbed as terminal).
- Duplicate `FAILED` raising via the state machine.
- A `FOR UPDATE` lock-contention test proving two overlapping transactions serialize correctly.
- `CANCELLED → COMPLETED` terminal-override precedence.

## Related Issues

- Closes #604