### PR TITLE
refactor: remove self-inflicted complexity (dead field, dup cost helper, dispatch-only tests)

### DIFF
--- a/amelia/pipelines/nodes.py
+++ b/amelia/pipelines/nodes.py
@@ -20,7 +20,7 @@ from amelia.agents.reviewer import Reviewer
 from amelia.core.types import ReviewResult
 from amelia.pipelines.implementation.state import ImplementationState
 from amelia.pipelines.utils import extract_node_config
-from amelia.server.models.tokens import TokenUsage, calculate_token_cost
+from amelia.server.models.tokens import TokenUsage, resolve_driver_cost
 from amelia.skills.review import REVIEW_TYPE_SKILLS, detect_stack, load_skills
 from amelia.tools.git_utils import get_current_commit
 
@@ -118,18 +118,9 @@ async def _save_token_usage(
         if driver_usage is None:
             return
 
-        cost = driver_usage.cost_usd or 0.0
-
-        # Compute cost from cached pricing if driver didn't provide it
-        if not cost:
-            model = driver_usage.model or getattr(driver, "model", "unknown")
-            cost = await calculate_token_cost(
-                model=model,
-                input_tokens=driver_usage.input_tokens or 0,
-                output_tokens=driver_usage.output_tokens or 0,
-                cache_read_tokens=driver_usage.cache_read_tokens or 0,
-                cache_creation_tokens=driver_usage.cache_creation_tokens or 0,
-            )
+        cost = await resolve_driver_cost(
+            driver_usage, getattr(driver, "model", "unknown")
+        )
 
         usage = TokenUsage(
             workflow_id=workflow_id,

--- a/amelia/server/models/responses.py
+++ b/amelia/server/models/responses.py
@@ -90,9 +90,6 @@ class WorkflowDetailResponse(BaseModel):
     )
     token_usage: TokenSummary | None = Field(default=None, description="Token usage summary")
     recent_events: list[dict[str, Any]] = Field(description="Recent workflow events")
-    final_response: str | None = Field(
-        default=None, description="Final response from the agent"
-    )
     pipeline_type: str | None = Field(
         default=None, description="Pipeline type (e.g. full, review, pr_auto_fix)"
     )

--- a/amelia/server/models/tokens.py
+++ b/amelia/server/models/tokens.py
@@ -13,6 +13,7 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from amelia.drivers.base import DriverUsage
 from amelia.server.models.model_cache import ModelCacheEntry
 
 
@@ -345,3 +346,25 @@ async def calculate_token_cost(
     )
 
     return round(cost, 6)
+
+
+async def resolve_driver_cost(
+    driver_usage: DriverUsage,
+    fallback_model: str | None = None,
+) -> float:
+    """Return the driver-reported cost, or compute it from cached pricing when absent.
+
+    Falls back to ``calculate_token_cost`` using ``fallback_model`` when the driver
+    does not supply ``cost_usd``. Returns 0.0 when no cost and no model are available.
+    """
+    cost = driver_usage.cost_usd or 0.0
+    model = driver_usage.model or fallback_model
+    if not cost and model:
+        cost = await calculate_token_cost(
+            model=model,
+            input_tokens=driver_usage.input_tokens or 0,
+            output_tokens=driver_usage.output_tokens or 0,
+            cache_read_tokens=driver_usage.cache_read_tokens or 0,
+            cache_creation_tokens=driver_usage.cache_creation_tokens or 0,
+        )
+    return cost

--- a/amelia/server/services/brainstorm.py
+++ b/amelia/server/services/brainstorm.py
@@ -41,7 +41,7 @@ from amelia.server.models.brainstorm import (
 )
 from amelia.server.models.events import BrainstormEventType, EventDomain, WorkflowEvent
 from amelia.server.models.requests import CreateWorkflowRequest
-from amelia.server.models.tokens import calculate_token_cost
+from amelia.server.models.tokens import resolve_driver_cost
 from amelia.server.services.brainstormer_agent import (
     BRAINSTORMER_USER_PROMPT_TEMPLATE,
     BrainstormerFilesystemMiddleware,
@@ -63,18 +63,7 @@ async def _build_message_usage(
     calculate_token_cost using cached pricing data. Uses fallback_model
     when driver_usage.model is not set.
     """
-    cost = driver_usage.cost_usd or 0.0
-
-    # Compute cost from cached pricing if driver didn't provide it
-    model = driver_usage.model or fallback_model
-    if not cost and model:
-        cost = await calculate_token_cost(
-            model=model,
-            input_tokens=driver_usage.input_tokens or 0,
-            output_tokens=driver_usage.output_tokens or 0,
-            cache_read_tokens=driver_usage.cache_read_tokens or 0,
-            cache_creation_tokens=driver_usage.cache_creation_tokens or 0,
-        )
+    cost = await resolve_driver_cost(driver_usage, fallback_model)
 
     return MessageUsage(
         input_tokens=driver_usage.input_tokens or 0,

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -117,6 +117,10 @@ export interface BrainstormingSession {
   id: string;
   profile_id: string;
   driver_session_id: string | null;
+  /** Driver backing the session ('cli' or 'api'); optional, defaults to null backend-side. */
+  driver_type?: string | null;
+  /** Path to the generated output artifact, if any; optional, defaults to null backend-side. */
+  output_artifact_path?: string | null;
   status: SessionStatus;
   topic: string | null;
   created_at: string;

--- a/tests/unit/agents/prompts/test_resolver.py
+++ b/tests/unit/agents/prompts/test_resolver.py
@@ -98,7 +98,8 @@ class TestRecordForWorkflow:
     """Tests for record_for_workflow method."""
 
     async def test_records_custom_versions_only(self, mock_repository) -> None:
-        """Should only record custom versions, not defaults."""
+        """Should record one row per custom-versioned prompt with the right args."""
+        version_id = uuid4()
         mock_repository.get_prompt.return_value = Prompt(
             id="architect.plan",
             agent="architect",
@@ -106,7 +107,7 @@ class TestRecordForWorkflow:
             current_version_id=str(uuid4()),
         )
         mock_repository.get_version.return_value = PromptVersion(
-            id=uuid4(),
+            id=version_id,
             prompt_id="architect.plan",
             version_number=1,
             content="Custom content",
@@ -114,8 +115,18 @@ class TestRecordForWorkflow:
         resolver = PromptResolver(mock_repository)
         await resolver.record_for_workflow("wf-1")
 
-        # Should have been called for each prompt with a version_id
-        assert mock_repository.record_workflow_prompt.called
+        # Every default prompt resolves to the same custom version here, so the
+        # resolver must record exactly one row per known prompt id.
+        calls = mock_repository.record_workflow_prompt.call_args_list
+        assert mock_repository.record_workflow_prompt.call_count == len(PROMPT_DEFAULTS)
+
+        # Each call is record_workflow_prompt(workflow_id, prompt_id, version_id).
+        recorded_workflow_ids = {call.args[0] for call in calls}
+        recorded_prompt_ids = {call.args[1] for call in calls}
+        recorded_version_ids = {call.args[2] for call in calls}
+        assert recorded_workflow_ids == {"wf-1"}
+        assert recorded_prompt_ids == set(PROMPT_DEFAULTS)
+        assert recorded_version_ids == {version_id}
 
     async def test_does_not_record_defaults(self, mock_repository) -> None:
         """Should not record anything when all use defaults."""

--- a/tests/unit/pipelines/test_nodes_cost_fallback.py
+++ b/tests/unit/pipelines/test_nodes_cost_fallback.py
@@ -67,7 +67,7 @@ async def test_calls_calculate_token_cost_when_cost_usd_is_none(
     driver = _make_driver(cost_usd=None, input_tokens=1000, output_tokens=500)
 
     with patch(
-        "amelia.pipelines.nodes.calculate_token_cost",
+        "amelia.server.models.tokens.calculate_token_cost",
         new_callable=AsyncMock,
         return_value=0.042,
     ) as mock_calc:
@@ -92,7 +92,7 @@ async def test_calls_calculate_token_cost_when_cost_usd_is_zero(
     driver = _make_driver(cost_usd=0.0, input_tokens=2000, output_tokens=800)
 
     with patch(
-        "amelia.pipelines.nodes.calculate_token_cost",
+        "amelia.server.models.tokens.calculate_token_cost",
         new_callable=AsyncMock,
         return_value=0.1,
     ) as mock_calc:
@@ -117,7 +117,7 @@ async def test_uses_driver_cost_when_provided(
     driver = _make_driver(cost_usd=0.55)
 
     with patch(
-        "amelia.pipelines.nodes.calculate_token_cost",
+        "amelia.server.models.tokens.calculate_token_cost",
         new_callable=AsyncMock,
     ) as mock_calc:
         await _save_token_usage(driver, workflow_id, "developer", repository)
@@ -141,7 +141,7 @@ async def test_falls_back_to_driver_model_when_usage_model_is_none(
     )
 
     with patch(
-        "amelia.pipelines.nodes.calculate_token_cost",
+        "amelia.server.models.tokens.calculate_token_cost",
         new_callable=AsyncMock,
         return_value=0.03,
     ) as mock_calc:
@@ -172,7 +172,7 @@ async def test_forwards_cache_tokens_to_calculate_token_cost(
     )
 
     with patch(
-        "amelia.pipelines.nodes.calculate_token_cost",
+        "amelia.server.models.tokens.calculate_token_cost",
         new_callable=AsyncMock,
         return_value=0.065,
     ) as mock_calc:

--- a/tests/unit/server/events/test_connection_manager.py
+++ b/tests/unit/server/events/test_connection_manager.py
@@ -206,9 +206,16 @@ class TestConnectionManagerTraceEvents:
 
         await manager.broadcast(trace_event)
 
-        # Both clients receive trace events (no workflow filtering)
-        assert mock_websocket.send_text.called
-        assert mock_ws2.send_text.called
+        # Both clients receive the SAME trace event despite mismatched subscriptions
+        # (trace events bypass workflow filtering). Decode the JSON each client got and
+        # assert the wrapper type plus the actual event id/type, so a wrong payload fails.
+        for ws in (mock_websocket, mock_ws2):
+            ws.send_text.assert_awaited_once()
+            payload = json.loads(ws.send_text.call_args[0][0])
+            assert payload["type"] == "event"
+            assert payload["payload"]["id"] == str(trace_event.id)
+            assert payload["payload"]["event_type"] == EventType.CLAUDE_TOOL_CALL.value
+            assert payload["payload"]["agent"] == "developer"
 
 
 class TestBroadcastDomainRouting:

--- a/tests/unit/server/models/test_tokens.py
+++ b/tests/unit/server/models/test_tokens.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
+from amelia.drivers.base import DriverUsage
 from amelia.server.models.model_cache import (
     ModelCacheCapabilities,
     ModelCacheEntry,
@@ -23,6 +24,7 @@ from amelia.server.models.tokens import (
     calculate_token_cost,
     fetch_openrouter_pricing,
     get_pricing,
+    resolve_driver_cost,
 )
 
 
@@ -677,6 +679,86 @@ class TestCalculateTokenCost:
             )
             # Same as claude-sonnet-4-5-20251101: $3 + $15 = $18
             assert cost == 18.0
+
+
+class TestResolveDriverCost:
+    """Tests for resolve_driver_cost() against the real cost path."""
+
+    def _reset_cache(self) -> None:
+        """Reset module-level cache state between tests."""
+        import amelia.server.models.tokens as tokens_mod
+
+        tokens_mod._cached_pricing = {}
+        tokens_mod._cache_expires_at = 0.0
+        tokens_mod._cache_lock = asyncio.Lock()
+
+    async def test_driver_cost_returned_unchanged_without_computation(self) -> None:
+        """When the driver reports cost_usd, it is returned as-is."""
+        self._reset_cache()
+        usage = DriverUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cost_usd=0.42,
+            model="claude-sonnet-4-5-20251101",
+        )
+
+        # If this path computed cost it would be $18, not 0.42.
+        cost = await resolve_driver_cost(usage)
+        assert cost == 0.42
+
+    async def test_computes_from_pricing_when_cost_absent(self) -> None:
+        """When cost_usd is missing but a model is known, cost is computed > 0."""
+        self._reset_cache()
+        usage = DriverUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cost_usd=None,
+            model="claude-sonnet-4-5-20251101",
+        )
+
+        with patch(
+            "amelia.server.models.tokens.fetch_openrouter_pricing",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            cost = await resolve_driver_cost(usage)
+
+        # Static fallback for sonnet: 1M*$3 + 1M*$15 = $18.
+        assert cost == 18.0
+
+    async def test_uses_fallback_model_when_usage_model_absent(self) -> None:
+        """fallback_model supplies pricing when driver_usage.model is None."""
+        self._reset_cache()
+        usage = DriverUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cost_usd=None,
+            model=None,
+        )
+
+        with patch(
+            "amelia.server.models.tokens.fetch_openrouter_pricing",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            cost = await resolve_driver_cost(
+                usage, fallback_model="claude-sonnet-4-5-20251101"
+            )
+
+        assert cost == 18.0
+
+    async def test_returns_zero_when_no_cost_and_no_model(self) -> None:
+        """With no cost and no model anywhere, returns 0.0 (no computation)."""
+        self._reset_cache()
+        usage = DriverUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cost_usd=None,
+            model=None,
+        )
+
+        cost = await resolve_driver_cost(usage)
+        assert cost == 0.0
 
 
 class TestTokenSummary:

--- a/tests/unit/server/orchestrator/test_queue_and_plan.py
+++ b/tests/unit/server/orchestrator/test_queue_and_plan.py
@@ -313,8 +313,22 @@ class TestQueueAndPlanWorkflow:
             if workflow_id in orchestrator._planning_tasks:
                 await orchestrator._planning_tasks[workflow_id]
 
-        # Should have emitted events (workflow_created, stage events, approval_required)
-        assert mock_event_bus.emit.called
+        # event_bus.emit() receives fully-built WorkflowEvent objects. Inspect the
+        # emitted event_type values so the test fails if the wrong events fire.
+        from amelia.server.models.events import EventType
+
+        emitted_types = {
+            call.args[0].event_type for call in mock_event_bus.emit.call_args_list
+        }
+
+        # The happy planning path must emit: creation, the architect stage completing,
+        # and an approval gate once the graph interrupts at human_approval_node.
+        assert EventType.WORKFLOW_CREATED in emitted_types
+        assert EventType.STAGE_COMPLETED in emitted_types
+        assert EventType.APPROVAL_REQUIRED in emitted_types
+        # Planning paused for approval — it must NOT report completion or failure.
+        assert EventType.WORKFLOW_COMPLETED not in emitted_types
+        assert EventType.WORKFLOW_FAILED not in emitted_types
 
     @pytest.mark.asyncio
     async def test_queue_and_plan_validates_worktree(

--- a/tests/unit/server/services/test_brainstorm_cost_fallback.py
+++ b/tests/unit/server/services/test_brainstorm_cost_fallback.py
@@ -30,7 +30,7 @@ def _make_driver_usage(
 class TestBrainstormCostFallback:
     """Test cost calculation fallback when driver doesn't provide cost."""
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_calls_calculate_token_cost_when_driver_has_no_cost(
         self, mock_calc: AsyncMock
     ):
@@ -57,7 +57,7 @@ class TestBrainstormCostFallback:
             cache_creation_tokens=0,
         )
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_passes_through_driver_provided_cost(self, mock_calc: AsyncMock):
         """When driver provides cost_usd, it's used directly without fallback."""
         usage = _make_driver_usage(
@@ -72,7 +72,7 @@ class TestBrainstormCostFallback:
         assert result.cost_usd == 0.05
         mock_calc.assert_not_awaited()
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_skips_calculation_when_model_is_none(self, mock_calc: AsyncMock):
         """When driver_usage.model is None, cost stays 0.0 (no calculation)."""
         usage = _make_driver_usage(
@@ -87,7 +87,7 @@ class TestBrainstormCostFallback:
         assert result.cost_usd == 0.0
         mock_calc.assert_not_awaited()
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_includes_cache_tokens_in_calculation(self, mock_calc: AsyncMock):
         """Cache read/write tokens are passed to calculate_token_cost."""
         mock_calc.return_value = 0.010335
@@ -112,7 +112,7 @@ class TestBrainstormCostFallback:
             cache_creation_tokens=100,
         )
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_zero_cost_triggers_fallback(self, mock_calc: AsyncMock):
         """When driver provides cost_usd=0.0, fallback is triggered."""
         mock_calc.return_value = 0.0105
@@ -129,7 +129,7 @@ class TestBrainstormCostFallback:
         assert result.cost_usd > 0.0
         mock_calc.assert_awaited_once()
 
-    @patch("amelia.server.services.brainstorm.calculate_token_cost", new_callable=AsyncMock)
+    @patch("amelia.server.models.tokens.calculate_token_cost", new_callable=AsyncMock)
     async def test_fallback_model_used_when_driver_usage_model_is_none(
         self, mock_calc: AsyncMock
     ):

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -31,26 +31,11 @@ def api_driver() -> ApiDriver:
 class TestApiDriverInit:
     """Test ApiDriver initialization."""
 
-    def test_uses_provided_model(self) -> None:
-        """Should use the provided model name."""
-        driver = ApiDriver(model="anthropic/claude-sonnet-4-20250514", provider="openrouter")
-        assert driver.model == "anthropic/claude-sonnet-4-20250514"
-
     def test_defaults_to_minimax_m2(self) -> None:
         """Should default to MiniMax M2 when no model provided."""
         driver = ApiDriver()
         assert driver.model == ApiDriver.DEFAULT_MODEL
         assert driver.model == "minimax/minimax-m2"  # No prefix
-
-    def test_stores_cwd(self) -> None:
-        """Should store the cwd parameter."""
-        driver = ApiDriver(cwd="/some/path")
-        assert driver.cwd == "/some/path"
-
-    def test_stores_provider(self) -> None:
-        """Should store the provider parameter."""
-        driver = ApiDriver(provider="openrouter")
-        assert driver.provider == "openrouter"
 
     def test_provider_defaults_to_openrouter(self) -> None:
         """Should default provider to 'openrouter' when not specified."""


### PR DESCRIPTION
## Summary

A focused audit for the same family of self-inflicted complexity removed in #619 — redundancy/indirection that exists only because two layers we own weren't unified. Part of #603.

Stacked on #619 (`refactor/609-split-dashboard-types`); retarget to `main` once #619 merges.

Six discovery sweeps ran (models/wire, type parity, god-modules, dead code, test quality, name collisions/dup). Every finding was verified against source before acting — several were dropped as false positives or legitimate design (see below). Three coherent fixes survived, each its own commit.

## What changed

### 1. `fix(types)` — drop a dead backend field, fix one real TS↔backend drift
- **Dead field:** `WorkflowDetailResponse.final_response` was defined but **never populated** — the route constructs the response without it, so it was always `null` on the wire. Deleted. (The live `final_response` on pipeline/agentic state is a different field, untouched.)
- **Real drift:** `GET /brainstorm/sessions` returns `BrainstormingSession` **verbatim** (no adapter), but the dashboard type omitted `driver_type` and `output_artifact_path` — both populated, persisted, and serialized. Added as optional-nullable to match the wire.

### 2. `refactor(tokens)` — extract canonical `resolve_driver_cost`
The driver-cost fallback (*use `driver_usage.cost_usd`, else compute from cached pricing via `calculate_token_cost`, honoring a fallback model*) was **copy-pasted** in `brainstorm._build_message_usage` and `nodes._save_token_usage`. Extracted one `resolve_driver_cost` in `models/tokens.py`; both call sites delegate. New `TestResolveDriverCost` asserts the **returned cost** across three shapes (provided → passthrough; absent+model → computed; absent+no-model → `0.0`).

### 3. `test` — assert consequence, not dispatch
Rewrote dispatch-only tests (asserting a mock was `.called`) to assert observable side effects:
- `test_queue_and_plan_emits_events` → asserts the emitted **event-type sequence** (`WORKFLOW_CREATED`, `STAGE_COMPLETED`, `APPROVAL_REQUIRED`; and that `COMPLETED`/`FAILED` are absent — it paused at the approval gate).
- `test_broadcast_sends_trace_events_to_all_clients` → decodes the **JSON sent to both clients** and asserts wrapper type + the trace event's `id`/`event_type`/`agent`.
- `test_records_custom_versions_only` → asserts recorded **call args** (workflow_id, prompt ids, version).
- `test_api_driver.py` → trimmed three pure-storage constructor tautologies; kept the default-resolution tests (real logic).

## Findings deliberately NOT acted on (verified out of scope)

- **`recent_events` on `WorkflowDetail`:** *not* drift. The client adapter destructures `recent_events` off the wire response to derive `recoverable`, then discards it — its absence from the domain type is by design.
- **`WorkflowEvent.level` optionality:** false positive — the backend fills `level` in post-init, so it's always present on the wire; the TS required field is correct.
- **Brainstorm wire envelope / `AgenticMessageType`→`BrainstormEventType` map:** legitimate domain boundaries (#619 established brainstorm as a distinct domain); the driver→event map carries real semantic renames + ask-user interception, not pure indirection.
- **`AgenticMessage`/`DriverUsage` inlined in `sandbox/worker.py`:** intentional container isolation.
- **God-modules (epic #603):** `orchestrator/service.py` (1600), `runner.py` (1178), `repository.py` (1022), `pr_auto_fix/orchestrator.py` (925) are high-risk, behavior-sensitive splits. Left for dedicated #603 sub-PRs rather than bundled here.
- **Dead code sweep:** nothing actionable.

## Verification

- `ruff check` ✅ · `mypy amelia` ✅ (175 files)
- `pytest` ✅ **2488 passed, 1 skipped**
- `pytest -m integration` ✅ **432 passed, 2 skipped**
- `pnpm type-check` ✅ · `pnpm lint` ✅ · `pnpm test:run` ✅ **904 passed** · `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)