### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-07
+
+### Added
+
+- **dashboard:** Replace profile edit modal with a routed detail page — profile editing now navigates to a dedicated URL instead of opening an overlay ([#599](https://github.com/existential-birds/amelia/pull/599))
+
+### Changed
+
+- **dashboard:** Remove most-recently-completed fallback from the active workflows view — the view no longer surfaces a completed workflow when no workflow is running ([#600](https://github.com/existential-birds/amelia/pull/600))
+
+### Fixed
+
+- **server:** Make `set_status` atomic using row-level locking with terminal-state precedence — prevents a non-terminal status update from overwriting a terminal one under concurrent writers ([#612](https://github.com/existential-birds/amelia/pull/612))
+
+### Security
+
+- **deps:** Resolve 7 Dependabot alerts in `react-router` and `ai-sdk` ([#614](https://github.com/existential-birds/amelia/pull/614))
+- **deps:** Bump `starlette` 0.50.0 → 1.0.1 ([#611](https://github.com/existential-birds/amelia/pull/611))
+- **deps:** Bump `aiohttp` 3.13.4 → 3.14.0 ([#602](https://github.com/existential-birds/amelia/pull/602))
+
 ## [0.21.0] - 2026-05-31
 
 ### Added
@@ -564,7 +584,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/existential-birds/amelia/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/existential-birds/amelia/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/existential-birds/amelia/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/existential-birds/amelia/compare/v0.19.0...v0.20.0

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -8,7 +8,7 @@ Exports:
     __version__: Package version string.
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"
 
 __all__ = [
     "__version__",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amelia/design-system-docs",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Amelia Design System documentation site built with VitePress by hey-amelia bot",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.21.0"
+version = "0.22.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "amelia"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- Bump version to 0.22.0
- Update CHANGELOG.md with changes since v0.21.0

## Changes in this release

### Added
- **dashboard:** Profile edit modal replaced with a routed detail page

### Changed
- **dashboard:** Remove most-recently-completed fallback from active workflows view

### Fixed
- **server:** `set_status` is now atomic with row-level locking and terminal-state precedence

### Security
- **deps:** Resolve 7 Dependabot alerts in `react-router` and `ai-sdk`
- **deps:** Bump `starlette` 0.50.0 → 1.0.1
- **deps:** Bump `aiohttp` 3.13.4 → 3.14.0

## Post-merge steps

After merging, run:
\`\`\`
/release-tag 0.22.0
\`\`\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)