### PR TITLE
chore: remove redundant and stale code comments

### DIFF
--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -132,7 +132,6 @@ Before planning, discover:
         if not state.issue:
             raise ValueError("Cannot generate plan: no issue in ImplementationState")
 
-        # Build user prompt from state (simplified - no codebase scan)
         user_prompt = self._build_agentic_prompt(state, profile)
 
         cwd = profile.repo_root
@@ -148,7 +147,6 @@ Before planning, discover:
             plan_path=plan_path,
         )
 
-        # Build kwargs for driver execution
         driver_kwargs: dict[str, Any] = {
             "required_file_path": plan_path,
         }
@@ -183,7 +181,6 @@ Before planning, discover:
                         tool_input=message.tool_input or {},
                     )
                     tool_calls.append(call)
-                    # Log tool call details with explicit tool name in message
                     input_keys = list(message.tool_input.keys()) if message.tool_input else []
                     logger.debug(
                         "Architect tool call",
@@ -221,7 +218,6 @@ Before planning, discover:
                         tool_calls_count=len(tool_calls),
                     )
 
-                    # Log all tool calls at completion
                     logger.debug(
                         "Architect completed",
                         tool_calls_summary=[
@@ -231,7 +227,6 @@ Before planning, discover:
                         raw_output_preview=raw_output[:300] if raw_output else None,
                     )
 
-                    # Extract plan_path from write_plan or write_file tool calls
                     # Note: CLI driver normalizes "Write" to "write_file" (ToolName.WRITE_FILE)
                     extracted_plan_path: Path | None = None
                     for tc in tool_calls:
@@ -298,7 +293,6 @@ Before planning, discover:
         parts.append(f"**Title:** {state.issue.title}")
         parts.append(f"**Description:**\n{state.issue.description}")
 
-        # Include design document if present (from brainstorming handoff)
         if state.design is not None:
             parts.append("\n## Design Document")
             parts.append(
@@ -316,7 +310,6 @@ Before planning, discover:
             "then create a detailed implementation plan for this issue."
         )
 
-        # Add output instruction with resolved plan path
         # IMPORTANT: Explicitly require writing to file - without this,
         # the LLM may just output the plan as text instead of writing to the file.
         plan_path = resolve_plan_path(profile.plan_path_pattern, state.issue.id)
@@ -335,7 +328,6 @@ Before planning, discover:
             "The workflow will fail if you don't create the plan file."
         )
 
-        # Task-specific formatting templates
         parts.append("""
 ## Plan Document Header
 

--- a/amelia/agents/developer.py
+++ b/amelia/agents/developer.py
@@ -155,7 +155,6 @@ class Developer:
                 event = message.to_workflow_event(workflow_id=workflow_id, agent="developer")
 
             elif message.type == AgenticMessageType.RESULT:
-                # Update session_id from result message
                 if message.session_id:
                     session_id = message.session_id
 
@@ -233,10 +232,8 @@ IMPLEMENTATION PLAN:
                 parts.append(f"Executing Task 1 of {total}:\n\n")
             parts.append(task_section)
 
-        # Main task
         parts.append(f"\n\nPlease complete the following task:\n\n{state.goal}")
 
-        # Review feedback (if this is a review-fix iteration)
         rejected_comments = collect_rejected_comments(state.last_reviews)
         if rejected_comments:
             feedback = "\n".join(f"- {c}" for c in rejected_comments)

--- a/amelia/agents/evaluator.py
+++ b/amelia/agents/evaluator.py
@@ -173,7 +173,6 @@ Provide clear evidence for each disposition decision."""
         """
         parts: list[str] = []
 
-        # Task context (if available)
         if state.goal:
             parts.append(f"## Current Task\n\n{state.goal}")
         elif state.issue:
@@ -185,7 +184,6 @@ Provide clear evidence for each disposition decision."""
             if issue_parts:
                 parts.append("## Issue Context\n\n" + "\n\n".join(issue_parts))
 
-        # Review feedback to evaluate — aggregate comments from all reviews
         if not state.last_reviews:
             raise ValueError("No review feedback found in state")
 
@@ -256,7 +254,6 @@ You MUST call `submit_evaluation` exactly once with all items.""")
         if not state.last_reviews:
             raise ValueError("ImplementationState must have last_reviews set for evaluation")
 
-        # Handle empty review comments — aggregate from all reviews
         all_comments = collect_all_comments(state.last_reviews)
         if not all_comments:
             logger.warning(
@@ -286,7 +283,6 @@ You MUST call `submit_evaluation` exactly once with all items.""")
             )
             return result, None
 
-        # Build prompt and call driver
         prompt = self._build_prompt(state)
 
         logger.debug(
@@ -318,7 +314,6 @@ You MUST call `submit_evaluation` exactly once with all items.""")
             on_call=_on_submit,
         )
 
-        # Execute agentic evaluation with submit_evaluation tool (per D-05, D-06)
         new_session_id: str | None = None
         stream_result_input: Any | None = None  # fallback for drivers/tests that don't invoke on_call
         driver_error: str | None = None
@@ -368,7 +363,6 @@ You MUST call `submit_evaluation` exactly once with all items.""")
                 "submit_evaluation must cover every review item exactly once"
             )
 
-        # Partition items by disposition
         items_to_implement: list[EvaluatedItem] = []
         items_rejected: list[EvaluatedItem] = []
         items_deferred: list[EvaluatedItem] = []
@@ -393,7 +387,6 @@ You MUST call `submit_evaluation` exactly once with all items.""")
             needs_clarification=len(items_needing_clarification),
         )
 
-        # Emit completion event
         if self._event_bus is not None:
             summary_parts = []
             if items_to_implement:

--- a/amelia/agents/oracle.py
+++ b/amelia/agents/oracle.py
@@ -126,7 +126,6 @@ class Oracle:
             working_dir=working_dir,
         )
 
-        # Emit started event
         self._emit(self._make_event(
             EventType.ORACLE_CONSULTATION_STARTED,
             session_id=session_id,
@@ -134,7 +133,6 @@ class Oracle:
             workflow_id=workflow_id,
         ))
 
-        # Gather codebase context only when file patterns are specified
         files_consulted: list[str] = []
         bundle_tokens = 0
         bundle = None
@@ -176,7 +174,6 @@ class Oracle:
                 session_id=session_id,
             )
 
-        # Build prompt with context
         context_parts: list[str] = [f"## Problem\n\n{problem}"]
         if bundle and bundle.files:
             context_parts.append("\n## Codebase Context\n")

--- a/amelia/agents/prompts/defaults.py
+++ b/amelia/agents/prompts/defaults.py
@@ -1,4 +1,3 @@
-# amelia/agents/prompts/defaults.py
 """Hardcoded default prompts for all agents.
 
 These serve as:

--- a/amelia/agents/prompts/models.py
+++ b/amelia/agents/prompts/models.py
@@ -1,4 +1,3 @@
-# amelia/agents/prompts/models.py
 """Pydantic models for prompt configuration.
 
 Provides data models for prompts, versions, and resolution results.

--- a/amelia/agents/prompts/resolver.py
+++ b/amelia/agents/prompts/resolver.py
@@ -1,4 +1,3 @@
-# amelia/agents/prompts/resolver.py
 """Prompt resolution for agents.
 
 Provides the PromptResolver that returns current prompt content,

--- a/amelia/agents/reviewer.py
+++ b/amelia/agents/reviewer.py
@@ -270,7 +270,6 @@ class Reviewer:
             Tuple of (ReviewResult, session_id from driver).
 
         """
-        # Build the task prompt using shared helper
         task_context = self._extract_task_context(state) or "Review the code changes."
 
         if diff_path:
@@ -289,7 +288,6 @@ The changes are against commit: {base_commit}"""
 
 The changes are in git - diff against commit: {base_commit}"""
 
-        # Build system prompt with base_commit, review_guidelines, and diff_path
         system_prompt = self.agentic_prompt.format(
             base_commit=base_commit,
             review_guidelines=self._review_guidelines,
@@ -351,7 +349,6 @@ The changes are in git - diff against commit: {base_commit}"""
                 instructions=system_prompt,
                 submit_tools=[submit_tool],
             ):
-                # Emit stream events for visibility using to_workflow_event()
                 if self._event_bus is not None and msg.type != AgenticMessageType.RESULT:
                     event = msg.to_workflow_event(workflow_id=workflow_id, agent=self._agent_name)
                     self._event_bus.emit(event)
@@ -374,7 +371,6 @@ The changes are in git - diff against commit: {base_commit}"""
                             workflow_id=workflow_id,
                         )
 
-                # Capture final result from RESULT message
                 if msg.type == AgenticMessageType.RESULT:
                     attempt_session_id = msg.session_id
                     attempt_result = msg.content
@@ -423,7 +419,6 @@ The changes are in git - diff against commit: {base_commit}"""
             severity_str = None
 
         if severity_str is not None:
-            # Validate severity
             try:
                 severity = Severity(severity_str)
             except ValueError:
@@ -475,7 +470,6 @@ The changes are in git - diff against commit: {base_commit}"""
                 severity=Severity.MAJOR if result.severity in (Severity.NONE, Severity.MINOR) else result.severity,
             )
 
-        # Emit completion event
         self._emit_review_completion(
             workflow_id,
             result.approved,
@@ -551,12 +545,10 @@ The changes are in git - diff against commit: {base_commit}"""
             re.MULTILINE,
         )
 
-        # Determine current section by tracking headers
         current_severity: str | None = None
         for line in output.split("\n"):
             line_stripped = line.strip().lower()
 
-            # Detect severity section headers
             if "### critical" in line_stripped or "critical (blocking)" in line_stripped:
                 current_severity = "critical"
             elif "### major" in line_stripped or "major (should fix)" in line_stripped:
@@ -568,7 +560,6 @@ The changes are in git - diff against commit: {base_commit}"""
             elif line_stripped.startswith("## verdict"):
                 current_severity = None
 
-            # Match issues in current section
             if current_severity:
                 issue_match = issue_pattern.match(line)
                 if issue_match:
@@ -580,7 +571,6 @@ The changes are in git - diff against commit: {base_commit}"""
                         issue_text = f"[{current_severity}] {title}"
                     issues.append((current_severity, issue_text))
 
-        # Decide approval based on verdict match or fallback heuristic
         if verdict_match:
             verdict_text = verdict_match.group(1).lower()
             approved = verdict_text == "yes"
@@ -610,7 +600,6 @@ The changes are in git - diff against commit: {base_commit}"""
                 workflow_id=workflow_id,
             )
 
-        # Determine overall severity from highest issue severity
         severity_priority = {"critical": 3, "major": 2, "minor": 1}
         if issues:
             max_severity_value = max(severity_priority.get(sev, 0) for sev, _ in issues)
@@ -624,7 +613,6 @@ The changes are in git - diff against commit: {base_commit}"""
         else:
             overall_severity = Severity.NONE if approved else Severity.MINOR
 
-        # Extract just the issue text for comments
         comments = [issue_text for _, issue_text in issues]
 
         if not comments and not approved:

--- a/amelia/cli/config.py
+++ b/amelia/cli/config.py
@@ -172,11 +172,6 @@ def _build_default_agents(
     }
 
 
-# =============================================================================
-# Profile Commands
-# =============================================================================
-
-
 @profile_app.command("list")
 def profile_list() -> None:
     """List all profiles."""
@@ -200,7 +195,6 @@ def profile_list() -> None:
             table.add_column("Agents", style="yellow")
 
             for profile in profiles:
-                # Get driver/model from first agent for display
                 display_driver: str = "-"
                 display_model: str = "-"
                 if profile.agents:
@@ -247,7 +241,6 @@ def profile_show(
 
             console.print(table)
 
-            # Show agents table
             if profile.agents:
                 agents_table = Table(title="Agent Configurations")
                 agents_table.add_column("Agent", style="cyan")
@@ -312,7 +305,6 @@ def profile_create(
     If options are not provided, prompts interactively.
     Creates default agent configurations using the specified driver and model.
     """
-    # Interactive prompts if options not provided
     if driver is None:
         driver = typer.prompt(
             "Driver",
@@ -373,7 +365,6 @@ def profile_create(
     async def _run() -> None:
         db, repo = await _get_profile_repository()
         try:
-            # Check if profile already exists
             existing = await repo.get_profile(name)
             if existing:
                 console.print(f"[red]Profile '{name}' already exists.[/red]")
@@ -383,11 +374,9 @@ def profile_create(
             if driver is None or model is None or tracker is None or repo_root is None:
                 raise ValueError("All profile options must be provided")
 
-            # Validate and cast to proper types
             validated_driver = _validate_driver(driver)
             validated_tracker = _validate_tracker(tracker)
 
-            # Build default agents configuration
             agents = _build_default_agents(validated_driver, model, agent_options)
 
             profile = Profile(
@@ -458,11 +447,6 @@ def profile_activate(
     asyncio.run(_run())
 
 
-# =============================================================================
-# First-Run Setup
-# =============================================================================
-
-
 async def check_and_run_first_time_setup() -> bool:
     """Check if this is first run and prompt for profile creation.
 
@@ -488,11 +472,9 @@ async def check_and_run_first_time_setup() -> bool:
         tracker = typer.prompt("Tracker (noop, github, jira)", default="noop")
         repo_root = typer.prompt("Repository root", default=str(Path.cwd()))
 
-        # Validate driver and tracker
         validated_driver = _validate_driver(driver_input)
         validated_tracker = _validate_tracker(tracker)
 
-        # Build default agents configuration
         agents = _build_default_agents(validated_driver, model)
 
         profile = Profile(
@@ -518,11 +500,6 @@ def run_first_time_setup() -> bool:
         True if setup completed or not needed, False if user cancelled.
     """
     return asyncio.run(check_and_run_first_time_setup())
-
-
-# =============================================================================
-# Server Settings Commands
-# =============================================================================
 
 
 @server_app.command("show")
@@ -574,7 +551,6 @@ def server_set(
     - workflow_start_timeout_seconds (float)
     - max_concurrent (int)
     """
-    # Convert value to appropriate type
     int_fields = {
         "log_retention_days",
         "checkpoint_retention_days",

--- a/amelia/client/cli.py
+++ b/amelia/client/cli.py
@@ -138,12 +138,10 @@ def start_command(
         stream: If True, stream workflow events to terminal until completion.
         branch: Branch override. None=auto-create, empty=use current.
     """
-    # Validate --description requires --title
     if description and not title:
         console.print("[red]Error:[/red] --description requires --title to be set")
         raise typer.Exit(1)
 
-    # Validate --plan requires --queue
     if plan and not queue:
         console.print("[red]Error:[/red] --plan requires --queue flag")
         raise typer.Exit(1)
@@ -204,18 +202,15 @@ def reject_command(
     Args:
         reason: Detailed reason for rejecting the plan to guide replanning.
     """
-    # Detect worktree context
     try:
         worktree_path, _ = get_worktree_context()
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
 
-    # Find workflow in this worktree
     client = AmeliaClient()
 
     async def _reject() -> str:
-        # Get workflows for this worktree
         result = await client.get_active_workflows(worktree_path=worktree_path)
 
         if not result.workflows:
@@ -225,7 +220,6 @@ def reject_command(
 
         workflow = result.workflows[0]
 
-        # Reject it
         try:
             await client.reject_workflow(workflow_id=workflow.id, reason=reason)
             console.print(f"[yellow]✗[/yellow] Plan rejected for workflow [bold]{workflow.id}[/bold]")
@@ -261,18 +255,15 @@ def approve_command(
     Auto-detects the active workflow from the current git worktree context
     and approves the pending plan, allowing execution to continue.
     """
-    # Detect worktree context
     try:
         worktree_path, _ = get_worktree_context()
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
 
-    # Find workflow in this worktree
     client = AmeliaClient()
 
     async def _approve() -> str:
-        # Get workflows for this worktree
         result = await client.get_active_workflows(worktree_path=worktree_path)
 
         if not result.workflows:
@@ -282,7 +273,6 @@ def approve_command(
 
         workflow = result.workflows[0]
 
-        # Approve it
         try:
             await client.approve_workflow(workflow_id=workflow.id)
             console.print(f"[green]✓[/green] Plan approved for workflow [bold]{workflow.id}[/bold]")
@@ -332,7 +322,6 @@ def status_command(
             console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1) from None
 
-    # Get workflows via API
     client = AmeliaClient()
 
     async def _status() -> None:
@@ -346,7 +335,6 @@ def status_command(
                 console.print("\n[yellow]Start a workflow:[/yellow] amelia start ISSUE-123")
             return
 
-        # Display workflows in a table
         table = Table(title="Active Workflows", show_header=True)
         table.add_column("Workflow ID", style="cyan", no_wrap=True)
         table.add_column("Issue", style="magenta")
@@ -388,14 +376,12 @@ def cancel_command(
     Args:
         force: If True, skip the confirmation prompt.
     """
-    # Detect worktree context
     try:
         worktree_path, _ = get_worktree_context()
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
 
-    # Find workflow in this worktree
     client = AmeliaClient()
 
     async def _get_workflow() -> WorkflowSummary:
@@ -483,12 +469,10 @@ async def _get_profile_from_server(profile_name: str | None) -> Profile:
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             if profile_name:
-                # Get specific profile
                 response = await client.get(f"{base_url}/api/profiles/{profile_name}")
                 if response.status_code == 404:
                     raise ValueError(f"Profile '{profile_name}' not found")
             else:
-                # Get active profile via config endpoint
                 response = await client.get(f"{base_url}/api/config")
                 if response.status_code != 200:
                     raise ValueError("Failed to get server config")
@@ -496,15 +480,12 @@ async def _get_profile_from_server(profile_name: str | None) -> Profile:
                 active_profile_id = config_data.get("active_profile")
                 if not active_profile_id:
                     raise ValueError("No active profile set. Create one via the dashboard.")
-                # Now get the full profile
                 response = await client.get(f"{base_url}/api/profiles/{active_profile_id}")
 
             if response.status_code != 200:
                 raise ValueError(f"Failed to get profile: {response.text}")
 
             data = response.json()
-            # Convert API response to Profile type
-            # Parse agents dict from API response
             from amelia.core.types import AgentConfig  # noqa: PLC0415
 
             agents: dict[str, AgentConfig] = {}
@@ -557,7 +538,6 @@ def plan_command(
         title: Optional task title for none tracker (bypasses issue lookup).
         description: Optional task description (requires --title to be set).
     """
-    # Validate --description requires --title
     if description and not title:
         console.print("[red]Error:[/red] --description requires --title to be set")
         raise typer.Exit(1)
@@ -565,10 +545,8 @@ def plan_command(
     worktree_path, _ = _get_worktree_context()
 
     async def _generate_plan() -> ImplementationState:
-        # Get profile from server
         profile = await _get_profile_from_server(profile_name)
 
-        # Update profile with worktree path
         profile = profile.model_copy(update={"repo_root": worktree_path})
 
         # Get issue: construct directly if title provided with noop tracker, else use tracker
@@ -584,11 +562,9 @@ def plan_command(
                 f"--title requires noop tracker, but profile uses '{profile.tracker}'"
             )
         else:
-            # Fetch issue using tracker
             tracker = create_tracker(profile)
             issue = tracker.get_issue(issue_id, cwd=worktree_path)
 
-        # Create minimal implementation state
         from datetime import UTC, datetime  # noqa: PLC0415
 
         state = ImplementationState(
@@ -599,7 +575,6 @@ def plan_command(
             issue=issue,
         )
 
-        # Create architect with agent config
         agent_config = profile.get_agent_config("architect")
         architect = Architect(agent_config)
 
@@ -621,7 +596,6 @@ def plan_command(
         console.print("\n[green]✓[/green] Plan generated successfully!")
         console.print(f"  Saved to: [bold]{final_state.plan_path}[/bold]\n")
 
-        # Show preview of the plan
         if final_state.plan_path and Path(final_state.plan_path).exists():
             plan_lines = Path(final_state.plan_path).read_text().splitlines()[:30]
             console.print("\n".join(plan_lines))
@@ -659,7 +633,6 @@ def run_command(
     client = AmeliaClient()
 
     if workflow_id:
-        # Start specific workflow
         async def _start_one() -> dict[str, str]:
             return await client.start_workflow(workflow_id)
 
@@ -679,7 +652,6 @@ def run_command(
             raise typer.Exit(1) from None
 
     else:
-        # Batch start
         async def _start_batch() -> BatchStartResponse:
             return await client.start_batch(
                 workflow_ids=None,

--- a/amelia/client/git.py
+++ b/amelia/client/git.py
@@ -30,7 +30,6 @@ def get_worktree_context() -> tuple[str, str]:
         >>> get_worktree_context()
         ('/home/user/myproject', 'detached-abc1234')
     """
-    # Check if we're in a git repo at all
     result = subprocess.run(
         ["git", "rev-parse", "--is-inside-work-tree"],
         capture_output=True,
@@ -58,7 +57,6 @@ def get_worktree_context() -> tuple[str, str]:
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to determine worktree root: {e.stderr}") from e
 
-    # Get branch name for display
     try:
         branch = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],

--- a/amelia/client/streaming.py
+++ b/amelia/client/streaming.py
@@ -200,7 +200,6 @@ async def stream_workflow_events(
 
                 event_type = event.get("event_type")
 
-                # Collect summary data from stage_completed events
                 if event_type == "stage_completed":
                     event_data = event.get("data", {}) or {}
                     result = event_data.get("result", {}) or {}
@@ -212,12 +211,10 @@ async def stream_workflow_events(
                     elif status == "failed":
                         failed += 1
 
-                # Collect commit SHA from workflow_completed
                 if event_type == "workflow_completed":
                     event_data = event.get("data", {}) or {}
                     commit_sha = event_data.get("commit_sha") or None
 
-                # Collect commit SHA from pr_auto_fix_completed
                 if event_type == "pr_auto_fix_completed":
                     event_data = event.get("data", {}) or {}
                     commit_sha = event_data.get("commit_sha") or None
@@ -255,7 +252,6 @@ def _display_event(console: Console, event: dict[str, Any]) -> None:
         _CUSTOM_FORMATTERS[event_type](console, event)
         return
 
-    # Check for simple format configurations
     if event_type in _SIMPLE_EVENT_FORMATS:
         fmt = _SIMPLE_EVENT_FORMATS[event_type]
         text = fmt.prefix + (message if fmt.include_message else "")
@@ -263,5 +259,4 @@ def _display_event(console: Console, event: dict[str, Any]) -> None:
         console.print(f"{newline}[{fmt.style}]{text}[/{fmt.style}]")
         return
 
-    # Default: show other events with less emphasis
     console.print(f"[dim]{event_type}: {message}[/dim]")

--- a/amelia/core/agentic_state.py
+++ b/amelia/core/agentic_state.py
@@ -86,14 +86,11 @@ class AgenticState(BaseModel):
     goal: str
     system_prompt: str | None = None
 
-    # Tool execution history
     tool_calls: tuple[ToolCall, ...] = ()
     tool_results: tuple[ToolResult, ...] = ()
 
-    # Completion state
     final_response: str | None = None
     status: AgenticStatus = AgenticStatus.RUNNING
     error: str | None = None
 
-    # Session continuity
     session_id: uuid.UUID | None = None

--- a/amelia/core/constants.py
+++ b/amelia/core/constants.py
@@ -1,4 +1,3 @@
-# amelia/core/constants.py
 """Constants used across the Amelia codebase."""
 
 from datetime import date

--- a/amelia/core/exceptions.py
+++ b/amelia/core/exceptions.py
@@ -1,4 +1,3 @@
-# amelia/core/exceptions.py
 """Custom exceptions for Amelia."""
 
 

--- a/amelia/core/text.py
+++ b/amelia/core/text.py
@@ -21,14 +21,10 @@ def slugify(text: str, max_length: int = 15) -> str:
         raise ValueError(f"max_length must be >= 0, got {max_length}")
     if max_length == 0:
         return ""
-    # Lowercase and replace non-alphanumeric with dashes
     slug = re.sub(r"[^a-z0-9]+", "-", text.lower())
-    # Strip leading/trailing dashes
     slug = slug.strip("-")
-    # Truncate at dash boundary if possible
     if len(slug) > max_length:
         truncated = slug[:max_length]
-        # Try to break at last dash within limit
         # Break at last dash to avoid trailing dash and mid-word cuts
         last_dash = truncated.rfind("-")
         slug = truncated[:last_dash] if last_dash > 0 else truncated

--- a/amelia/core/types.py
+++ b/amelia/core/types.py
@@ -21,7 +21,6 @@ from pydantic import (
 )
 
 
-# Default allowed hosts for sandbox network allowlist
 DEFAULT_NETWORK_ALLOWED_HOSTS: tuple[str, ...] = (
     "api.anthropic.com",
     "openrouter.ai",

--- a/amelia/core/utils.py
+++ b/amelia/core/utils.py
@@ -2,7 +2,6 @@
 import re
 
 
-# ANSI escape code pattern
 # Matches:
 # - CSI sequences: \x1b[<params><command> (e.g., \x1b[31m for red, \x1b[2K for clear line)
 # - OSC sequences: \x1b]<params>\x07 (e.g., \x1b]0;Title\x07 for terminal title)

--- a/amelia/drivers/api/chat_model.py
+++ b/amelia/drivers/api/chat_model.py
@@ -67,7 +67,6 @@ def _is_model_provider_error(exc: ValueError) -> bool:
     # langchain_openai pattern: ValueError({"error": {...}, "provider": "..."})
     if exc.args and isinstance(exc.args[0], dict):
         return True
-    # String-based detection for known provider error patterns
     msg = str(exc).lower()
     return any(pattern in msg for pattern in _get_provider_error_patterns())
 

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -270,7 +270,6 @@ class ApiDriver(DriverInterface):
             # Use FilesystemBackend for non-agentic generation - no shell execution needed
             backend = FilesystemBackend(root_dir=self.cwd or ".", virtual_mode=False)
 
-            # Configure structured output via ToolStrategy when schema is provided
             agent_kwargs: dict[str, Any] = {
                 "model": chat_model,
                 "system_prompt": system_prompt or "",
@@ -283,7 +282,6 @@ class ApiDriver(DriverInterface):
 
             result = await agent.ainvoke({"messages": [HumanMessage(content=prompt)]})
 
-            # If schema is provided, extract from structured_response
             output: Any
             if schema:
                 structured_response = result.get("structured_response")
@@ -294,7 +292,6 @@ class ApiDriver(DriverInterface):
                         schema=schema.__name__,
                     )
                 else:
-                    # Log diagnostic info for debugging structured output failures
                     messages = result.get("messages", [])
                     last_msg_type = type(messages[-1]).__name__ if messages else "None"
                     logger.warning(
@@ -311,7 +308,6 @@ class ApiDriver(DriverInterface):
                         original_message=f"Last message type: {last_msg_type}",
                     )
             else:
-                # No schema - extract text from messages
                 messages = result.get("messages", [])
                 if not messages:
                     raise RuntimeError("No response messages from agent")
@@ -404,7 +400,6 @@ class ApiDriver(DriverInterface):
                 "Use ClaudeCliDriver for tool-restricted execution."
             )
 
-        # Extract optional parameters from kwargs
         tools: list[Any] | None = kwargs.get("tools")
         middleware: list[AgentMiddleware] | None = kwargs.get("middleware")
         required_tool: str | None = kwargs.get("required_tool")
@@ -434,7 +429,6 @@ class ApiDriver(DriverInterface):
             if required_tool is None and lc_submit_tools:
                 required_tool = submit_tools[0].name
 
-        # Initialize usage tracking
         start_time = time.perf_counter()
         total_input = 0
         total_output = 0
@@ -485,7 +479,6 @@ class ApiDriver(DriverInterface):
                         session_id=current_session_id,
                     )
 
-            # Use session_id as thread_id for checkpointing
             thread_id = current_session_id
 
             # LLM APIs are stateless - always pass system prompt with every request
@@ -510,15 +503,13 @@ class ApiDriver(DriverInterface):
             )
 
             last_message: AIMessage | None = None
-            tool_call_count = 0  # DEBUG: Track tool calls
-            last_write_todos_input: dict[str, Any] | None = None  # Track incomplete tasks
-            all_tool_names: list[str] = []  # Track all tool calls for debugging
+            tool_call_count = 0
+            last_write_todos_input: dict[str, Any] | None = None
+            all_tool_names: list[str] = []
             continuation_count = 0
 
-            # Config for checkpointing
             config = {"configurable": {"thread_id": thread_id}}
 
-            # Initial message
             current_input: dict[str, Any] = {"messages": [HumanMessage(content=prompt)]}
 
             # Continuation loop - keeps going until required file is created or max attempts
@@ -543,7 +534,6 @@ class ApiDriver(DriverInterface):
                             seen_message_ids.add(msg_id)
                             num_turns += 1
 
-                            # Extract token usage from usage_metadata
                             usage_meta = getattr(message, "usage_metadata", None)
                             if usage_meta:
                                 total_input += usage_meta.get("input_tokens", 0)
@@ -592,7 +582,6 @@ class ApiDriver(DriverInterface):
                                     )
                                     log_claude_result(result_type="assistant", content=thinking_text)
 
-                        # Tool calls
                         for tool_call in message.tool_calls or []:
                             tool_raw_name = tool_call["name"]
                             # Normalize tool name to standard format
@@ -627,7 +616,6 @@ class ApiDriver(DriverInterface):
                             log_claude_result(result_type="tool_use", tool_name=tool_normalized, tool_input=tool_args)
 
                     elif isinstance(message, ToolMessage):
-                        # Normalize tool name to standard format
                         result_raw_name = message.name
                         result_normalized: str | None = (
                             normalize_tool_name(result_raw_name)
@@ -643,16 +631,13 @@ class ApiDriver(DriverInterface):
                             model=self.model,
                         )
 
-                # After inner loop: check if we need to continue
                 needs_continuation = False
                 continuation_reason = ""
 
-                # Check if required tool was called
                 if required_tool and required_tool not in all_tool_names:
                     needs_continuation = True
                     continuation_reason = "required tool not called"
 
-                # If required_file_path is specified, verify file exists with content
                 if required_file_path and not needs_continuation:
                     file_path = backend.cwd / required_file_path
                     if not file_path.exists():
@@ -675,7 +660,6 @@ class ApiDriver(DriverInterface):
                         )
                         break
 
-                    # Extract agent's final response for debugging
                     agent_response = _extract_text_content(last_message.content) if last_message else ""
 
                     response_preview = agent_response[:500] if agent_response else "EMPTY"
@@ -699,7 +683,6 @@ class ApiDriver(DriverInterface):
                 else:
                     break  # Done - required tool was called and file exists
 
-            # Store accumulated usage before yielding result
             duration_ms = int((time.perf_counter() - start_time) * 1000)
             self._usage = DriverUsage(
                 input_tokens=total_input if total_input > 0 else None,
@@ -710,8 +693,6 @@ class ApiDriver(DriverInterface):
                 model=self.model,
             )
 
-            # Final result from last AI message
-            # Check for incomplete tasks in write_todos
             incomplete_tasks: list[str] = []
             if last_write_todos_input:
                 todos = last_write_todos_input.get("todos", [])
@@ -719,7 +700,6 @@ class ApiDriver(DriverInterface):
                     if isinstance(todo, dict) and todo.get("status") == "in_progress":
                         incomplete_tasks.append(todo.get("content", "unknown task"))
 
-            # Log comprehensive summary
             logger.info(
                 "API driver execution complete",
                 total_tool_calls=tool_call_count,
@@ -729,7 +709,6 @@ class ApiDriver(DriverInterface):
                 incomplete_tasks_count=len(incomplete_tasks),
             )
 
-            # Warn if agent terminated with incomplete tasks
             if incomplete_tasks:
                 logger.warning(
                     "Agent terminated with in_progress tasks - possible premature termination",
@@ -750,7 +729,6 @@ class ApiDriver(DriverInterface):
             if last_message:
                 final_content = _extract_text_content(last_message.content)
 
-                # Log the model's final response to understand why it stopped
                 preview = final_content[:500] if final_content else "EMPTY"
                 logger.info(
                     "Agent final response",

--- a/amelia/drivers/cli/claude.py
+++ b/amelia/drivers/cli/claude.py
@@ -139,7 +139,6 @@ def _is_clarification_request(text: str) -> bool:
     """
     text_lower = text.lower()
 
-    # Check for clarification phrases
     if any(phrase in text_lower for phrase in _CLARIFICATION_PHRASES):
         return True
 
@@ -342,12 +341,10 @@ class ClaudeCliDriver(DriverInterface):
         Returns:
             Configured ClaudeAgentOptions instance.
         """
-        # Determine permission mode
         permission_mode: Literal["default", "acceptEdits", "plan", "bypassPermissions"] | None = None
         if bypass_permissions or self.skip_permissions:
             permission_mode = "bypassPermissions"
 
-        # Build output format for schema if provided
         # Note: SDK expects "schema" key, not "json_schema"
         output_format = None
         if schema:
@@ -366,7 +363,6 @@ class ClaudeCliDriver(DriverInterface):
             # Resuming: use preset without append to skip --system-prompt flag
             effective_system_prompt = SystemPromptPreset(type="preset", preset="claude_code")
 
-        # Map canonical tool names to CLI SDK names
         cli_allowed_tools: list[str] | None = None
         if allowed_tools is not None:
             cli_allowed_tools = []
@@ -436,7 +432,6 @@ class ClaudeCliDriver(DriverInterface):
         options.stderr = lambda line: stderr_lines.append(line)
 
         try:
-            # Collect all messages
             result_message: ResultMessage | None = None
             assistant_content: list[str] = []
 
@@ -475,7 +470,6 @@ class ClaudeCliDriver(DriverInterface):
             if result_message.is_error:
                 raise RuntimeError(f"Claude SDK reported error: {result_message.result}")
 
-            # Handle structured output
             if schema:
                 # Try structured_output first (preferred for schema requests)
                 if result_message.structured_output is not None:
@@ -524,7 +518,6 @@ class ClaudeCliDriver(DriverInterface):
                         original_message=str(e),
                     ) from e
             else:
-                # Return raw text result
                 if result_message.result:
                     return (result_message.result, session_id_result)
                 elif assistant_content:
@@ -670,10 +663,8 @@ class ClaudeCliDriver(DriverInterface):
                                     model=self.model,
                                 )
                             elif isinstance(block, ToolUseBlock):
-                                # Track tool calls in history
                                 self.tool_call_history.append(block)
                                 last_tool_name = block.name
-                                # Normalize tool name to standard format
                                 normalized_name = normalize_tool_name(block.name)
                                 yield AgenticMessage(
                                     type=AgenticMessageType.TOOL_CALL,
@@ -684,7 +675,6 @@ class ClaudeCliDriver(DriverInterface):
                                 )
                             elif isinstance(block, ToolResultBlock):
                                 content = block.content if isinstance(block.content, str) else str(block.content)
-                                # Normalize tool name to standard format
                                 result_tool_name: str | None = None
                                 if last_tool_name:
                                     result_tool_name = normalize_tool_name(last_tool_name)
@@ -703,7 +693,6 @@ class ClaudeCliDriver(DriverInterface):
                             for block in message.content:
                                 if isinstance(block, ToolResultBlock):
                                     content = block.content if isinstance(block.content, str) else str(block.content)
-                                    # Normalize tool name to standard format
                                     result_tool_name = None
                                     if last_tool_name:
                                         result_tool_name = normalize_tool_name(last_tool_name)

--- a/amelia/drivers/cli/codex.py
+++ b/amelia/drivers/cli/codex.py
@@ -222,7 +222,7 @@ class CodexCliDriver(DriverInterface):
                         line=line,
                         error=str(e),
                     )
-                    continue  # skip malformed lines
+                    continue
                 except ValidationError as e:
                     logger.debug(
                         "Skipping invalid codex stream event",
@@ -306,7 +306,7 @@ class CodexCliDriver(DriverInterface):
                     except json.JSONDecodeError:
                         continue
                     if isinstance(obj, dict) and obj.get("type") in _LIFECYCLE_EVENT_TYPES:
-                        continue  # skip turn.completed, etc.
+                        continue
                     return obj
                 # All parseable lines were lifecycle events — return the last one
                 # and let the caller deal with validation.
@@ -382,10 +382,8 @@ class CodexCliDriver(DriverInterface):
         else:
             data = parsed
 
-        # Validate against schema if provided
         if schema:
             try:
-                # If data is a string, parse it as JSON first
                 if isinstance(data, str):
                     data = json.loads(data)
 
@@ -421,7 +419,6 @@ class CodexCliDriver(DriverInterface):
                     original_message=str(data)[:500],
                 ) from e
 
-        # For non-schema case, convert to string if needed
         text = json.dumps(data) if not isinstance(data, str) else data
         return (text, None)
 
@@ -471,7 +468,6 @@ class CodexCliDriver(DriverInterface):
 
         captured_thread_id: str | None = None
 
-        # Use streaming mode - iterate asynchronously
         # Update self._usage incrementally after each turn.completed event
         # so usage data is available even if the consumer breaks early or
         # an exception interrupts streaming.

--- a/amelia/drivers/cli/utils.py
+++ b/amelia/drivers/cli/utils.py
@@ -16,13 +16,10 @@ def strip_markdown_fences(text: str) -> str:
     """
     stripped = text.strip()
 
-    # Check for fenced code block pattern
     if stripped.startswith("```"):
         lines = stripped.split("\n")
 
-        # Find the opening fence (first line starting with ```)
         if lines and lines[0].startswith("```"):
-            # Find the closing fence
             end_idx = -1
             for i in range(len(lines) - 1, 0, -1):
                 if lines[i].strip() == "```":
@@ -30,7 +27,6 @@ def strip_markdown_fences(text: str) -> str:
                     break
 
             if end_idx > 0:
-                # Extract content between fences
                 content_lines = lines[1:end_idx]
                 return "\n".join(content_lines).strip()
 

--- a/amelia/knowledge/embeddings.py
+++ b/amelia/knowledge/embeddings.py
@@ -8,7 +8,6 @@ import httpx
 from loguru import logger
 
 
-# Constants
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/embeddings"
 EMBEDDING_BATCH_SIZE = 100
 EMBEDDING_MAX_PARALLEL = 3
@@ -86,7 +85,6 @@ class EmbeddingClient:
         if not texts:
             return []
 
-        # Split into batches
         batches = [
             texts[i : i + EMBEDDING_BATCH_SIZE]
             for i in range(0, len(texts), EMBEDDING_BATCH_SIZE)
@@ -99,7 +97,6 @@ class EmbeddingClient:
             batch_size=EMBEDDING_BATCH_SIZE,
         )
 
-        # Process batches in parallel with concurrency limit
         semaphore = asyncio.Semaphore(EMBEDDING_MAX_PARALLEL)
         processed_count = 0
         lock = asyncio.Lock()
@@ -147,7 +144,6 @@ class EmbeddingClient:
                 try:
                     embeddings = await self._call_api(texts)
 
-                    # Report progress
                     if on_complete:
                         await on_complete(len(texts))
 

--- a/amelia/knowledge/ingestion.py
+++ b/amelia/knowledge/ingestion.py
@@ -23,7 +23,6 @@ class IngestionError(Exception):
         super().__init__(user_message, *args)
 
 
-# Supported MIME types
 _SUPPORTED_TYPES = {"application/pdf", "text/markdown"}
 
 # Max text length for tag extraction (~2000 tokens)
@@ -154,7 +153,6 @@ class IngestionPipeline:
                     chunk_texts, progress_callback=embed_progress
                 )
 
-                # Build ChunkData list
                 chunk_data: list[ChunkData] = []
                 total_tokens = 0
                 for i, ((chunk, text, n_tokens), embedding) in enumerate(
@@ -186,7 +184,6 @@ class IngestionPipeline:
                         driver_type=self.tag_derivation_driver,
                     )
 
-                    # Merge derived tags with existing user-provided tags
                     if derived_tags:
                         try:
                             existing_doc = await self.repository.get_document(document_id)
@@ -345,7 +342,6 @@ class IngestionPipeline:
         Returns:
             Tuple of (text_excerpt, unique_heading_paths).
         """
-        # Extract unique heading paths from chunks
         unique_headings: list[list[str]] = []
         seen_paths = set()
         for chunk in chunk_data:
@@ -354,7 +350,6 @@ class IngestionPipeline:
                 unique_headings.append(chunk["heading_path"])
                 seen_paths.add(path_tuple)
 
-        # Truncate text if needed
         text_excerpt = raw_text[:MAX_RAW_TEXT_FOR_TAGS]
         if len(raw_text) > MAX_RAW_TEXT_FOR_TAGS:
             text_excerpt += "\n\n[... content truncated for tag extraction ...]"
@@ -377,7 +372,6 @@ class IngestionPipeline:
         Returns:
             Prompt string for LLM tag extraction.
         """
-        # Format heading tree
         heading_tree = ""
         if heading_paths:
             for path in heading_paths:
@@ -417,14 +411,11 @@ Return 5-10 tags that best describe this document's content and purpose."""
         seen = set()
 
         for tag in tags:
-            # Strip whitespace and lowercase
             tag = tag.strip().lower()
 
-            # Skip empty or very long tags
             if not tag or len(tag) > 50:
                 continue
 
-            # Deduplicate (case-insensitive)
             if tag not in seen:
                 cleaned.append(tag)
                 seen.add(tag)
@@ -455,17 +446,14 @@ Return 5-10 tags that best describe this document's content and purpose."""
             Failures are logged but not raised - returns empty list on error.
         """
         try:
-            # Prepare input (truncate text, extract headings)
             text_excerpt, heading_paths = self._prepare_tag_extraction_input(
                 raw_text, chunk_data, document_name
             )
 
-            # Build prompt
             prompt = self._build_tag_extraction_prompt(
                 text_excerpt, heading_paths, document_name
             )
 
-            # Extract structured output using LLM
             from amelia.core.extraction import extract_structured  # noqa: PLC0415
             from amelia.knowledge.models import TagExtractionOutput  # noqa: PLC0415
 
@@ -476,7 +464,6 @@ Return 5-10 tags that best describe this document's content and purpose."""
                 driver_type=driver_type,
             )
 
-            # Validate and clean tags
             tags = self._validate_tags(result.tags)
 
             logger.info(

--- a/amelia/knowledge/search.py
+++ b/amelia/knowledge/search.py
@@ -39,7 +39,6 @@ async def knowledge_search(
         similarity_threshold=similarity_threshold,
     )
 
-    # Log similarity scores for debugging
     if results:
         similarities = [r.similarity for r in results]
         logger.info(

--- a/amelia/logging.py
+++ b/amelia/logging.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from loguru import Record
 
 
-# Dashboard color palette (from amelia-dashboard-dark.html)
 COLORS = {
     "gold": "#FFC857",  # Active, warnings, primary accent
     "sage_green": "#5B8A72",  # Success, completed
@@ -31,7 +30,6 @@ COLORS = {
     "sage_pending": "#4A5C54",  # Pending states
 }
 
-# ANSI reset code
 RESET = "\033[0m"
 
 
@@ -49,7 +47,6 @@ def _log_format(record: "Record") -> str:
     """
     level = record["level"].name
 
-    # Color mappings using loguru's color tag syntax
     level_colors = {
         "TRACE": f"<fg {COLORS['sage_pending']}>",
         "DEBUG": f"<fg {COLORS['sage_muted']}>",
@@ -77,10 +74,8 @@ def _log_format(record: "Record") -> str:
         f"<fg {COLORS['cream']}>{{message}}{close}"
     )
 
-    # Add structured fields if present
     extra = record["extra"]
     if extra:
-        # Format extra fields as key=value pairs
         extra_str = " ".join(f"{k}={v!r}" for k, v in extra.items())
         # Escape braces to prevent Loguru format string injection
         extra_str = extra_str.replace("{", "{{").replace("}", "}}")
@@ -88,7 +83,6 @@ def _log_format(record: "Record") -> str:
 
     fmt += "\n"
 
-    # Add exception formatting if present
     if record["exception"]:
         fmt += "{exception}\n"
 
@@ -107,10 +101,8 @@ def _plain_log_format(record: "Record") -> str:
     Returns:
         Plain formatted string without color codes.
     """
-    # Format: timestamp | level | module | message [extra]
     fmt = "{time:HH:mm:ss} │ {level: <8} │ {name}:{message}"
 
-    # Add structured fields if present
     extra = record["extra"]
     if extra:
         extra_str = " ".join(f"{k}={v!r}" for k, v in extra.items())
@@ -119,7 +111,6 @@ def _plain_log_format(record: "Record") -> str:
 
     fmt += "\n"
 
-    # Add exception formatting if present
     if record["exception"]:
         fmt += "{exception}\n"
 
@@ -135,14 +126,11 @@ def configure_logging(level: str = "INFO") -> None:
     Args:
         level: Minimum log level to display (e.g., "DEBUG", "INFO", "WARNING").
     """
-    # Remove default handler
     logger.remove()
 
-    # Detect if stderr is a TTY (terminal) or piped
     # When piped (e.g., under `amelia dev` subprocess), use plain format
     is_tty = sys.stderr.isatty()
 
-    # Add custom formatted handler with explicit flushing for piped output
     logger.add(
         sys.stderr,
         level=level,
@@ -165,7 +153,6 @@ def log_server_startup(host: str, port: int, database_url: str, version: str) ->
         database_url: PostgreSQL connection URL.
         version: Application version string.
     """
-    # Log configuration details with consistent styling
     gold = "\033[38;2;255;200;87m"
     sage = "\033[38;2;91;138;114m"
     blue = "\033[38;2;91;155;213m"
@@ -225,7 +212,6 @@ def log_claude_result(
         num_turns: Number of conversation turns from result events.
         cost_usd: Total cost in USD from result events.
     """
-    # ANSI color codes from palette
     gold = _ansi_color(COLORS["gold"])
     sage = _ansi_color(COLORS["sage_green"])
     blue = _ansi_color(COLORS["blue"])
@@ -234,27 +220,22 @@ def log_claude_result(
     cream = _ansi_color(COLORS["cream"])
     pending = _ansi_color(COLORS["sage_pending"])
 
-    # Box drawing character for visual structure
     vertical = "│"
 
     lines: list[str] = []
 
     if result_type == "assistant":
-        # Claude's thinking/response - use cream for main text
         header = f"{blue}◆ Claude{RESET}"
         lines.append(f"  {header}")
         if content:
-            # Wrap content at ~80 chars and indent
             for line in content.split("\n"):
                 wrapped = line[:120] + ("…" if len(line) > 120 else "")
                 lines.append(f"  {muted}{vertical}{RESET} {cream}{wrapped}{RESET}")
 
     elif result_type == "tool_use":
-        # Tool execution - use gold for emphasis
         header = f"{gold}⚡ Tool: {tool_name or 'unknown'}{RESET}"
         lines.append(f"  {header}")
         if tool_input:
-            # Pretty-print tool input with truncation
             try:
                 input_str = json.dumps(tool_input, indent=2)
                 input_lines = input_str.split("\n")
@@ -267,14 +248,12 @@ def log_claude_result(
                 lines.append(f"  {muted}{vertical}{RESET} {pending}{str(tool_input)[:200]}{RESET}")
 
     elif result_type == "result":
-        # Completion result - use sage green for success, rust for error
         is_success = subtype == "success"
         status_color = sage if is_success else rust
         status_icon = "✓" if is_success else "✗"
         header = f"{status_color}{status_icon} Result{RESET}"
         lines.append(f"  {header}")
 
-        # Stats line with duration, turns, and cost
         stats_parts = []
         if duration_ms is not None:
             duration_sec = duration_ms / 1000
@@ -294,14 +273,11 @@ def log_claude_result(
             )
             lines.append(f"  {muted}{vertical}{RESET} {stats}")
 
-        # Session ID (truncated)
         if session_id:
             short_session = session_id[:8] + "…" if len(session_id) > 8 else session_id
             lines.append(f"  {muted}{vertical}{RESET} {muted}session:{RESET} {blue}{short_session}{RESET}")
 
-        # Result text preview (first ~200 chars, first line only)
         if result_text:
-            # Get first non-empty line
             first_line = result_text.strip().split("\n")[0]
             total_lines = len(result_text.strip().split("\n"))
             preview = first_line[:200] + ("…" if len(first_line) > 200 else "")
@@ -310,21 +286,18 @@ def log_claude_result(
                 lines.append(f"  {muted}{vertical} ({total_lines} lines total){RESET}")
 
     elif result_type == "error":
-        # Error - use rust red
         header = f"{rust}✗ Error{RESET}"
         lines.append(f"  {header}")
         if content:
-            for line in content.split("\n")[:5]:  # Limit error lines
+            for line in content.split("\n")[:5]:
                 lines.append(f"  {muted}{vertical}{RESET} {rust}{line}{RESET}")
 
     elif result_type == "system":
-        # System message - use muted sage
         header = f"{muted}○ System{RESET}"
         lines.append(f"  {header}")
         if content:
             lines.append(f"  {muted}{vertical} {content}{RESET}")
 
-    # Output to stderr (same as loguru)
     if lines:
         sys.stderr.write("\n".join(lines) + "\n")
         sys.stderr.flush()

--- a/amelia/main.py
+++ b/amelia/main.py
@@ -86,7 +86,6 @@ def review(
         if local:
             typer.echo("Reviewing local uncommitted changes...")
 
-            # Gather git diff
             diff_content = await run_shell_command("git diff")
             if not diff_content or not diff_content.strip():
                 typer.echo("No local uncommitted changes found.")
@@ -94,7 +93,6 @@ def review(
 
             typer.echo(f"Found {len(diff_content)} bytes of changes")
 
-            # Create workflow via API
             client = AmeliaClient()
             try:
                 response = await client.create_review_workflow(
@@ -104,7 +102,6 @@ def review(
                 )
                 typer.echo(f"Created review workflow: {response.id}")
 
-                # Stream events via WebSocket
                 await stream_workflow_events(response.id)
 
             except ServerUnreachableError:
@@ -144,7 +141,6 @@ def fix_pr(
     async def _run() -> None:
         client = AmeliaClient()
 
-        # Validate pr_autofix is enabled
         status = await client.get_pr_autofix_status(profile_name)
         if not status.enabled:
             typer.echo(
@@ -153,7 +149,6 @@ def fix_pr(
             )
             raise typer.Exit(code=1)
 
-        # Trigger the fix cycle
         response = await client.trigger_pr_autofix(
             pr_number, profile_name, aggressiveness
         )
@@ -161,12 +156,10 @@ def fix_pr(
             f"Triggered auto-fix for PR #{pr_number} (workflow: {response.workflow_id})"
         )
 
-        # Stream events and collect summary
         summary = await stream_workflow_events(
             response.workflow_id, display=not quiet
         )
 
-        # Print summary line
         summary_line = (
             f"{summary.fixed} comments fixed, "
             f"{summary.skipped} skipped, "
@@ -216,7 +209,6 @@ def watch_pr(
     async def _run() -> None:
         client = AmeliaClient()
 
-        # Validate pr_autofix is enabled
         status = await client.get_pr_autofix_status(profile_name)
         if not status.enabled:
             typer.echo(
@@ -228,7 +220,6 @@ def watch_pr(
         previous_comment_ids: set[int] = set()
 
         while True:
-            # Trigger a fix cycle
             response = await client.trigger_pr_autofix(
                 pr_number, profile_name, aggressiveness
             )
@@ -236,12 +227,10 @@ def watch_pr(
                 f"Triggered auto-fix for PR #{pr_number} (workflow: {response.workflow_id})"
             )
 
-            # Stream events and collect summary
             summary = await stream_workflow_events(
                 response.workflow_id, display=not quiet
             )
 
-            # Print summary line
             summary_line = (
                 f"{summary.fixed} comments fixed, "
                 f"{summary.skipped} skipped, "
@@ -251,7 +240,6 @@ def watch_pr(
                 summary_line += f" (commit: {summary.commit_sha[:8]})"
             typer.echo(summary_line)
 
-            # Check if any unresolved comments remain
             comments_response = await client.get_pr_comments(
                 pr_number, profile_name
             )

--- a/amelia/pipelines/base.py
+++ b/amelia/pipelines/base.py
@@ -58,25 +58,20 @@ class BasePipelineState(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    # Identity (immutable, self-describing for serialization)
     workflow_id: uuid.UUID
     pipeline_type: str
     profile_id: str
     created_at: datetime
 
-    # Lifecycle
     status: Literal["pending", "running", "paused", "completed", "failed"]
 
-    # Human interaction
     pending_user_input: bool = False
     user_message: str | None = None
 
-    # Agentic execution
     driver_session_id: str | None = None
     final_response: str | None = None
     error: str | None = None
 
-    # Oracle consultations (append-only)
     oracle_consultations: Annotated[
         list[OracleConsultation], operator.add
     ] = Field(default_factory=list)

--- a/amelia/pipelines/implementation/external_plan.py
+++ b/amelia/pipelines/implementation/external_plan.py
@@ -73,7 +73,6 @@ async def read_plan_content(
     else:
         content = plan_content or ""
 
-    # Validate content is not empty
     if not content.strip():
         raise ValueError("Plan content is empty")
 
@@ -186,7 +185,6 @@ async def import_external_plan(
     # Establish working directory as security boundary
     working_dir = Path(profile.repo_root).expanduser().resolve()
 
-    # Read content
     content = await read_plan_content(
         plan_file=plan_file,
         plan_content=plan_content,
@@ -201,7 +199,6 @@ async def import_external_plan(
             source_path = working_dir / plan_file
         source_path = source_path.expanduser().resolve()
 
-    # Write to target
     await write_plan_to_target(
         content=content,
         target_path=target_path,
@@ -209,13 +206,10 @@ async def import_external_plan(
         source_path=source_path,
     )
 
-    # Extract structured fields
     result = extract_plan_fields(content)
 
-    # Run structural validation
     validation_result = validate_plan_structure(result.goal, content)
 
-    # Resolve target_path for the result
     resolved_target = target_path.expanduser().resolve()
 
     logger.info(

--- a/amelia/pipelines/implementation/graph.py
+++ b/amelia/pipelines/implementation/graph.py
@@ -120,9 +120,6 @@ def create_implementation_graph(
         }
     )
 
-    # Conditional edge from human_approval_node:
-    # - approve: continue to developer_node
-    # - reject: go to END
     workflow.add_conditional_edges(
         "human_approval_node",
         route_approval,
@@ -132,7 +129,6 @@ def create_implementation_graph(
         }
     )
 
-    # Developer -> Reviewer
     workflow.add_edge("developer_node", "reviewer_node")
 
     # Reviewer routing: developer (retry), next_task_node (task approved), or __end__ (all done)
@@ -149,7 +145,6 @@ def create_implementation_graph(
     # next_task_node loops back to developer for the next task
     workflow.add_edge("next_task_node", "developer_node")
 
-    # Set default interrupt_before only if checkpointer is provided and interrupt_before is None
     if interrupt_before is None and checkpointer is not None:
         interrupt_before = ["human_approval_node"]
 

--- a/amelia/pipelines/implementation/nodes.py
+++ b/amelia/pipelines/implementation/nodes.py
@@ -192,7 +192,6 @@ async def plan_validator_node(
         workflow_id=nc.workflow_id,
     )
 
-    # Read plan file - fail fast if not found
     if not plan_path.exists():
         raise ValueError(f"Plan file not found at {plan_path}")
 
@@ -264,7 +263,6 @@ async def plan_validator_node(
         key_files = _extract_key_files_from_plan(plan_content)
         total_tasks = extract_task_count(plan_content)
 
-    # Run structural validation
     validation_result = validate_plan_structure(goal, plan_content)
 
     revision_count = state.plan_revision_count
@@ -328,15 +326,11 @@ async def call_architect_node(
     if state.issue is None:
         raise ValueError("Cannot call Architect: no issue provided in state.")
 
-    # Extract all config params in one call
     nc = extract_node_config(config)
 
     agent_config = nc.profile.get_agent_config("architect")
     architect = Architect(agent_config, prompts=nc.prompts, sandbox_provider=nc.sandbox_provider)
 
-    # P1: record this invocation into the workflow trajectory (server mode only).
-    # Note: plan_validator_node performs regex-only validation (no driver call),
-    # so the architect is the only P1 seam in this module today.
     if nc.recorder is not None:
         inv = nc.recorder.begin_invocation("architect", model=agent_config.model)
         architect.driver = RecordingDriver(architect.driver, inv)
@@ -368,7 +362,6 @@ async def call_architect_node(
             tool_calls_count=len(final_state.tool_calls),
         )
 
-        # Log all tool calls for diagnosis
         logger.debug(
             "All tool calls from architect",
             tool_calls_detail=[
@@ -460,7 +453,6 @@ async def human_approval_node(
     approved = typer.confirm("Do you approve this plan to proceed with development?", default=True)
     comment = typer.prompt("Add an optional comment for the audit log (press Enter to skip)", default="")
 
-    # Log the approval decision
     logger.info(
         "Human approval received",
         approved=approved,

--- a/amelia/pipelines/implementation/state.py
+++ b/amelia/pipelines/implementation/state.py
@@ -49,12 +49,10 @@ class ImplementationState(BasePipelineState):
     # Override pipeline_type with literal
     pipeline_type: Literal["implementation"] = "implementation"
 
-    # Agentic execution tracking (from agent interactions)
     tool_calls: Annotated[list[ToolCall], operator.add] = Field(default_factory=list)
     tool_results: Annotated[list[ToolResult], operator.add] = Field(default_factory=list)
     agentic_status: AgenticStatus = AgenticStatus.RUNNING
 
-    # Domain data (from planning phase)
     issue: Issue | None = None
     design: Design | None = None
     goal: str | None = None
@@ -67,37 +65,30 @@ class ImplementationState(BasePipelineState):
     plan_path: Path | None = None
     key_files: list[str] = Field(default_factory=list)
 
-    # Human approval (plan review)
     human_approved: bool | None = None
     human_feedback: str | None = None
 
-    # Code review tracking
     last_reviews: list[ReviewResult] = Field(default_factory=list)
     code_changes_for_review: str | None = None
 
-    # Review iteration tracking
     review_iteration: int = 0
 
     # Plan validation feedback loop (mirrors last_reviews + task_review_iteration)
     plan_validation_result: PlanValidationResult | None = None
     plan_revision_count: int = 0
 
-    # Task-based execution (multi-task plans)
     total_tasks: int = 1
     current_task_index: int = 0
     task_review_iteration: int = 0
 
-    # Structured review workflow
     evaluation_result: EvaluationResult | None = None
     approved_items: list[int] = Field(default_factory=list)
     review_pass: int = 0
     review_mode: str | None = None
     max_review_passes: int = 3
 
-    # Structured plan data (from write_plan JSON sidecar)
     plan_structured: WritePlanInput | None = None
 
-    # External plan tracking
     external_plan: bool = False
     """True if plan was imported externally (bypasses Architect)."""
 

--- a/amelia/pipelines/implementation/utils.py
+++ b/amelia/pipelines/implementation/utils.py
@@ -38,7 +38,6 @@ def extract_task_count(plan_markdown: str) -> int:
     matches = re.findall(pattern, plan_markdown, re.MULTILINE)
     count = len(matches) if matches else 1
 
-    # Debug: Log task extraction details (without plan content)
     logger.debug(
         "extract_task_count analysis",
         pattern=pattern,
@@ -78,14 +77,12 @@ def validate_plan_structure(
             "with headers like '### Task 1: Component Name'."
         )
 
-    # Check for goal
     if not goal or goal == "Implementation plan":
         issues.append(
             "No goal found. Plan must include a clear goal statement "
             "(e.g. '**Goal:** Add user authentication')."
         )
 
-    # Check minimum content length
     if len(plan_markdown.strip()) < 200:
         issues.append(
             "Plan content is too short to be a complete implementation plan. "
@@ -143,11 +140,9 @@ def _looks_like_plan(text: str) -> bool:
     if not text or len(text) < 100:
         return False
 
-    # Count plan indicators
     indicators = 0
     lower_text = text.lower()
 
-    # Check for common plan headers/sections
     plan_markers = [
         "# ",  # Markdown headers
         "## ",
@@ -164,7 +159,6 @@ def _looks_like_plan(text: str) -> bool:
         if marker in lower_text:
             indicators += 1
 
-    # Need at least 3 indicators to consider it a plan
     if indicators < 3:
         return False
 
@@ -197,23 +191,19 @@ def _extract_goal_from_plan(plan_content: str) -> str:
     Returns:
         Extracted goal or a default placeholder.
     """
-    # Try to find **Goal:** pattern (multi-line: capture until blank line, heading, or bold)
     # Use [^\n] with explicit \n to avoid polynomial backtracking with re.DOTALL
     goal_match = re.search(
         r"\*\*Goal:\*\*[ \t]*([^\n](?:[^\n]|\n(?!\n|#|\*\*))*)",
         plan_content,
     )
     if goal_match:
-        # Normalize whitespace: collapse newlines and multiple spaces
         goal = re.sub(r"\s+", " ", goal_match.group(1)).strip()
         logger.debug("Goal extracted from **Goal:** pattern", goal=goal)
         return goal
 
-    # Try to find first # header as title
     title_match = re.search(r"^#\s+(.+?)(?:\n|$)", plan_content, re.MULTILINE)
     if title_match:
         title = title_match.group(1).strip()
-        # Remove "Implementation Plan" suffix if present
         title = re.sub(r"\s*Implementation Plan\s*$", "", title, flags=re.IGNORECASE)
         logger.debug("Goal extracted from heading fallback", title=title)
         return f"Implement {title}" if title else "Implementation plan"
@@ -281,7 +271,6 @@ def extract_task_section(plan_markdown: str, task_index: int) -> str:
         Markdown containing header context plus the specific task section.
         Falls back to full plan if extraction fails.
     """
-    # Split into lines for processing
     lines = plan_markdown.split("\n")
 
     # Find header section (before first ## Phase or ---)
@@ -296,7 +285,6 @@ def extract_task_section(plan_markdown: str, task_index: int) -> str:
 
     header_lines = lines[:header_end]
 
-    # Find all task boundaries using regex
     task_pattern = re.compile(r"^### Task \d+(\.\d+)?:")
     phase_pattern = re.compile(r"^## Phase \d+:")
 
@@ -315,7 +303,6 @@ def extract_task_section(plan_markdown: str, task_index: int) -> str:
         # No tasks found or index out of range, return full plan
         return plan_markdown
 
-    # Get the task section boundaries
     task_start = task_starts[task_index]
     task_end = (
         task_starts[task_index + 1]
@@ -323,26 +310,21 @@ def extract_task_section(plan_markdown: str, task_index: int) -> str:
         else len(lines)
     )
 
-    # Get the phase header for this task
     phase_header = ""
     for idx, header in phase_for_task:
         if idx == task_index:
             phase_header = header
             break
 
-    # Build the extracted section
     result_parts = []
 
-    # Add header context
     result_parts.append("\n".join(header_lines).strip())
     result_parts.append("\n---\n")
 
-    # Add phase header if available
     if phase_header:
         result_parts.append(phase_header)
         result_parts.append("\n\n")
 
-    # Add the task section
     task_section = "\n".join(lines[task_start:task_end]).strip()
     result_parts.append(task_section)
 
@@ -424,7 +406,6 @@ async def commit_task_changes(state: ImplementationState, config: RunnableConfig
     # Disable git prompts to prevent hangs in headless/server contexts
     git_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
-    # Stage all changes
     try:
         await _run_git(["add", "-A"], cwd=working_dir, env=git_env)
     except TimeoutError:
@@ -453,7 +434,6 @@ async def commit_task_changes(state: ImplementationState, config: RunnableConfig
             return False
         # returncode 1 means changes exist — continue to commit
 
-    # Commit with task reference
     issue_key = state.issue.id if state.issue else "unknown"
     commit_msg = f"feat({issue_key}): complete task {task_number}"
 
@@ -487,7 +467,6 @@ async def commit_task_changes(state: ImplementationState, config: RunnableConfig
             task=task_number,
         )
 
-        # Re-stage all changes
         try:
             await _run_git(["add", "-A"], cwd=working_dir, env=git_env)
         except TimeoutError:
@@ -500,7 +479,6 @@ async def commit_task_changes(state: ImplementationState, config: RunnableConfig
             )
             return False
 
-        # Retry commit
         try:
             await _run_git(["commit", "-m", commit_msg], cwd=working_dir, env=git_env)
             logger.info(

--- a/amelia/pipelines/nodes.py
+++ b/amelia/pipelines/nodes.py
@@ -119,7 +119,6 @@ async def call_developer_node(
     if not state.goal:
         raise ValueError("Developer node has no goal. The architect should have generated a goal first.")
 
-    # Extract all config params in one call
     nc = extract_node_config(config)
 
     # Capture current HEAD so the next reviewer only diffs against this point
@@ -141,7 +140,6 @@ async def call_developer_node(
     agent_config = nc.profile.get_agent_config("developer")
     developer = Developer(agent_config, prompts=nc.prompts, sandbox_provider=nc.sandbox_provider)
 
-    # P1: record this invocation into the workflow trajectory (server mode only)
     if nc.recorder is not None:
         inv = nc.recorder.begin_invocation("developer", model=agent_config.model)
         developer.driver = RecordingDriver(developer.driver, inv)
@@ -200,7 +198,6 @@ async def call_reviewer_node(
     """
     logger.info(f"Orchestrator: Calling Reviewer for issue {state.issue.id if state.issue else 'N/A'}")
 
-    # Extract all config params in one call
     nc = extract_node_config(config)
 
     # Use "task_reviewer" only for non-final tasks in task-based execution
@@ -211,7 +208,6 @@ async def call_reviewer_node(
         agent_config = nc.profile.get_agent_config(agent_name)
     except ValueError:
         agent_config = nc.profile.get_agent_config("reviewer")
-    # Compute base_commit if not in state
     base_commit = state.base_commit
     if not base_commit:
         computed_commit = await _resolve_commit(nc.profile.repo_root, nc.sandbox_provider)
@@ -223,7 +219,6 @@ async def call_reviewer_node(
                 base_commit=base_commit,
             )
         else:
-            # Fallback to HEAD if get_current_commit fails
             base_commit = "HEAD"
             logger.warning(
                 "Could not compute base_commit, falling back to HEAD",
@@ -236,7 +231,6 @@ async def call_reviewer_node(
             base_commit=base_commit,
         )
 
-    # Detect stack and load review skills
     config_review_types = (config or {}).get("configurable", {}).get("review_types")
     raw_review_types = config_review_types or agent_config.options.get("review_types", ["general"])
     if not isinstance(raw_review_types, list) or not raw_review_types:
@@ -247,7 +241,6 @@ async def call_reviewer_node(
         raw_review_types = ["general"]
     review_types: list[str] = [str(rt) for rt in raw_review_types]
 
-    # Warn about unknown review types
     unknown_types = [rt for rt in review_types if rt not in REVIEW_TYPE_SKILLS]
     if unknown_types:
         logger.warning(
@@ -321,7 +314,6 @@ async def call_reviewer_node(
                 review_guidelines=guidelines,
             )
 
-            # P1: one trajectory invocation per review pass (server mode only)
             if nc.recorder is not None:
                 inv = nc.recorder.begin_invocation(agent_name, model=agent_config.model)
                 reviewer.driver = RecordingDriver(reviewer.driver, inv)
@@ -332,7 +324,6 @@ async def call_reviewer_node(
                 diff_path=str(diff_path),
             )
 
-            # Tag result with the review type as reviewer_persona
             review_result = review_result.model_copy(update={"reviewer_persona": review_type})
             reviews.append(review_result)
             new_session_id = session_id
@@ -348,7 +339,6 @@ async def call_reviewer_node(
 
         next_iteration = state.review_iteration + 1
 
-        # Build return dict with all review results
         result_dict: dict[str, Any] = {
             "last_reviews": reviews,
             "driver_session_id": new_session_id,
@@ -356,7 +346,6 @@ async def call_reviewer_node(
             "task_review_iteration": state.task_review_iteration + 1,
         }
 
-        # Debug: Log the full state update being returned
         logger.debug(
             "call_reviewer_node returning state update",
             review_count=len(reviews),

--- a/amelia/pipelines/pr_auto_fix/nodes.py
+++ b/amelia/pipelines/pr_auto_fix/nodes.py
@@ -68,7 +68,6 @@ async def classify_node(
         profile_name=agent_config.profile_name,
     )
 
-    # Build thread context by grouping comments by thread_id
     all_thread_comments: dict[str, list[PRReviewComment]] = {}
     for comment in state.comments:
         if comment.thread_id is not None:
@@ -84,7 +83,6 @@ async def classify_node(
     if not filtered:
         return {"classified_comments": [], "file_groups": {}}
 
-    # LLM classification
     classifications = await classify_comments(
         filtered, driver, state.autofix_config, recorder=recorder,
     )
@@ -107,10 +105,8 @@ async def classify_node(
                 "prompt_hash": prompt_hash,
             })
 
-    # Group by file path
     file_group_comments = group_comments_by_file(state.comments, classifications)
 
-    # Convert from dict[path, list[PRReviewComment]] to dict[path, list[int]]
     file_groups: dict[str | None, list[int]] = {
         path: [c.id for c in comments]
         for path, comments in file_group_comments.items()
@@ -192,7 +188,6 @@ def _build_developer_goal(
             parts.append(f"**Reason:** {cls.reason}")
         parts.append("")
 
-    # Constraints
     parts.append("## Constraints")
     if file_path:
         parts.append(f"- Only modify files related to {file_path}")
@@ -225,12 +220,10 @@ async def develop_node(
     configurable = config.get("configurable", {})
     recorder = configurable.get("trajectory_recorder")
 
-    # Build classification lookup from state
     classifications: dict[int, CommentClassification] = {
         cls.comment_id: cls for cls in state.classified_comments
     }
 
-    # Build comment lookup from state
     comments_by_id: dict[int, PRReviewComment] = {
         c.id: c for c in state.comments
     }
@@ -242,7 +235,6 @@ async def develop_node(
     for file_path, comment_ids in state.file_groups.items():
         comments = [comments_by_id[cid] for cid in comment_ids if cid in comments_by_id]
 
-        # Build goal with full context, anchoring paths to the worktree CWD
         goal_text = _build_developer_goal(
             file_path, comments, classifications,
             state.pr_number, state.head_branch,
@@ -271,7 +263,6 @@ async def develop_node(
             baseline_files = set(baseline_status.strip().splitlines()) if baseline_status.strip() else set()
             baseline_head = await git_ops._run_git("rev-parse", "HEAD")
 
-            # Create Developer with PR-fix system prompt
             agent_config = profile.get_agent_config("developer")
             dev = Developer(
                 config=agent_config,
@@ -280,12 +271,10 @@ async def develop_node(
                 },
             )
 
-            # P1: record this per-group invocation into the cycle trajectory
             if recorder is not None:
                 inv = recorder.begin_invocation("developer", model=agent_config.model)
                 dev.driver = RecordingDriver(dev.driver, inv)
 
-            # Create temporary ImplementationState for Developer.run()
             impl_state = ImplementationState(
                 workflow_id=state.workflow_id,
                 pipeline_type="implementation",
@@ -296,7 +285,6 @@ async def develop_node(
                 plan_markdown=goal_text,  # Required by Developer._build_prompt
             )
 
-            # Run Developer and iterate to completion
             final_state = impl_state
             async for updated_state, _event in dev.run(
                 final_state, profile=profile, workflow_id=workflow_id,
@@ -351,7 +339,6 @@ async def develop_node(
                 comment_ids=comment_ids,
             ))
 
-    # Determine overall status
     any_fixed = any(r.status == GroupFixStatus.FIXED for r in group_results)
     all_no_changes = all(r.status == GroupFixStatus.NO_CHANGES for r in group_results)
     agentic_status = (
@@ -417,12 +404,10 @@ async def commit_push_node(
     try:
         git_ops = GitOperations(profile.repo_root)
 
-        # Check if there are changes to commit
         if not await git_ops.has_changes():
             logger.info("No changes to commit, skipping")
             return {"status": "completed", "commit_sha": None}
 
-        # Build commit message
         message = _build_commit_message(
             state.autofix_config.commit_prefix,
             state.group_results,
@@ -503,7 +488,6 @@ async def reply_resolve_node(
 
     github_service = GitHubPRService(profile.repo_root)
 
-    # Build comment lookup
     comments_by_id: dict[int, PRReviewComment] = {
         c.id: c for c in state.comments
     }
@@ -560,7 +544,6 @@ async def reply_resolve_node(
             resolved = False
             error_msg: str | None = None
 
-            # Post reply
             body = _build_reply_body(
                 group_result.status,
                 comment.author,
@@ -583,7 +566,6 @@ async def reply_resolve_node(
                 )
                 error_msg = str(e)
 
-            # Determine if we should resolve
             should_resolve = (
                 group_result.status == GroupFixStatus.FIXED
                 or (
@@ -592,7 +574,6 @@ async def reply_resolve_node(
                 )
             )
 
-            # Resolve thread (only if reply was successfully posted)
             if should_resolve and replied:
                 if comment.thread_id:
                     try:

--- a/amelia/pipelines/pr_auto_fix/orchestrator.py
+++ b/amelia/pipelines/pr_auto_fix/orchestrator.py
@@ -72,7 +72,6 @@ class PRAutoFixOrchestrator:
         self._pr_locks: dict[tuple[str, int], asyncio.Lock] = {}
         self._pr_pending: dict[tuple[str, int], dict[str, Any]] = {}
 
-        # Cooldown interruption
         self._cooldown_events: dict[tuple[str, int], asyncio.Event] = {}
 
         # Repo-level git serialization (keyed by repo_path)
@@ -132,7 +131,6 @@ class PRAutoFixOrchestrator:
                 "effective_config": effective_config,
                 "workflow_id": workflow_id,
             }
-            # If in cooldown, reset the timer
             if key in self._cooldown_events:
                 self._cooldown_events[key].set()
                 self._emit_event(
@@ -223,12 +221,10 @@ class PRAutoFixOrchestrator:
                         comments=comments,
                         workflow_id=workflow_id,
                     )
-                    return  # Success
+                    return
 
-                # Create isolated worktree for this PR fix cycle
                 worktree_id = f"pr-{pr_number}-{int(time.time())}"
                 async with LocalWorktree(profile.repo_root, head_branch, worktree_id) as worktree_path:
-                    # Override profile.repo_root to point at worktree
                     wt_profile = profile.model_copy(update={"repo_root": str(worktree_path)})
                     await self._execute_pipeline(
                         pr_number,
@@ -240,7 +236,7 @@ class PRAutoFixOrchestrator:
                         comments=comments,
                         workflow_id=workflow_id,
                     )
-                    return  # Success
+                    return
 
             except ValueError as exc:
                 if "diverged" not in str(exc).lower():
@@ -407,7 +403,6 @@ class PRAutoFixOrchestrator:
             },
         )
 
-        # Emit started event
         self._emit_event(
             EventType.PR_AUTO_FIX_STARTED,
             pr_number,
@@ -418,7 +413,6 @@ class PRAutoFixOrchestrator:
         )
 
         try:
-            # Run the pipeline with timing
             start_time = time.monotonic()
 
             # Generate metrics run_id upfront so classify_node and
@@ -467,7 +461,6 @@ class PRAutoFixOrchestrator:
             issue_cache["comment_count"] = len(comments_raw)
             issue_cache["pr_comments"] = pr_comments
 
-            # Emit PR_COMMENTS_RESOLVED if any threads were resolved
             resolved_count = sum(
                 1
                 for r in resolution_results_raw
@@ -495,7 +488,6 @@ class PRAutoFixOrchestrator:
                     workflow_id=workflow_id,
                 )
 
-            # Update workflow record as completed
             state = state.model_copy(
                 update={
                     "workflow_status": WorkflowStatus.COMPLETED,
@@ -524,7 +516,6 @@ class PRAutoFixOrchestrator:
                         else []
                     )
 
-                    # Count per-comment (iterate comment_ids, not groups -- Pitfall 3)
                     fixed = 0
                     failed = 0
                     no_changes = 0
@@ -601,7 +592,6 @@ class PRAutoFixOrchestrator:
                         error=str(metrics_exc),
                     )
 
-            # Emit completed event
             self._emit_event(
                 EventType.PR_AUTO_FIX_COMPLETED,
                 pr_number,
@@ -612,7 +602,6 @@ class PRAutoFixOrchestrator:
             )
 
         except Exception as exc:
-            # Update workflow record as failed
             state = state.model_copy(
                 update={
                     "workflow_status": WorkflowStatus.FAILED,
@@ -703,7 +692,6 @@ class PRAutoFixOrchestrator:
         group_results = final_state.get("group_results", [])
         resolution_results = final_state.get("resolution_results", [])
 
-        # Build lookup maps
         # comment_id -> group fix status
         comment_fix_status: dict[int, str] = {}
         # comment_id -> reason string (why the comment was skipped/failed/etc.)
@@ -902,7 +890,6 @@ class PRAutoFixOrchestrator:
         """
         state = final_state if isinstance(final_state, dict) else {}
 
-        # classify_node completed
         self._emit_event(
             EventType.STAGE_COMPLETED,
             pr_number,
@@ -938,7 +925,6 @@ class PRAutoFixOrchestrator:
                     workflow_id=workflow_id,
                 )
 
-        # commit_push_node completed
         commit_sha = state.get("commit_sha")
         self._emit_event(
             EventType.STAGE_COMPLETED,
@@ -952,7 +938,6 @@ class PRAutoFixOrchestrator:
             workflow_id=workflow_id,
         )
 
-        # reply_resolve_node completed
         self._emit_event(
             EventType.STAGE_COMPLETED,
             pr_number,

--- a/amelia/pipelines/pr_auto_fix/state.py
+++ b/amelia/pipelines/pr_auto_fix/state.py
@@ -83,29 +83,23 @@ class PRAutoFixState(BasePipelineState):
 
     model_config = ConfigDict(frozen=True)
 
-    # Pipeline identity
     pipeline_type: Literal["pr_auto_fix"] = "pr_auto_fix"
     status: Literal["pending", "running", "paused", "completed", "failed"] = "pending"
 
-    # PR context
     pr_number: int
     head_branch: str
     repo: str
 
-    # Classification
     classified_comments: list[CommentClassification] = Field(default_factory=list)
     file_groups: dict[str | None, list[int]] = Field(default_factory=dict)
 
-    # Agentic execution
     goal: str | None = None
     agentic_status: AgenticStatus = AgenticStatus.RUNNING
 
-    # Results
     commit_sha: str | None = None
     group_results: list[GroupFixResult] = Field(default_factory=list)
     resolution_results: list[ResolutionResult] = Field(default_factory=list)
 
-    # Configuration
     autofix_config: PRAutoFixConfig = Field(default_factory=PRAutoFixConfig)
     comments: list[PRReviewComment] = Field(default_factory=list)
 

--- a/amelia/pipelines/registry.py
+++ b/amelia/pipelines/registry.py
@@ -12,7 +12,6 @@ from amelia.pipelines.pr_auto_fix.pipeline import PRAutoFixPipeline
 from amelia.pipelines.review.pipeline import ReviewPipeline
 
 
-# Registry mapping pipeline names to their classes
 PIPELINES: dict[str, type[Pipeline[Any]]] = {
     "implementation": ImplementationPipeline,
     "pr_auto_fix": PRAutoFixPipeline,

--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -124,7 +124,6 @@ class DaytonaSandboxProvider:
 
         worker_src = Path(__file__).parent / "worker.py"
         content = worker_src.read_bytes()
-        # Ensure parent directory exists.
         await sandbox.process.exec(f"mkdir -p {shlex.quote(str(Path(WORKER_PATH).parent))}")
         await sandbox.fs.upload_file(content, WORKER_PATH)
         logger.info("Uploaded standalone worker", path=WORKER_PATH, size=len(content))

--- a/amelia/sandbox/docker.py
+++ b/amelia/sandbox/docker.py
@@ -232,7 +232,6 @@ class DockerSandboxProvider(SandboxProvider):
         Attempts to restart an existing stopped container first. If no
         container exists, creates a new one with ``docker run``.
         """
-        # Try restarting an existing stopped container first.
         restart = await asyncio.create_subprocess_exec(
             "docker", "start", self.container_name,
             stdout=asyncio.subprocess.DEVNULL,

--- a/amelia/sandbox/proxy.py
+++ b/amelia/sandbox/proxy.py
@@ -40,10 +40,8 @@ class ProviderConfig(BaseModel):
     api_key: str
 
 
-# Type alias for the provider resolver function
 type ProviderResolver = Callable[[str], Coroutine[Any, Any, ProviderConfig | None]]
 
-# Type alias for the token validator function (sync or async)
 type TokenValidator = Callable[[str], bool] | Callable[[str], Coroutine[Any, Any, bool]]
 
 
@@ -185,7 +183,6 @@ def create_proxy_router(
 
         upstream_url = f"{provider.base_url.rstrip('/')}{path}"
 
-        # Forward original headers, replacing auth and removing internal headers
         headers = dict(request.headers)
         headers["authorization"] = f"Bearer {provider.api_key}"
         # Remove hop-by-hop and internal headers
@@ -243,7 +240,6 @@ def create_proxy_router(
                 detail="Upstream provider request failed",
             ) from e
 
-        # Pass through the upstream response
         return StreamingResponse(
             content=upstream_response.aiter_raw(),
             status_code=upstream_response.status_code,

--- a/amelia/sandbox/worker.py
+++ b/amelia/sandbox/worker.py
@@ -164,17 +164,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     sub = parser.add_subparsers(dest="mode", required=True)
 
-    # Shared arguments
     shared = argparse.ArgumentParser(add_help=False)
     shared.add_argument("--prompt-file", required=True, help="Path to prompt file")
     shared.add_argument("--model", required=True, help="LLM model identifier")
 
-    # agentic subcommand
     agentic = sub.add_parser("agentic", parents=[shared])
     agentic.add_argument("--cwd", required=True, help="Working directory")
     agentic.add_argument("--instructions", help="System instructions")
 
-    # generate subcommand
     generate = sub.add_parser("generate", parents=[shared])
     generate.add_argument("--schema", help="Schema as module:ClassName")
 
@@ -276,13 +273,11 @@ async def _run_agentic(args: argparse.Namespace) -> None:
         message = messages[-1]
         num_turns += 1
 
-        # Track usage
         if hasattr(message, "usage_metadata") and message.usage_metadata:
             total_input += message.usage_metadata.get("input_tokens", 0)
             total_output += message.usage_metadata.get("output_tokens", 0)
 
         if isinstance(message, AIMessage):
-            # Emit thinking for text content
             content = message.content
             if isinstance(content, list):
                 for block in content:
@@ -299,7 +294,6 @@ async def _run_agentic(args: argparse.Namespace) -> None:
                     model=args.model,
                 ))
 
-            # Emit tool calls
             for tc in message.tool_calls:
                 _emit_line(AgenticMessage(
                     type=AgenticMessageType.TOOL_CALL,
@@ -319,11 +313,9 @@ async def _run_agentic(args: argparse.Namespace) -> None:
                 model=args.model,
             ))
 
-    # Verify agent produced output
     if num_turns == 0:
         raise RuntimeError("Agent stream yielded no messages")
 
-    # Final result — last AI message content
     final_content = ""
     for msg in reversed(chunk.get("messages", [])):
         if isinstance(msg, AIMessage):
@@ -380,7 +372,6 @@ async def _run_generate(args: argparse.Namespace) -> None:
         )
         result = await agent.ainvoke({"messages": [HumanMessage(content=prompt)]})
 
-        # Extract structured output — prefer structured_response key
         structured = result.get("structured_response")
         if structured is not None:
             content = structured.model_dump_json() if isinstance(structured, BaseModel) else str(structured)
@@ -400,7 +391,6 @@ async def _run_generate(args: argparse.Namespace) -> None:
         result = await chat_model.ainvoke([HumanMessage(content=prompt)])
         content = result.content if hasattr(result, "content") else str(result)
 
-    # Track usage
     total_input = 0
     total_output = 0
     for msg in result.get("messages", []) if isinstance(result, dict) else [result]:

--- a/amelia/server/banner.py
+++ b/amelia/server/banner.py
@@ -6,7 +6,6 @@ from rich.style import Style
 from rich.text import Text
 
 
-# --- Color Palette ---
 NAVY = "#0a2463"
 TWILIGHT = "#1245ba"
 RUST = "#a0311c"
@@ -16,12 +15,10 @@ GRAY = "#6d726a"
 MOSS = "#88976b"
 DARK_GREEN = "#1f332e"
 
-# Additional colors for specialized log types
 CYAN = "#17a2b8"      # Available for future use
 PURPLE = "#6f42c1"    # Knowledge library operations
 PINK = "#e83e8c"      # Other specialized operations (future)
 
-# --- ASCII Art ---
 # Combined plane and text for unified gradient handling
 # The plane is a stylized twin-engine (nod to the Electra)
 BANNER_ART = """\
@@ -49,7 +46,6 @@ def _interpolate_color(color1: str, color2: str, factor: float) -> str:
     Returns:
         Interpolated hex color string.
     """
-    # Parse hex colors
     r1 = int(color1[1:3], 16)
     g1 = int(color1[3:5], 16)
     b1 = int(color1[5:7], 16)
@@ -58,7 +54,6 @@ def _interpolate_color(color1: str, color2: str, factor: float) -> str:
     g2 = int(color2[3:5], 16)
     b2 = int(color2[5:7], 16)
 
-    # Interpolate
     r = int(r1 + (r2 - r1) * factor)
     g = int(g1 + (g2 - g1) * factor)
     b = int(b1 + (b2 - b1) * factor)
@@ -86,7 +81,6 @@ def get_gradient_banner(start_color: str, end_color: str) -> Text:
     for i, line in enumerate(lines):
         for j, char in enumerate(line):
             if char.strip():  # Only color non-whitespace
-                # Calculate gradient position (0.0 to 1.0) based on horizontal position
                 factor = j / max_len if max_len > 0 else 0
                 color = _interpolate_color(start_color, end_color, factor)
                 text.append(char, style=Style(color=color))
@@ -161,7 +155,6 @@ def get_service_urls_display(
 
     text = Text()
 
-    # Dashboard line with arrow
     text.append("    ➜ ", style=MOSS)
     text.append("Dashboard: ", style=CREAM)
     text.append(dashboard_url, style=f"bold {GOLD}")

--- a/amelia/server/cli.py
+++ b/amelia/server/cli.py
@@ -54,16 +54,12 @@ def server(
 
     Port and host can be configured via AMELIA_PORT and AMELIA_HOST env vars.
     """
-    # Skip if subcommand is invoked
     if ctx.invoked_subcommand is not None:
         return
 
-    # Run first-time setup if needed
     if not run_first_time_setup():
         raise typer.Exit(1)
 
-    # Configure logging with dashboard colors
-    # Read log level from environment variable (default to INFO)
     log_level = os.environ.get("AMELIA_LOG_LEVEL", "INFO").upper()
     configure_logging(level=log_level)
 
@@ -72,14 +68,12 @@ def server(
     if working_dir:
         os.environ["AMELIA_WORKING_DIR"] = str(working_dir)
 
-    # Load config (respects environment variables)
     config = ServerConfig()
 
     # CLI flags override config
     effective_port = port if port is not None else config.port
     effective_host = "0.0.0.0" if bind_all else config.host
 
-    # Print ASCII banner
     print_banner(console)
 
     if bind_all:
@@ -104,8 +98,6 @@ def server(
         console.print("\nServer stopped.")
 
 
-# NOTE: Cleanup command will be implemented in Phase 2.1-02 (Database Foundation)
-# when LogRetentionService is added. See docs/plans/phase-2.1-02-database-foundation.md
 @server_app.command("cleanup", hidden=True)
 def cleanup(
     retention_days: Annotated[
@@ -123,7 +115,6 @@ def cleanup(
 
     Note: This command requires the database foundation (Phase 2.1-02).
     """
-    # Placeholder until LogRetentionService is implemented in Phase 2.1-02
     console.print(
         "[yellow]Cleanup not yet available.[/yellow] "
         "Requires database foundation (see docs/plans/phase-2.1-02-database-foundation.md)"

--- a/amelia/server/database/brainstorm_repository.py
+++ b/amelia/server/database/brainstorm_repository.py
@@ -38,9 +38,6 @@ class BrainstormRepository:
         """
         self._db = db
 
-    # =========================================================================
-    # Session Operations
-    # =========================================================================
 
     async def create_session(self, session: BrainstormingSession) -> None:
         """Create a new brainstorming session.
@@ -191,9 +188,6 @@ class BrainstormRepository:
             updated_at=row["updated_at"],
         )
 
-    # =========================================================================
-    # Message Operations
-    # =========================================================================
 
     async def save_message(self, message: Message) -> None:
         """Save a message.
@@ -205,7 +199,6 @@ class BrainstormRepository:
         if message.parts:
             parts_data = [p.model_dump() for p in message.parts]
 
-        # Extract usage fields if present
         input_tokens = message.usage.input_tokens if message.usage else None
         output_tokens = message.usage.output_tokens if message.usage else None
         cost_usd = message.usage.cost_usd if message.usage else None
@@ -284,7 +277,6 @@ class BrainstormRepository:
             # JSONB codec returns list directly
             parts = [MessagePart(**p) for p in row["parts"]]
 
-        # Load usage if present
         usage = None
         if row["input_tokens"] is not None:
             usage = MessageUsage(
@@ -304,9 +296,6 @@ class BrainstormRepository:
             created_at=row["created_at"],
         )
 
-    # =========================================================================
-    # Artifact Operations
-    # =========================================================================
 
     async def save_artifact(self, artifact: Artifact) -> None:
         """Save an artifact.
@@ -361,9 +350,6 @@ class BrainstormRepository:
             created_at=row["created_at"],
         )
 
-    # =========================================================================
-    # Usage Aggregation
-    # =========================================================================
 
     async def get_session_usage(self, session_id: uuid.UUID) -> SessionUsageSummary | None:
         """Aggregate token usage for all messages in a brainstorm session.

--- a/amelia/server/database/prompt_repository.py
+++ b/amelia/server/database/prompt_repository.py
@@ -1,4 +1,3 @@
-# amelia/server/database/prompt_repository.py
 """Repository for prompt configuration persistence.
 
 Provides CRUD operations for prompts, versions, and workflow linking.
@@ -28,8 +27,6 @@ class PromptRepository:
             db: Database connection wrapper.
         """
         self._db = db
-
-    # Prompt CRUD
 
     async def create_prompt(self, prompt: Prompt) -> None:
         """Create a new prompt definition.
@@ -82,8 +79,6 @@ class PromptRepository:
             description=row["description"],
             current_version_id=row["current_version_id"],
         )
-
-    # Version management
 
     async def get_versions(self, prompt_id: str) -> list[PromptVersion]:
         """Get all versions for a prompt, newest first.
@@ -151,14 +146,12 @@ class PromptRepository:
         Returns:
             The created version.
         """
-        # Get next version number
         row = await self._db.fetch_one(
             "SELECT MAX(version_number) as max_version FROM prompt_versions WHERE prompt_id = $1",
             prompt_id,
         )
         next_version = (row["max_version"] or 0) + 1 if row else 1
 
-        # Create version
         version_id = uuid.uuid4()
         now = datetime.now(UTC)
         await self._db.execute(
@@ -167,7 +160,6 @@ class PromptRepository:
             version_id, prompt_id, next_version, content, now, change_note,
         )
 
-        # Set as active
         await self._db.execute(
             "UPDATE prompts SET current_version_id = $1 WHERE id = $2",
             version_id, prompt_id,
@@ -204,8 +196,6 @@ class PromptRepository:
             "UPDATE prompts SET current_version_id = NULL WHERE id = $1",
             prompt_id,
         )
-
-    # Workflow linking
 
     async def record_workflow_prompt(
         self,

--- a/amelia/server/database/repository.py
+++ b/amelia/server/database/repository.py
@@ -320,7 +320,6 @@ class WorkflowRepository:
             else:
                 validate_transition(current, new_status)  # non-terminal: state machine rules
 
-            # Set completed_at for terminal states
             completed_at = None
             if new_status in (WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED):
                 completed_at = datetime.now(UTC)

--- a/amelia/server/database/settings_repository.py
+++ b/amelia/server/database/settings_repository.py
@@ -84,7 +84,6 @@ class SettingsRepository:
         if not updates:
             return await self.get_server_settings()
 
-        # Build UPDATE statement
         set_clauses = []
         values = []
         for i, (k, v) in enumerate(updates.items(), start=1):

--- a/amelia/server/dependencies.py
+++ b/amelia/server/dependencies.py
@@ -18,16 +18,12 @@ from amelia.server.database.metrics_repository import MetricsRepository
 from amelia.server.orchestrator.service import OrchestratorService
 
 
-# Module-level config instance
 _config: ServerConfig | None = None
 
-# Module-level database instance
 _database: Database | None = None
 
-# Module-level knowledge service instance
 _knowledge_service: KnowledgeService | None = None
 
-# Module-level orchestrator instance
 _orchestrator: OrchestratorService | None = None
 
 

--- a/amelia/server/dev.py
+++ b/amelia/server/dev.py
@@ -36,7 +36,6 @@ from amelia.server.banner import (
 from amelia.server.config import ServerConfig
 
 
-# Process prefixes
 SERVER_PREFIX = Text("[server]    ", style=TWILIGHT)
 DASHBOARD_PREFIX = Text("[dashboard] ", style=GOLD)
 
@@ -206,7 +205,6 @@ def _get_log_level_style(text: str) -> str:
 
     # Check for loguru-style logs (level appears after │ separator)
     if "│" in text_upper:
-        # Extract the level field (second segment between │ separators)
         parts = text_upper.split("│")
         if len(parts) >= 2:
             level = parts[1].strip()
@@ -239,8 +237,6 @@ async def stream_output(
         prefix: The colored Rich Text prefix to prepend to each line.
         is_stderr: Unused, kept for API compatibility.
     """
-    # Note: is_stderr is kept for API compatibility but we parse log levels instead
-    # because uvicorn writes all logs (including INFO) to stderr
     _ = is_stderr
     while True:
         line = await stream.readline()
@@ -248,7 +244,6 @@ async def stream_output(
             break
         text = line.decode().rstrip()
         if text:
-            # Enhanced log level detection for both uvicorn and loguru formats
             style = _get_log_level_style(text)
             console.print(prefix + Text(text, style=Style(color=style)))
 
@@ -348,14 +343,11 @@ class ProcessManager:
         assert process.stdout is not None
         assert process.stderr is not None
 
-        # Stream both stdout and stderr
         stdout_task = asyncio.create_task(stream_output(process.stdout, prefix))
         stderr_task = asyncio.create_task(stream_output(process.stderr, prefix, is_stderr=True))
 
-        # Wait for process to complete
         exit_code = await process.wait()
 
-        # Wait for output streaming to complete
         await stdout_task
         await stderr_task
 
@@ -475,7 +467,6 @@ async def run_dev_mode(
     manager = ProcessManager()
     loop = asyncio.get_running_loop()
 
-    # Handle signals
     def signal_handler() -> None:
         """Handle termination signals by requesting graceful shutdown."""
         manager.request_shutdown()
@@ -527,7 +518,6 @@ async def run_dev_mode(
                 )
                 return 1
 
-            # Start Vite dev server for HMR
             dashboard = await manager.start_dashboard()
             tasks.append(
                 asyncio.create_task(
@@ -541,7 +531,6 @@ async def run_dev_mode(
             return_when=asyncio.FIRST_COMPLETED,
         )
 
-        # Cancel pending tasks
         for task in pending:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -549,7 +538,6 @@ async def run_dev_mode(
 
     finally:
         await manager.shutdown()
-        # Remove signal handlers
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.remove_signal_handler(sig)
 
@@ -597,7 +585,6 @@ def dev(
 
     is_dev_repo = is_amelia_dev_repo()
 
-    # Check prerequisites for dev mode
     if is_dev_repo and not no_dashboard:
         if not check_node_installed():
             console.print(
@@ -617,15 +604,12 @@ def dev(
             )
             raise typer.Exit(code=1)
 
-    # Print banner
     print_banner(console)
 
-    # Load config
     config = ServerConfig()
     effective_port = port if port is not None else config.port
     effective_host = "0.0.0.0" if bind_all else config.host
 
-    # Check port availability
     if not check_port_available(effective_host, effective_port):
         console.print(
             Text(
@@ -636,7 +620,6 @@ def dev(
         )
         raise typer.Exit(code=1)
 
-    # Show mode and service URLs
     mode = "dev" if is_dev_repo else "user"
     is_dev_mode = is_dev_repo and not no_dashboard
     console.print(Text(f"Mode: {mode}", style=MOSS))
@@ -652,7 +635,6 @@ def dev(
             )
         )
 
-    # Run the async event loop
     try:
         exit_code = asyncio.run(
             run_dev_mode(effective_host, effective_port, no_dashboard, is_dev_repo)

--- a/amelia/server/events/connection_manager.py
+++ b/amelia/server/events/connection_manager.py
@@ -1,4 +1,3 @@
-# amelia/server/events/connection_manager.py
 """WebSocket connection manager with subscription filtering."""
 from __future__ import annotations
 
@@ -102,10 +101,8 @@ class ConnectionManager:
         targets: list[WebSocket] = []
         async with self._lock:
             if is_trace:
-                # Trace events go to ALL clients
                 targets = list(self._connections.keys())
             else:
-                # Regular events filtered by workflow subscription
                 wid_str = str(event.workflow_id) if event.workflow_id else None
                 for ws, subscribed_ids in self._connections.items():
                     # Empty set = subscribed to all workflows
@@ -136,7 +133,6 @@ class ConnectionManager:
                 "timestamp": event.timestamp.isoformat(),
             }
         else:
-            # Workflow events use wrapped format
             payload = {
                 "type": "event",
                 "payload": event.model_dump(mode="json"),
@@ -146,7 +142,6 @@ class ConnectionManager:
             *(self._send_to_client(ws, payload) for ws in targets)
         )
 
-        # Remove failed connections
         failed = [ws for ws, success in results if not success]
         succeeded = len(targets) - len(failed)
         logger.debug(

--- a/amelia/server/lifecycle/pr_poller.py
+++ b/amelia/server/lifecycle/pr_poller.py
@@ -87,7 +87,6 @@ class PRCommentPoller:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._task
 
-        # Cancel all fire-and-forget tasks
         for task in self._active_tasks:
             task.cancel()
         for task in self._active_tasks:
@@ -122,14 +121,12 @@ class PRCommentPoller:
         without pr_autofix or whose next-poll time hasn't passed.
         Sets next_poll BEFORE calling _poll_profile to prevent overlap.
         """
-        # Find first enabled profile's repo_root for rate limit check
         profiles = await self._profile_repo.list_profiles()
         enabled_profiles = [p for p in profiles if p.pr_autofix is not None]
 
         if not enabled_profiles:
             return
 
-        # Check rate limit using first enabled profile's repo
         backoff_seconds = await self._should_back_off(enabled_profiles[0].repo_root)
         if backoff_seconds is not None:
             self._emit_rate_limited_event(backoff_seconds)
@@ -138,7 +135,6 @@ class PRCommentPoller:
 
         now = time.monotonic()
         for profile in enabled_profiles:
-            # Skip if next-poll time hasn't passed
             if now < self._next_poll.get(profile.name, 0):
                 continue
 
@@ -206,7 +202,6 @@ class PRCommentPoller:
 
             repo_slug = await self._get_repo_slug(profile.repo_root)
 
-            # Emit PR_COMMENTS_DETECTED event
             detected_event = WorkflowEvent(
                 id=uuid4(),
                 workflow_id=uuid4(),
@@ -223,7 +218,6 @@ class PRCommentPoller:
             )
             self._event_bus.emit(detected_event)
 
-            # Fire-and-forget dispatch
             task = asyncio.create_task(
                 self._orchestrator.trigger_fix_cycle(
                     pr_number=pr.number,

--- a/amelia/server/lifecycle/retention.py
+++ b/amelia/server/lifecycle/retention.py
@@ -180,7 +180,6 @@ class LogRetentionService:
 
         checkpointer = self._checkpointer
 
-        # Build query based on retention days
         if retention_days == 0:
             finished = await self._db.fetch_all(
                 "SELECT id FROM workflows WHERE status IN ('completed', 'failed', 'cancelled')"

--- a/amelia/server/lifecycle/server.py
+++ b/amelia/server/lifecycle/server.py
@@ -70,7 +70,6 @@ class ServerLifecycle:
         self._shutting_down = True
         logger.info("Server shutting down...")
 
-        # Wait for blocked workflows with timeout
         active = self._orchestrator.get_active_workflows()
         if active:
             logger.info(f"Waiting for {len(active)} active workflows...")
@@ -82,13 +81,11 @@ class ServerLifecycle:
             except TimeoutError:
                 logger.warning("Shutdown timeout - cancelling remaining workflows")
 
-        # Cancel any still-running workflows
         await self._orchestrator.cancel_all_workflows()
 
         # Persist final state (already done via repository on each update)
         logger.info("Final state persisted to database")
 
-        # Run log retention cleanup
         cleanup_result = await self._log_retention.cleanup_on_shutdown()
         logger.info(
             "Cleanup complete",

--- a/amelia/server/main.py
+++ b/amelia/server/main.py
@@ -133,18 +133,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     Initializes configuration, database, orchestrator, and lifecycle components.
     """
     # Rebuild ImplementationState forward references before any instantiation.
-    # ServerExecutionState no longer has forward refs (execution_state field removed).
     rebuild_implementation_state()
 
     # Configure logging (needed when uvicorn loads app directly, e.g. with --reload)
     log_level = os.environ.get("AMELIA_LOG_LEVEL", "INFO").upper()
     configure_logging(level=log_level)
 
-    # Initialize configuration
     config = ServerConfig()
     set_config(config)
 
-    # Connect to database and run migrations
     database = Database(config.database_url, min_size=config.db_pool_min_size, max_size=config.db_pool_max_size)
     try:
         await database.connect()
@@ -155,32 +152,25 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await migrator.run()
     await migrator.initialize_prompts()
 
-    # Initialize settings with defaults
     settings_repo = SettingsRepository(database)
     await settings_repo.ensure_defaults()
 
-    # Get server settings for orchestrator configuration
     server_settings = await settings_repo.get_server_settings()
 
-    # Set the database in dependencies module for DI
     set_database(database)
 
-    # Create repositories
     repository = WorkflowRepository(database)
     profile_repo = ProfileRepository(database)
 
-    # Create event bus
     event_bus = EventBus()
     # Wire WebSocket broadcasting and reconnect backfill
     event_bus.set_connection_manager(connection_manager)
     connection_manager.set_event_bus(event_bus)
 
-    # Bridge events to server console via loguru
     from amelia.server.events.log_subscriber import log_event_to_console  # noqa: PLC0415
 
     event_bus.subscribe(log_event_to_console)
 
-    # Create and register orchestrator
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
     from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
@@ -209,7 +199,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     set_orchestrator(orchestrator)
 
-    # Create brainstorm repository and service
     brainstorm_repo = BrainstormRepository(database)
     brainstorm_service = BrainstormService(
         repository=brainstorm_repo,
@@ -220,14 +209,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.brainstorm_service = brainstorm_service
     app.state.event_bus = event_bus
 
-    # Create knowledge service
     openrouter_api_key = os.environ.get("OPENROUTER_API_KEY", "")
     embedding_client: EmbeddingClient | None = None
     if openrouter_api_key:
         embedding_client = EmbeddingClient(api_key=openrouter_api_key)
         knowledge_repo = KnowledgeRepository(database)
 
-        # Tag derivation configuration
         tag_model = os.environ.get(
             "AMELIA_KNOWLEDGE_TAG_MODEL",
             "minimax/minimax-m2.5",  # Reliable tool calling support
@@ -235,9 +222,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         tag_driver_raw = os.environ.get(
             "AMELIA_KNOWLEDGE_TAG_DRIVER",
             "api",  # Default to API driver
-        ).lower()  # Normalize to lowercase
+        ).lower()
 
-        # Validate driver type
         try:
             tag_driver = DriverType(tag_driver_raw)
         except ValueError:
@@ -263,7 +249,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         knowledge_service = None
         logger.warning("OPENROUTER_API_KEY not set, knowledge service disabled")
 
-    # Create lifecycle components
     log_retention = LogRetentionService(
         db=database, config=server_settings, checkpointer=checkpointer
     )
@@ -273,7 +258,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     health_checker = WorktreeHealthChecker(orchestrator=orchestrator)
 
-    # Create PR auto-fix orchestrator for polling service
     # GitHubPRService needs a repo_root; the orchestrator uses it only for
     # create_issue_comment on divergence failure. The poller creates per-profile
     # services for actual PR listing and comment fetching.
@@ -296,12 +280,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.pr_autofix_orchestrator = pr_fix_orchestrator
     app.state.lifecycle = lifecycle
 
-    # Start lifecycle components
     await lifecycle.startup()
     await health_checker.start()
     await pr_poller.start()
 
-    # Log server startup with styled banner
     log_server_startup(
         host=config.host,
         port=config.port,
@@ -402,7 +384,6 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    # Mount routes
     application.include_router(config_router, prefix="/api")
     application.include_router(descriptions_router, prefix="/api")
     application.include_router(files_router, prefix="/api")
@@ -419,21 +400,18 @@ def create_app() -> FastAPI:
     application.include_router(prompts_router)  # Already has /api/prompts prefix
     application.include_router(settings_router)  # Already has /api prefix
 
-    # Set up prompt repository dependency
     def get_prompt_repo() -> PromptRepository:
         from amelia.server.dependencies import get_database
         return PromptRepository(get_database())
 
     application.dependency_overrides[get_prompt_repository] = get_prompt_repo
 
-    # Set up brainstorm service dependency
     def get_brainstorm_svc() -> BrainstormService:
         service: BrainstormService = application.state.brainstorm_service
         return service
 
     application.dependency_overrides[get_brainstorm_service] = get_brainstorm_svc
 
-    # Set up driver dependency for brainstorm routes
     async def get_brainstorm_driver() -> DriverInterface:
         """Get driver for brainstorming using active profile from database.
 
@@ -455,7 +433,6 @@ def create_app() -> FastAPI:
 
     application.dependency_overrides[get_driver] = get_brainstorm_driver
 
-    # Set up cwd dependency for brainstorm routes
     async def get_brainstorm_cwd() -> str:
         """Get working directory from active profile in database.
 
@@ -470,7 +447,6 @@ def create_app() -> FastAPI:
 
     application.dependency_overrides[get_cwd] = get_brainstorm_cwd
 
-    # Set up Oracle dependencies
     def get_oracle_event_bus() -> EventBus:
         """Get EventBus for Oracle consultations."""
         bus: EventBus = application.state.event_bus
@@ -478,7 +454,6 @@ def create_app() -> FastAPI:
 
     application.dependency_overrides[oracle_get_event_bus] = get_oracle_event_bus
 
-    # Mount sandbox proxy routes
     async def _resolve_provider(profile_name: str) -> ProviderConfig | None:
         return await resolve_proxy_provider(profile_name, get_profile_repository())
 
@@ -520,7 +495,6 @@ def create_app() -> FastAPI:
     bundled_static_dir = Path(__file__).parent / "static"
     dev_dashboard_dir = Path(__file__).parent.parent.parent / "dashboard" / "dist"
 
-    # Determine dashboard directory (None if not built)
     if (bundled_static_dir / "index.html").exists():
         dashboard_dir = bundled_static_dir
     elif dev_dashboard_dir.exists():
@@ -528,7 +502,6 @@ def create_app() -> FastAPI:
     else:
         dashboard_dir = None
 
-    # Mount assets if dashboard exists
     if dashboard_dir is not None:
         assets_dir = dashboard_dir / "assets"
         if assets_dir.exists():
@@ -551,13 +524,11 @@ def create_app() -> FastAPI:
         if full_path.startswith("api/") or full_path.startswith("ws/"):
             raise HTTPException(status_code=404, detail="Not found")
 
-        # Serve dashboard if built
         if dashboard_dir is not None:
             index_file = dashboard_dir / "index.html"
             if index_file.exists():
                 return FileResponse(index_file)
 
-        # Dashboard not built - return instructions
         return JSONResponse({
             "message": "Dashboard not built",
             "instructions": "Run 'cd dashboard && pnpm run build' to build the dashboard",
@@ -566,5 +537,4 @@ def create_app() -> FastAPI:
     return application
 
 
-# Create app instance
 app = create_app()

--- a/amelia/server/models/requests.py
+++ b/amelia/server/models/requests.py
@@ -20,12 +20,10 @@ def _validate_worktree_path(cls: type, v: str) -> str:
     Raises:
         ValueError: If path is not absolute or contains null bytes.
     """
-    # Reject null bytes
     if "\0" in v:
         msg = "worktree_path contains null byte"
         raise ValueError(msg)
 
-    # Must be absolute
     if not os.path.isabs(v):
         msg = "worktree_path must be absolute"
         raise ValueError(msg)
@@ -52,7 +50,6 @@ def _validate_profile(cls: type, v: str | None) -> str | None:
     if v is None:
         return v
 
-    # Must be lowercase alphanumeric with dashes/underscores
     if not v:
         msg = "profile cannot be empty"
         raise ValueError(msg)
@@ -223,7 +220,6 @@ class CreateWorkflowRequest(BaseModel):
                 msg = f"issue_id contains dangerous character: {repr(char)}"
                 raise ValueError(msg)
 
-        # Only allow alphanumeric, dashes, and underscores
         if not all(c.isalnum() or c in {"-", "_"} for c in v):
             msg = "issue_id must contain only alphanumeric characters, dashes, and underscores"
             raise ValueError(msg)
@@ -260,7 +256,6 @@ class CreateWorkflowRequest(BaseModel):
             msg = "driver cannot be empty"
             raise ValueError(msg)
 
-        # Accept simple driver types
         if v in ("api", "claude", "codex"):
             return v
 

--- a/amelia/server/models/tokens.py
+++ b/amelia/server/models/tokens.py
@@ -70,7 +70,6 @@ STATIC_FALLBACK_PRICING: dict[str, ModelPricing] = {
     "haiku": ModelPricing(input=1.0, output=5.0, cache_read=0.1, cache_write=1.25),
 }
 
-# Module-level cache state
 _cached_pricing: dict[str, ModelPricing] = {}
 _cache_expires_at: float = 0.0
 _cache_lock: asyncio.Lock = asyncio.Lock()
@@ -200,7 +199,6 @@ async def get_pricing(model: str) -> ModelPricing | None:
             _cached_pricing = new_pricing
         _cache_expires_at = time.time() + 86400  # 24-hour TTL
 
-    # Look up model in cached pricing, then static fallback
     if model in _cached_pricing:
         return _cached_pricing[model]
     return STATIC_FALLBACK_PRICING.get(model)

--- a/amelia/server/orchestrator/event_emitter.py
+++ b/amelia/server/orchestrator/event_emitter.py
@@ -19,7 +19,6 @@ from amelia.server.events.bus import EventBus
 from amelia.server.models.events import EventType, WorkflowEvent
 
 
-# Nodes that emit stage events
 STAGE_NODES: frozenset[str] = frozenset({
     "architect_node",
     "plan_validator_node",
@@ -96,7 +95,6 @@ def is_interrupt_chunk(chunk: tuple[str, Any] | dict[str, Any]) -> bool:
         if mode == "updates" and isinstance(data, dict):
             return "__interrupt__" in data
         return False
-    # Single mode (dict)
     return "__interrupt__" in chunk
 
 
@@ -214,10 +212,8 @@ class StreamEventEmitter:
                 summarized = summarize_stage_output(output)
                 assert summarized is not None
 
-                # Emit agent-specific messages based on node
                 await self._emit_agent_messages(workflow_id, node_name, summarized)
 
-                # Emit STAGE_COMPLETED for the current node
                 await self.emit(
                     workflow_id,
                     EventType.STAGE_COMPLETED,
@@ -226,9 +222,7 @@ class StreamEventEmitter:
                     data={"stage": node_name, "output": summarized},
                 )
 
-            # Emit TASK_COMPLETED when next_task_node completes
             if node_name == "next_task_node":
-                # Get total_tasks from output (passed through by next_task_node)
                 total_tasks = output.get("total_tasks")
                 if total_tasks is not None:
                     # The output contains the NEW index, so completed task is index - 1
@@ -264,7 +258,6 @@ class StreamEventEmitter:
             workflow_id: The workflow this task belongs to.
             task_data: Task event data from LangGraph.
         """
-        # Ignore task result events - only process task start events
         if "input" not in task_data:
             return
 
@@ -278,7 +271,6 @@ class StreamEventEmitter:
                 data={"stage": node_name},
             )
 
-        # Emit TASK_STARTED for developer_node in task-based mode
         if node_name == "developer_node":
             input_state = task_data.get("input")
             # input_state is an ImplementationState Pydantic model from LangGraph.
@@ -359,7 +351,6 @@ class StreamEventEmitter:
             workflow_id: The workflow ID.
             output: State updates from the architect node.
         """
-        # In agentic mode, architect sets goal and generates markdown plan
         goal = output.get("goal")
         plan_markdown = output.get("plan_markdown")
 
@@ -406,8 +397,6 @@ class StreamEventEmitter:
             workflow_id: The workflow ID.
             output: State updates from the developer node.
         """
-        # In agentic mode, developer works autonomously with tool calls
-        # Emit status updates based on agentic state
         status = output.get("agentic_status")
         final_response = output.get("final_response")
 
@@ -444,7 +433,6 @@ class StreamEventEmitter:
         if not last_reviews:
             return
 
-        # Emit a message for each review in the list
         for review in last_reviews:
             approved = review.approved
             severity = review.severity

--- a/amelia/server/orchestrator/runner.py
+++ b/amelia/server/orchestrator/runner.py
@@ -98,10 +98,6 @@ class GraphRunner:
             recorders if recorders is not None else {}
         )
 
-    # ------------------------------------------------------------------
-    # Setup helpers
-    # ------------------------------------------------------------------
-
     def create_server_graph(
         self,
         checkpointer: BaseCheckpointSaver[Any] | None = None,
@@ -143,7 +139,6 @@ class GraphRunner:
             resolved_prompts = await resolver.get_all_active()
             prompts = {pid: rp.content for pid, rp in resolved_prompts.items()}
 
-            # Record which versions the workflow uses (best-effort)
             await resolver.record_for_workflow(workflow_id)
 
             return prompts
@@ -286,7 +281,6 @@ class GraphRunner:
         Raises:
             ValueError: If required fields are missing.
         """
-        # Parse issue from issue_cache
         issue = None
         if state.issue_cache:
             issue = Issue.model_validate(state.issue_cache)
@@ -315,7 +309,6 @@ class GraphRunner:
             if plan_cache.current_task_index is not None:
                 plan_fields["current_task_index"] = plan_cache.current_task_index
 
-        # Reconstruct ImplementationState
         impl_state = ImplementationState(
             workflow_id=state.id,
             profile_id=profile.name,
@@ -356,7 +349,6 @@ class GraphRunner:
             config: The RunnableConfig with thread_id.
         """
         try:
-            # Fetch current checkpoint state from LangGraph
             checkpoint_state = await graph.aget_state(config)
             if checkpoint_state is None or checkpoint_state.values is None:
                 logger.warning(
@@ -365,11 +357,9 @@ class GraphRunner:
                 )
                 return
 
-            # Check for goal and plan_markdown from agentic execution
             goal = checkpoint_state.values.get("goal")
             plan_markdown = checkpoint_state.values.get("plan_markdown")
 
-            # Log checkpoint values for debugging
             logger.info(
                 "Syncing plan from checkpoint",
                 workflow_id=workflow_id,
@@ -387,7 +377,6 @@ class GraphRunner:
                 )
                 return
 
-            # Create PlanCache from checkpoint values
             plan_cache = PlanCache.from_checkpoint_values(checkpoint_state.values)
 
             # Update plan_cache column directly (efficient, no full state load)
@@ -459,10 +448,6 @@ class GraphRunner:
             "key_files": plan_result.key_files,
             "total_tasks": plan_result.total_tasks,
         }
-
-    # ------------------------------------------------------------------
-    # Trajectory finalization
-    # ------------------------------------------------------------------
 
     async def _get_review_verdicts(self, workflow_id: uuid.UUID) -> list[dict[str, Any]]:
         """Read the final review verdicts from the LangGraph checkpoint, if any.
@@ -558,10 +543,6 @@ class GraphRunner:
                 status=status,
             )
 
-    # ------------------------------------------------------------------
-    # Execution drivers
-    # ------------------------------------------------------------------
-
     async def run_workflow(
         self,
         workflow_id: uuid.UUID,
@@ -588,14 +569,12 @@ class GraphRunner:
             )
             return
 
-        # Get profile from settings using profile_id (with worktree_path fallback)
         profile = await self.get_profile_or_fail(
             workflow_id, profile_id, state.worktree_path
         )
         if profile is None:
             return
 
-        # Resolve prompts before starting workflow
         prompts = await self.resolve_prompts(workflow_id)
 
         # CRITICAL: Pass interrupt_before to enable server-mode approval
@@ -620,14 +599,12 @@ class GraphRunner:
         # Use astream with stream_mode="updates" to detect interrupts
         # astream_events does NOT surface __interrupt__ events
 
-        # BUG FIX (#199): Check if checkpoint exists before starting.
         # If we have an existing checkpoint, pass None to resume from it.
         # If no checkpoint, pass initial_state to start fresh.
         # This prevents the infinite loop bug where retries would restart
         # the workflow from review_iteration=0 instead of resuming.
         checkpoint_state = await graph.aget_state(config)
         if checkpoint_state is not None and checkpoint_state.values:
-            # Checkpoint exists - resume from it
             logger.debug(
                 "Resuming workflow from existing checkpoint",
                 workflow_id=workflow_id,
@@ -635,8 +612,6 @@ class GraphRunner:
             )
             input_state = None
         else:
-            # No checkpoint - start fresh with initial state
-            # Reconstruct ImplementationState from columns
             input_state = await self._reconstruct_initial_state(state, profile)
 
             logger.debug(
@@ -667,7 +642,6 @@ class GraphRunner:
                 )
                 await self._repository.set_status(workflow_id, WorkflowStatus.BLOCKED)
                 break
-            # Handle combined mode chunk
             await self._events.handle_combined_stream_chunk(workflow_id, chunk_tuple)
 
         if not was_interrupted:
@@ -702,7 +676,6 @@ class GraphRunner:
             )
             return
 
-        # Get profile from settings using profile_id (with worktree_path fallback)
         profile = await self.get_profile_or_fail(
             workflow_id, profile_id, state.worktree_path
         )
@@ -1011,10 +984,8 @@ class GraphRunner:
         if profile is None:
             return
 
-        # Resolve prompts before starting workflow
         prompts = await self.resolve_prompts(workflow_id)
 
-        # Use dedicated review graph for review workflows
         graph = create_review_graph(
             checkpointer=self._checkpointer,
         )
@@ -1051,7 +1022,6 @@ class GraphRunner:
             try:
                 await self._repository.set_status(workflow_id, WorkflowStatus.IN_PROGRESS)
 
-                # Convert Pydantic model to JSON-serializable dict for checkpointing
                 initial_state = execution_state.model_dump(mode="json")
 
                 async for chunk in graph.astream(
@@ -1082,7 +1052,6 @@ class GraphRunner:
                             failure_reason="Unexpected interrupt in review workflow",
                         )
                         return
-                    # Emit stage events for each node
                     await self._events.handle_combined_stream_chunk(workflow_id, chunk_tuple)
 
                 await self._events.emit(
@@ -1210,7 +1179,6 @@ class GraphRunner:
             config = self.build_runnable_config(workflow_id, profile, prompts, sandbox_provider)
 
             was_interrupted = False
-            # Convert Pydantic model to JSON-serializable dict for checkpointing
             input_state = execution_state.model_dump(mode="json")
 
             async for chunk in graph.astream(
@@ -1230,7 +1198,6 @@ class GraphRunner:
                         workflow_id=workflow_id,
                         interrupt_data=interrupt_data,
                     )
-                    # Sync plan from LangGraph checkpoint to ServerExecutionState
                     await self._sync_plan_from_checkpoint(workflow_id, graph, config)
 
                     # Re-fetch to avoid clobbering concurrent updates
@@ -1264,7 +1231,6 @@ class GraphRunner:
 
                     break
 
-                # Handle combined mode chunk (updates, tasks)
                 await self._events.handle_combined_stream_chunk(workflow_id, chunk_tuple)
 
             if not was_interrupted:
@@ -1279,7 +1245,6 @@ class GraphRunner:
             logger.info("Planning task cancelled", workflow_id=workflow_id)
             raise
         except Exception as e:
-            # Mark workflow as failed using fresh state
             try:
                 fresh = await self._repository.get(workflow_id)
                 if fresh is not None and fresh.workflow_status == WorkflowStatus.PENDING:

--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -336,14 +336,12 @@ class OrchestratorService:
         """
         profile = await self._resolve_profile(profile_name, worktree_path)
 
-        # Branch creation for local (non-sandbox) workflows
         created_branch: str | None = None
         if profile.sandbox.mode not in (SandboxMode.DAYTONA, SandboxMode.CONTAINER):
             created_branch = await self._setup_workflow_branch(
                 worktree_path, issue_id, branch,
             )
 
-        # Construct issue from provided title or fetch from tracker
         if task_title is not None:
             issue = Issue(
                 id=issue_id,
@@ -351,27 +349,21 @@ class OrchestratorService:
                 description=task_description or task_title,
             )
         else:
-            # Fetch issue from tracker
             tracker = create_tracker(profile)
             issue = tracker.get_issue(issue_id, cwd=worktree_path)
 
-        # Get current HEAD to track changes
         base_commit = await get_git_head(worktree_path)
 
-        # Load design from artifact path if provided
         design = None
         if artifact_path:
-            # Resolve worktree path to canonical form for validation
             worktree_resolved = Path(worktree_path).resolve()
             artifact_as_path = Path(artifact_path)
 
-            # Handle both absolute and relative paths
             if artifact_as_path.is_absolute():
                 resolved_artifact = artifact_as_path.resolve()
                 # Check if absolute path is within worktree (e.g., from LLM write_design_doc)
                 try:
                     resolved_artifact.relative_to(worktree_resolved)
-                    # Path is within worktree, use it directly
                     full_artifact_path = resolved_artifact
                 except ValueError:
                     # Absolute path outside worktree - treat as worktree-relative
@@ -379,7 +371,6 @@ class OrchestratorService:
                     relative_artifact = artifact_path.removeprefix("/")
                     full_artifact_path = (worktree_resolved / relative_artifact).resolve()
             else:
-                # Relative path: resolve against worktree
                 full_artifact_path = (worktree_resolved / artifact_path).resolve()
 
             # Validate the resolved path stays within the worktree
@@ -396,7 +387,6 @@ class OrchestratorService:
 
             design = Design.from_file(full_artifact_path)
 
-        # Create ImplementationState with all required fields
         execution_state = ImplementationState(
             workflow_id=workflow_id,
             profile_id=profile.name,
@@ -440,7 +430,6 @@ class OrchestratorService:
 
         current_branch = await get_current_branch(worktree_path)
 
-        # Validate we're on a default branch (or detached HEAD is an error)
         if current_branch is None:
             raise ValueError(
                 "Currently in detached HEAD state. "
@@ -465,7 +454,6 @@ class OrchestratorService:
                 f"or pass --branch to use the current branch as-is."
             )
 
-        # Determine target branch name
         target_branch = branch if branch else f"amelia/{issue_id}"
 
         await create_and_checkout_branch(worktree_path, target_branch)
@@ -612,8 +600,6 @@ class OrchestratorService:
 
             workflow_id = uuid4()
 
-            # Prepare issue and execution state using the helper
-            # This also loads the profile from the database
             _, loaded_profile, execution_state, created_branch = await self._prepare_workflow_state(
                 workflow_id=workflow_id,
                 worktree_path=resolved_path,
@@ -645,10 +631,8 @@ class OrchestratorService:
                     raise WorkflowConflictError(resolved_path, "existing") from e
                 raise
 
-            # Record the run's ATIF trajectory from the first agent invocation
             self._ensure_recorder(workflow_id, issue_id, loaded_profile)
 
-            # Start async task with retry wrapper for transient failures
             task = asyncio.create_task(self._runner.run_workflow_with_retry(workflow_id, state))
             self._active_tasks[resolved_path] = (workflow_id, task)
 
@@ -673,14 +657,12 @@ class OrchestratorService:
             InvalidWorktreeError: If worktree doesn't exist or isn't a git repo.
             ValueError: If settings are invalid or profile not found.
         """
-        # Validate and resolve worktree path securely
         worktree = self._validate_worktree_path(request.worktree_path)
         resolved_path = str(worktree)
 
         # Generate workflow ID before preparing state (required by ImplementationState)
         workflow_id = uuid4()
 
-        # Prepare common workflow state (settings, profile, issue, execution_state)
         resolved_path, profile, execution_state, created_branch = await self._prepare_workflow_state(
             workflow_id=workflow_id,
             worktree_path=resolved_path,
@@ -692,7 +674,6 @@ class OrchestratorService:
             branch=request.branch,
         )
 
-        # Handle external plan if provided
         plan_cache: PlanCache | None = None
         if request.plan_file is not None or request.plan_content is not None:
             working_dir = Path(profile.repo_root)
@@ -704,7 +685,6 @@ class OrchestratorService:
                 working_dir,
             )
 
-            # Import and validate external plan (regex extraction)
             plan_result = await import_external_plan(
                 plan_file=request.plan_file,
                 plan_content=request.plan_content,
@@ -713,7 +693,6 @@ class OrchestratorService:
                 workflow_id=workflow_id,
             )
 
-            # Update execution state with plan data and external flag
             execution_state = execution_state.model_copy(
                 update={
                     "external_plan": True,
@@ -734,7 +713,6 @@ class OrchestratorService:
                 external_plan=True,
             )
 
-        # Create ServerExecutionState in pending status (not started)
         # execution_state.issue is always set by _prepare_workflow_state
         assert execution_state.issue is not None
         state = ServerExecutionState(
@@ -750,10 +728,8 @@ class OrchestratorService:
             # No started_at - workflow hasn't started
         )
 
-        # Save to database
         await self._repository.create(state)
 
-        # Emit created event
         await self._events.emit(
             workflow_id,
             EventType.WORKFLOW_CREATED,
@@ -836,7 +812,6 @@ class OrchestratorService:
 
             await self._repository.create(state)
 
-            # Start with review graph instead of full graph
             task = asyncio.create_task(
                 self._runner.run_review_workflow(
                     new_id, state, execution_state,
@@ -869,7 +844,6 @@ class OrchestratorService:
             WorkflowConflictError: If worktree already has active workflow.
             ConcurrencyLimitError: If at max concurrent workflows.
         """
-        # Validate and resolve worktree path securely
         # Note: review workflow doesn't require .git, so we do minimal validation
         try:
             worktree = Path(worktree_path).expanduser().resolve()
@@ -881,7 +855,6 @@ class OrchestratorService:
 
         loaded_profile = await self._resolve_profile(profile, resolved_path)
 
-        # Create dummy issue for review context
         dummy_issue = Issue(
             id="LOCAL-REVIEW",
             title="Local Code Review",
@@ -920,7 +893,6 @@ class OrchestratorService:
         if not workflow:
             raise WorkflowNotFoundError(workflow_id)
 
-        # Check if workflow is in a cancellable state (not terminal)
         cancellable_states = {WorkflowStatus.PENDING, WorkflowStatus.IN_PROGRESS, WorkflowStatus.BLOCKED}
         if workflow.workflow_status not in cancellable_states:
             raise InvalidStateError(
@@ -929,7 +901,6 @@ class OrchestratorService:
                 current_status=workflow.workflow_status,
             )
 
-        # Cancel the in-memory task if running
         if workflow.worktree_path in self._active_tasks:
             _, task = self._active_tasks[workflow.worktree_path]
             task.cancel()
@@ -937,7 +908,6 @@ class OrchestratorService:
         if workflow_id in self._planning_tasks:
             self._planning_tasks[workflow_id].cancel()
 
-        # Persist the cancelled status to database
         await self._repository.set_status(workflow_id, WorkflowStatus.CANCELLED)
 
         # Finalize the trajectory with the cancelled outcome (no-op if the
@@ -987,7 +957,6 @@ class OrchestratorService:
                     current_status=workflow.workflow_status,
                 )
 
-            # Clear error state and transition to IN_PROGRESS
             workflow.failure_reason = None
             workflow.completed_at = None
             workflow.workflow_status = WorkflowStatus.IN_PROGRESS
@@ -1003,7 +972,6 @@ class OrchestratorService:
             # Continue the trajectory: an existing file is loaded and appended to
             await self._ensure_recorder_for_state(workflow)
 
-            # Launch workflow task (same as start_workflow)
             task = asyncio.create_task(
                 self._runner.run_workflow_with_retry(workflow_id, workflow)
             )
@@ -1027,7 +995,6 @@ class OrchestratorService:
                 with contextlib.suppress(TimeoutError, asyncio.CancelledError):
                     await asyncio.wait_for(task, timeout=timeout)
 
-        # Cancel any active planning tasks
         for _workflow_id, task in list(self._planning_tasks.items()):
             task.cancel()
             with contextlib.suppress(TimeoutError, asyncio.CancelledError):
@@ -1053,7 +1020,6 @@ class OrchestratorService:
         Returns:
             Workflow state if found, None otherwise.
         """
-        # Use cached workflow_id for O(1) lookup
         entry = self._active_tasks.get(worktree_path)
         if not entry:
             return None
@@ -1134,12 +1100,10 @@ class OrchestratorService:
             WorkflowNotFoundError: If workflow doesn't exist.
             InvalidStateError: If workflow is not in "blocked" state.
         """
-        # Validate workflow exists and get current state
         workflow = await self._repository.get(workflow_id)
         if not workflow:
             raise WorkflowNotFoundError(workflow_id)
 
-        # Validate workflow is in blocked state
         if workflow.workflow_status != WorkflowStatus.BLOCKED:
             raise InvalidStateError(
                 f"Cannot reject workflow in '{workflow.workflow_status}' state",
@@ -1148,7 +1112,6 @@ class OrchestratorService:
             )
 
         async with self._approval_lock:
-            # Update workflow status to failed with feedback
             await self._repository.set_status(
                 workflow_id, WorkflowStatus.FAILED, failure_reason=feedback
             )
@@ -1158,7 +1121,6 @@ class OrchestratorService:
                 f"Plan rejected: {feedback}",
             )
 
-            # Cancel the waiting task
             if workflow.worktree_path in self._active_tasks:
                 _, task = self._active_tasks[workflow.worktree_path]
                 task.cancel()
@@ -1177,7 +1139,6 @@ class OrchestratorService:
         failed_count = 0
         blocked_count = 0
 
-        # Handle IN_PROGRESS workflows — mark as FAILED
         in_progress = await self._repository.find_by_status([WorkflowStatus.IN_PROGRESS])
         for wf in in_progress:
             await self._repository.set_status(
@@ -1194,7 +1155,6 @@ class OrchestratorService:
             logger.info("Recovered interrupted workflow", workflow_id=wf.id)
             failed_count += 1
 
-        # Handle BLOCKED workflows — re-emit approval events
         blocked = await self._repository.find_by_status([WorkflowStatus.BLOCKED])
         for wf in blocked:
             await self._events.emit(
@@ -1265,10 +1225,8 @@ class OrchestratorService:
             # Note: started_at is None - workflow hasn't started yet
         )
 
-        # Save initial state
         await self._repository.create(state)
 
-        # Emit workflow created event
         await self._events.emit(
             workflow_id,
             EventType.WORKFLOW_CREATED,
@@ -1276,16 +1234,13 @@ class OrchestratorService:
             data={"issue_id": request.issue_id, "queued": True, "planning": True},
         )
 
-        # Planning runs the architect — record it into the workflow trajectory
         self._ensure_recorder(workflow_id, request.issue_id, profile)
 
-        # Spawn planning task in background (non-blocking)
         task = asyncio.create_task(
             self._runner.run_planning_task(workflow_id, state, execution_state, profile)
         )
         self._planning_tasks[workflow_id] = task
 
-        # Cleanup on completion
         def cleanup_planning(_: asyncio.Task[None]) -> None:
             self._planning_tasks.pop(workflow_id, None)
 
@@ -1310,12 +1265,10 @@ class OrchestratorService:
             ConcurrencyLimitError: If at max concurrent workflows.
         """
         async with self._start_lock:
-            # Get workflow from repository
             workflow = await self._repository.get(workflow_id)
             if not workflow:
                 raise WorkflowNotFoundError(workflow_id)
 
-            # Validate workflow is in pending state
             if workflow.workflow_status != WorkflowStatus.PENDING:
                 raise InvalidStateError(
                     f"Cannot start workflow in '{workflow.workflow_status}' state",
@@ -1323,7 +1276,6 @@ class OrchestratorService:
                     current_status=workflow.workflow_status,
                 )
 
-            # Check for worktree conflict - another active workflow on same worktree
             active_on_worktree = await self._repository.get_by_worktree(
                 workflow.worktree_path
             )
@@ -1332,10 +1284,8 @@ class OrchestratorService:
                     workflow.worktree_path, active_on_worktree.id
                 )
 
-            # Also check in-memory tasks for worktree conflict and limit
             self._assert_can_acquire_worktree(workflow.worktree_path)
 
-            # Checkout the workflow branch if one was persisted
             if workflow.branch:
                 from amelia.tools.git_utils import checkout_branch  # noqa: PLC0415
 
@@ -1354,10 +1304,8 @@ class OrchestratorService:
             workflow.started_at = datetime.now(UTC)
             await self._repository.update(workflow)
 
-            # Record the run's ATIF trajectory (best-effort profile resolution)
             await self._ensure_recorder_for_state(workflow)
 
-            # Spawn execution task
             task = asyncio.create_task(
                 self._runner.run_workflow_with_retry(workflow_id, workflow)
             )
@@ -1384,15 +1332,11 @@ class OrchestratorService:
         started: list[str] = []
         errors: dict[str, str] = {}
 
-        # Determine which workflows to start
         if request.workflow_ids:
-            # Start specific workflow IDs
             workflow_ids = request.workflow_ids
         else:
-            # Get all pending workflows
             pending_workflows = await self._repository.find_by_status([WorkflowStatus.PENDING])
 
-            # Filter by worktree_path if specified
             if request.worktree_path:
                 pending_workflows = [
                     w for w in pending_workflows
@@ -1401,7 +1345,6 @@ class OrchestratorService:
 
             workflow_ids = [str(w.id) for w in pending_workflows]
 
-        # Attempt to start each workflow
         for workflow_id in workflow_ids:
             try:
                 await self.start_pending_workflow(uuid.UUID(workflow_id))
@@ -1494,14 +1437,12 @@ class OrchestratorService:
                 "Plan already exists. Use force=true to overwrite."
             )
 
-        # Ensure profile_id exists
         if workflow.profile_id is None:
             raise InvalidStateError(
                 "Cannot set plan: workflow has no profile_id",
                 workflow_id=workflow_id,
             )
 
-        # Get profile for plan path resolution
         profile = await self._runner.get_profile_or_fail(
             workflow_id,
             workflow.profile_id,
@@ -1512,13 +1453,11 @@ class OrchestratorService:
 
         profile = update_profile_repo_root(profile, workflow.worktree_path)
 
-        # Resolve target plan path
         working_dir = Path(profile.repo_root)
         target_path = self._resolve_target_plan_path(
             plan_file, profile.plan_path_pattern, workflow.issue_id, working_dir
         )
 
-        # Delegate to import_external_plan for read, write, extract, validate
         plan_result = await import_external_plan(
             plan_file=plan_file,
             plan_content=plan_content,
@@ -1527,7 +1466,6 @@ class OrchestratorService:
             workflow_id=workflow_id,
         )
 
-        # Save PlanCache with goal populated
         plan_cache = PlanCache(
             goal=plan_result.goal,
             plan_markdown=plan_result.plan_markdown,
@@ -1537,7 +1475,6 @@ class OrchestratorService:
         )
         await self._repository.update_plan_cache(workflow_id, plan_cache)
 
-        # Emit validation event and build response
         result = await self._runner.emit_plan_validation_event(workflow_id, plan_result)
 
         logger.info(
@@ -1618,11 +1555,8 @@ class OrchestratorService:
             empty_plan_cache = PlanCache()
             await self._repository.update_plan_cache(workflow_id, empty_plan_cache)
 
-            # Transition to PENDING
             await self._repository.set_status(workflow_id, WorkflowStatus.PENDING)
 
-            # Reconstruct ImplementationState for graph input
-            # Parse issue from issue_cache
             issue = None
             if workflow.issue_cache:
                 issue = Issue.model_validate(workflow.issue_cache)
@@ -1631,7 +1565,6 @@ class OrchestratorService:
                 tracker = create_tracker(profile)
                 issue = tracker.get_issue(workflow.issue_id, cwd=workflow.worktree_path)
 
-            # Get current HEAD as base commit
             base_commit = await get_git_head(workflow.worktree_path)
 
             execution_state = ImplementationState(
@@ -1654,11 +1587,9 @@ class OrchestratorService:
                 data={"stage": "architect", "replan": True},
             )
 
-            # Replanning re-runs the architect — keep recording into the trajectory
             self._ensure_recorder(workflow_id, workflow.issue_id, profile)
 
-            # Spawn planning task in background (reuses existing runner.run_planning_task).
-            # Note: workflow/execution_state are only used as initial graph input
+            # workflow/execution_state are only used as initial graph input
             # (see runner.run_planning_task docstring). The reconstructed execution_state
             # seeds a fresh planning run. The task re-fetches from the repository
             # before any mutations, so staleness is safe.
@@ -1732,7 +1663,6 @@ class OrchestratorService:
                 workflow_id=workflow_id,
             )
 
-        # Get diff content
         diff_content = ""
         if base_commit:
             try:

--- a/amelia/server/routes/brainstorm.py
+++ b/amelia/server/routes/brainstorm.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
 router = APIRouter(tags=["brainstorm"])
 
 
-# Dependency placeholder - will be properly wired in main.py
 def get_brainstorm_service() -> BrainstormService:
     """Get BrainstormService dependency.
 
@@ -106,7 +105,6 @@ async def get_profile_info(
         return None
 
 
-# Request/Response Models
 class CreateSessionRequest(BaseModel):
     """Request to create a new brainstorming session."""
 
@@ -155,9 +153,6 @@ class HandoffResponse(BaseModel):
 
     workflow_id: uuid.UUID
     status: str
-
-
-# Session Lifecycle Endpoints
 @router.post(
     "/sessions",
     status_code=status.HTTP_201_CREATED,
@@ -235,7 +230,6 @@ async def get_session(
             detail=f"Session not found: {session_id}",
         )
 
-    # Load profile info for display
     session = result["session"]
     profile_info = await get_profile_info(session.profile_id, profile_repo)
 
@@ -261,7 +255,6 @@ async def delete_session(
     await service.delete_session(session_id)
 
 
-# Chat Endpoints
 @router.post(
     "/sessions/{session_id}/message",
     status_code=status.HTTP_202_ACCEPTED,
@@ -322,7 +315,6 @@ async def send_message(
                 session_id=str(session_id),
                 message_id=str(message_id),
             )
-            # Emit error event to notify frontend
             error_event = WorkflowEvent(
                 id=uuid4(),
                 workflow_id=session_id,
@@ -345,7 +337,6 @@ async def send_message(
     return SendMessageResponse(message_id=message_id)
 
 
-# Handoff Endpoint
 @router.post(
     "/sessions/{session_id}/handoff",
     response_model=HandoffResponse,

--- a/amelia/server/routes/config.py
+++ b/amelia/server/routes/config.py
@@ -54,13 +54,10 @@ async def get_server_config(
         Server configuration including repo_root, max_concurrent, active_profile,
         and active_profile_info.
     """
-    # Get server settings for max_concurrent
     server_settings = await settings_repo.get_server_settings()
 
-    # Get active profile
     active_profile = await profile_repo.get_active_profile()
 
-    # Build response based on whether there's an active profile
     if active_profile is None:
         return ConfigResponse(
             repo_root="",

--- a/amelia/server/routes/files.py
+++ b/amelia/server/routes/files.py
@@ -38,7 +38,6 @@ def _validate_and_resolve_path(user_path: str, working_dir: Path) -> Path:
     """
     path = Path(user_path)
 
-    # Resolve relative paths against the working directory
     if not path.is_absolute():
         path = working_dir / path
 
@@ -68,7 +67,6 @@ def _validate_and_resolve_path(user_path: str, working_dir: Path) -> Path:
             "Path not accessible (outside working directory)", "PATH_NOT_ACCESSIBLE"
         )
 
-    # Check file exists
     if not resolved_path.exists():
         raise FileOperationError("File not found", "FILE_NOT_FOUND", status_code=404)
 
@@ -131,7 +129,6 @@ async def read_file(
     Raises:
         FileOperationError: If path is invalid, outside working_dir, or file doesn't exist.
     """
-    # Determine base directory
     if worktree_path:
         base_dir = Path(worktree_path)
         if not base_dir.is_absolute():
@@ -185,7 +182,6 @@ async def list_files(
     Raises:
         FileOperationError: If directory is outside base directory or base directory doesn't exist.
     """
-    # Determine base directory
     if worktree_path:
         base_dir = Path(worktree_path)
         if not base_dir.is_absolute():
@@ -234,7 +230,6 @@ async def list_files(
                     modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
                 )
             )
-        # Sort by modification time, newest first
         result.sort(key=lambda e: e.modified_at, reverse=True)
         return result
 
@@ -266,7 +261,6 @@ async def get_file(
     Raises:
         FileOperationError: If path is invalid, outside working_dir, or file doesn't exist.
     """
-    # Determine base directory
     if worktree_path:
         base_dir = Path(worktree_path)
         if not base_dir.is_absolute():
@@ -284,13 +278,11 @@ async def get_file(
     # Validate and resolve path - returns only after all security checks pass
     resolved_path = _validate_and_resolve_path(file_path, base_dir)
 
-    # Read content
     try:
         content = await asyncio.to_thread(resolved_path.read_text, encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
         raise FileOperationError(f"Failed to read file: {e}", "READ_ERROR") from e
 
-    # Determine content type based on extension
     suffix = resolved_path.suffix.lower()
     content_type = {
         ".md": "text/markdown",

--- a/amelia/server/routes/github.py
+++ b/amelia/server/routes/github.py
@@ -34,9 +34,6 @@ _GH_ISSUE_LIMIT = "50"
 _MAX_BODY_LENGTH = 5000
 
 
-# ---------------------------------------------------------------------------
-# Issue models and endpoint
-# ---------------------------------------------------------------------------
 
 
 class GitHubIssueLabel(BaseModel):
@@ -152,9 +149,6 @@ async def list_github_issues(
     )
 
 
-# ---------------------------------------------------------------------------
-# PR models
-# ---------------------------------------------------------------------------
 
 
 class TriggerPRAutoFixRequest(BaseModel):
@@ -224,9 +218,6 @@ async def _get_repo_name(repo_root: str) -> str:
     return stdout_bytes.decode().strip()
 
 
-# ---------------------------------------------------------------------------
-# PR endpoints
-# ---------------------------------------------------------------------------
 
 
 @router.get("/prs/config", response_model=PRAutoFixStatusResponse)
@@ -341,7 +332,6 @@ async def trigger_pr_autofix(
 
     repo = await _get_repo_name(resolved.repo_root)
 
-    # Determine config override
     effective_config: PRAutoFixConfig | None = None
     if body and body.aggressiveness:
         try:

--- a/amelia/server/routes/metrics.py
+++ b/amelia/server/routes/metrics.py
@@ -36,14 +36,12 @@ def _resolve_date_range(
     Raises:
         HTTPException: 400 on invalid combinations.
     """
-    # Validate mutual exclusivity
     if preset is not None and (start is not None or end is not None):
         raise HTTPException(
             status_code=400,
             detail="Provide either start/end or preset, not both.",
         )
 
-    # Validate date parameters
     if bool(start) != bool(end):
         raise HTTPException(
             status_code=400,
@@ -55,7 +53,6 @@ def _resolve_date_range(
             detail="Start date must be on or before end date.",
         )
 
-    # Determine date range
     if start and end:
         return start, end
 
@@ -76,7 +73,6 @@ def _resolve_date_range(
         start_date = end_date - timedelta(days=days - 1)
         return start_date, end_date
 
-    # Default to 30d
     end_date = datetime.now(UTC).date()
     start_date = end_date - timedelta(days=29)
     return start_date, end_date

--- a/amelia/server/routes/oracle.py
+++ b/amelia/server/routes/oracle.py
@@ -22,7 +22,6 @@ from amelia.server.events.bus import EventBus
 router = APIRouter(tags=["oracle"])
 
 
-# --- Request / Response models ---
 
 
 class OracleConsultRequest(BaseModel):
@@ -57,9 +56,6 @@ class OracleConsultResponse(BaseModel):
     consultation: OracleConsultation
 
 
-# --- Dependency stubs (overridden in main.py) ---
-
-
 def get_event_bus() -> EventBus:
     """Get EventBus -- overridden in main.py."""
     raise NotImplementedError("Must be overridden via dependency_overrides")
@@ -88,9 +84,6 @@ def _validate_repo_root(requested: str, profile_root: str) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"working_dir must be within profile root: {profile_root}",
         ) from exc
-
-
-# --- Route ---
 
 
 @router.post(
@@ -122,7 +115,6 @@ async def create_consultation(
         HTTPException: 400 if working_dir invalid or oracle not configured.
         HTTPException: 404 if profile not found.
     """
-    # Resolve profile
     if request.profile_id:
         profile = await profile_repo.get_profile(request.profile_id)
         if profile is None:
@@ -138,10 +130,8 @@ async def create_consultation(
                 detail="No active profile",
             )
 
-    # Validate working_dir
     _validate_repo_root(request.working_dir, profile.repo_root)
 
-    # Get oracle agent config
     try:
         agent_config = profile.get_agent_config("oracle")
     except ValueError as exc:
@@ -150,7 +140,6 @@ async def create_consultation(
             detail=str(exc),
         ) from exc
 
-    # Override model if provided
     if request.model:
         agent_config = AgentConfig(
             driver=agent_config.driver,
@@ -158,7 +147,6 @@ async def create_consultation(
             options=agent_config.options,
         )
 
-    # Run consultation
     oracle = Oracle(config=agent_config, event_bus=event_bus)
     result: OracleConsultResult = await oracle.consult(
         problem=request.problem,

--- a/amelia/server/routes/paths.py
+++ b/amelia/server/routes/paths.py
@@ -117,7 +117,6 @@ async def validate_path(request: PathValidationRequest) -> PathValidationRespons
     """
     file_path = Path(request.path)
 
-    # Check if path is absolute
     if not file_path.is_absolute():
         return PathValidationResponse(
             exists=False,
@@ -151,7 +150,6 @@ async def validate_path(request: PathValidationRequest) -> PathValidationRespons
             message="Path must be within the home directory",
         )
 
-    # Check existence
     if not resolved_path.exists():
         return PathValidationResponse(
             exists=False,
@@ -159,7 +157,6 @@ async def validate_path(request: PathValidationRequest) -> PathValidationRespons
             message="Path does not exist",
         )
 
-    # Check if it's a directory
     if not resolved_path.is_dir():
         return PathValidationResponse(
             exists=True,
@@ -167,7 +164,6 @@ async def validate_path(request: PathValidationRequest) -> PathValidationRespons
             message="Path is a file, not a directory",
         )
 
-    # Check if it's a git repository
     # .git is a directory for regular repos, or a file with a gitdir pointer for worktrees
     git_dir = resolved_path / ".git"
     is_git_repo = git_dir.is_dir()
@@ -189,7 +185,6 @@ async def validate_path(request: PathValidationRequest) -> PathValidationRespons
     branch = await _get_git_branch(resolved_path)
     has_changes = await _has_uncommitted_changes(resolved_path)
 
-    # Build message
     change_indicator = " with uncommitted changes" if has_changes else ""
     branch_info = f" on branch '{branch}'" if branch else ""
     message = f"Git repository{branch_info}{change_indicator}"

--- a/amelia/server/routes/prompts.py
+++ b/amelia/server/routes/prompts.py
@@ -1,4 +1,3 @@
-# amelia/server/routes/prompts.py
 """API routes for prompt configuration.
 
 Provides endpoints for listing, viewing, and editing agent prompts.
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
 router = APIRouter(prefix="/api/prompts", tags=["prompts"])
 
 
-# Dependency placeholder - will be overridden by app
 def get_prompt_repository() -> "PromptRepository":
     """Get prompt repository dependency.
 
@@ -36,9 +34,6 @@ def get_prompt_repository() -> "PromptRepository":
         "Prompt repository dependency not configured. "
         "Ensure the app has overridden this dependency."
     )
-
-
-# Request/Response models
 
 
 class PromptSummary(BaseModel):
@@ -193,9 +188,6 @@ class ResetResponse(BaseModel):
     message: str
 
 
-# Routes
-
-
 @router.get("", response_model=PromptListResponse)
 async def list_prompts(
     repository: "PromptRepository" = Depends(get_prompt_repository),
@@ -210,7 +202,6 @@ async def list_prompts(
     """
     prompts = await repository.list_prompts()
 
-    # Get version numbers for active versions
     summaries = []
     for prompt in prompts:
         version_number = None

--- a/amelia/server/routes/settings.py
+++ b/amelia/server/routes/settings.py
@@ -1,4 +1,3 @@
-# amelia/server/routes/settings.py
 """API routes for server settings and profiles."""
 import os
 from collections.abc import Mapping
@@ -71,7 +70,6 @@ def _validate_required_agents(agents: Mapping[str, object] | None) -> None:
             raise ValueError(f"Missing required agents: {', '.join(sorted(missing))}")
 
 
-# Response models
 class ServerSettingsResponse(BaseModel):
     """Server settings API response."""
 
@@ -213,7 +211,6 @@ async def fetch_openrouter_model_entry(model_id: str) -> ModelCacheEntry | None:
     return None
 
 
-# Server settings endpoints
 @router.get("/settings", response_model=ServerSettingsResponse)
 async def get_server_settings(
     repo: SettingsRepository = Depends(get_settings_repository),
@@ -266,7 +263,6 @@ async def get_model(
     return to_model_lookup_response(fetched)
 
 
-# Profile endpoints
 @router.get("/profiles", response_model=list[ProfileResponse])
 async def list_profiles(
     repo: ProfileRepository = Depends(get_profile_repository),
@@ -284,7 +280,6 @@ async def create_profile(
     repo: ProfileRepository = Depends(get_profile_repository),
 ) -> ProfileResponse:
     """Create a new profile."""
-    # Convert AgentConfigCreate to AgentConfig
     agents = {
         name: AgentConfig(
             driver=config.driver,
@@ -335,7 +330,6 @@ async def update_profile(
     """Update a profile."""
     update_dict: dict[str, Any] = {}
 
-    # Handle simple fields
     for field in ["tracker", "repo_root", "plan_output_dir", "plan_path_pattern"]:
         value = getattr(updates, field)
         if value is not None:

--- a/amelia/server/routes/usage.py
+++ b/amelia/server/routes/usage.py
@@ -21,7 +21,6 @@ from amelia.trajectory import aggregate_usage, load as load_trajectory
 
 router = APIRouter(prefix="/usage", tags=["usage"])
 
-# Valid preset values
 PRESETS = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}  # 'all' = 10 years
 
 
@@ -49,14 +48,12 @@ async def get_usage(
     Raises:
         HTTPException: 400 if invalid preset or date combination.
     """
-    # Validate mutual exclusivity
     if preset is not None and (start is not None or end is not None):
         raise HTTPException(
             status_code=400,
             detail="Provide either start/end or preset, not both.",
         )
 
-    # Validate date parameters
     if bool(start) != bool(end):
         raise HTTPException(
             status_code=400,
@@ -68,7 +65,6 @@ async def get_usage(
             detail="Start date must be on or before end date.",
         )
 
-    # Determine date range
     if start and end:
         start_date = start
         end_date = end
@@ -88,7 +84,6 @@ async def get_usage(
         end_date = datetime.now(UTC).date()
         start_date = end_date - timedelta(days=days - 1)
     else:
-        # Default to 30d
         end_date = datetime.now(UTC).date()
         start_date = end_date - timedelta(days=29)
 

--- a/amelia/server/routes/websocket.py
+++ b/amelia/server/routes/websocket.py
@@ -12,7 +12,6 @@ from amelia.server.events.connection_manager import ConnectionManager
 
 router = APIRouter(tags=["websocket"])
 
-# Global connection manager instance
 connection_manager = ConnectionManager()
 
 
@@ -44,7 +43,6 @@ async def websocket_endpoint(
     logger.info("websocket_connected", active_connections=connection_manager.active_connections)
 
     try:
-        # Handle backfill if reconnecting
         if since:
             bus = connection_manager.get_event_bus()
             if bus:
@@ -76,11 +74,9 @@ async def websocket_endpoint(
             else:
                 logger.warning("backfill_unavailable", reason="event_bus_not_initialized")
 
-        # Start heartbeat task
         heartbeat_task = asyncio.create_task(_heartbeat_loop(websocket))
 
         try:
-            # Message handling loop
             while True:
                 data = await websocket.receive_json()
                 message_type = data.get("type")
@@ -102,11 +98,9 @@ async def websocket_endpoint(
                     logger.debug("subscribed_to_all")
 
                 elif message_type == "pong":
-                    # Heartbeat response - just log
                     logger.debug("heartbeat_pong_received")
 
         finally:
-            # Cancel heartbeat when loop exits
             heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task

--- a/amelia/server/routes/workflows.py
+++ b/amelia/server/routes/workflows.py
@@ -52,8 +52,6 @@ from amelia.trajectory import (
 )
 
 
-# Cap on projected history entries in the detail response; mirrors the
-# pre-trajectory wire behavior (last 50 events).
 RECENT_EVENT_LIMIT = 50
 
 
@@ -87,7 +85,6 @@ def _to_workflow_summary(workflow: ServerExecutionState) -> WorkflowSummary:
     )
 
 
-# Create the workflows router
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 
 
@@ -109,8 +106,6 @@ async def create_workflow(
         WorkflowConflictError: If worktree is already in use.
         ConcurrencyLimitError: If concurrent workflow limit is reached.
     """
-    # Let orchestrator handle everything - it will raise appropriate exceptions
-    # Choose method based on start/plan_now flags
     if request.start:
         if request.plan_file is not None or request.plan_content is not None:
             # External plan + immediate start: queue (persists plan_cache) then start
@@ -122,7 +117,6 @@ async def create_workflow(
                 await orchestrator.cancel_workflow(workflow_id)
                 raise
         else:
-            # Immediate execution (existing behavior)
             workflow_id = await orchestrator.start_workflow(
                 issue_id=request.issue_id,
                 worktree_path=request.worktree_path,
@@ -203,7 +197,6 @@ async def list_workflows(
     Raises:
         HTTPException: 400 if cursor is invalid.
     """
-    # Decode cursor
     after_started_at: datetime | None = None
     after_id: str | None = None
     if cursor:
@@ -234,7 +227,6 @@ async def list_workflows(
     if has_more:
         workflows = workflows[:limit]
 
-    # Build next cursor
     next_cursor: str | None = None
     if has_more and workflows:
         last = workflows[-1]
@@ -352,7 +344,6 @@ async def get_workflow(
         summary = trajectory_to_token_summary(trajectory)
         token_usage = summary if summary.breakdown else None
 
-    # Extract plan data from plan_cache
     goal: str | None = None
     plan_markdown: str | None = None
     plan_path: str | None = None
@@ -838,7 +829,6 @@ def configure_exception_handlers(app: FastAPI) -> None:
             JSONResponse with 400 status code.
         """
         logger.warning("Validation error", error=str(exc))
-        # Convert error objects to JSON-serializable format
         errors: list[dict[str, object]] = []
         for error in exc.errors():
             serializable_error: dict[str, object] = {
@@ -846,7 +836,6 @@ def configure_exception_handlers(app: FastAPI) -> None:
                 "loc": list(error["loc"]),
                 "msg": error["msg"],
             }
-            # Add ctx if present
             if "ctx" in error:
                 serializable_error["ctx"] = {
                     k: str(v) for k, v in error["ctx"].items()

--- a/amelia/server/services/brainstorm.py
+++ b/amelia/server/services/brainstorm.py
@@ -49,7 +49,6 @@ from amelia.server.services.brainstormer_agent import (
 )
 
 
-# Default plan path pattern used when no profile is available
 _DEFAULT_PLAN_PATH_PATTERN = "docs/plans/{date}-{issue_key}.md"
 
 
@@ -141,7 +140,6 @@ class BrainstormService:
         Returns:
             Created session.
         """
-        # Look up driver type from brainstormer agent config if available
         driver_type: str | None = None
         if self._profile_repo is not None:
             profile = await self._profile_repo.get_profile(profile_id)
@@ -161,7 +159,6 @@ class BrainstormService:
 
         await self._repository.create_session(session)
 
-        # Emit session created event
         event = WorkflowEvent(
             id=uuid4(),
             workflow_id=session.id,  # Use session_id as workflow_id for events
@@ -206,7 +203,6 @@ class BrainstormService:
         messages = await self._repository.get_messages(session_id)
         artifacts = await self._repository.get_artifacts(session_id)
 
-        # Fetch and attach usage summary to session
         usage_summary = await self._repository.get_session_usage(session_id)
         session.usage_summary = usage_summary
 
@@ -368,11 +364,9 @@ class BrainstormService:
         # Acquire session lock to prevent sequence collisions under concurrent sends
         lock = self._get_session_lock(session_id)
         async with lock:
-            # Get next sequence number and save user message
             max_seq = await self._repository.get_max_sequence(session_id)
             user_sequence = max_seq + 1
 
-            # Detect first message and format prompt accordingly
             is_first_message = max_seq == 0
             if is_first_message:
                 formatted_prompt = BRAINSTORMER_USER_PROMPT_TEMPLATE.format(
@@ -401,7 +395,6 @@ class BrainstormService:
             else:
                 resolved_message_id = uuid4()
 
-            # Invoke driver and stream events
             assistant_content_parts: list[str] = []
             driver_session_id: str | None = None
             suppressed_tool_ids: set[str] = set()  # tool calls converted to text
@@ -427,7 +420,6 @@ class BrainstormService:
                 ):
                     continue
 
-                # Convert to event and emit
                 event = self._agentic_message_to_event(
                     agentic_msg, session_id, resolved_message_id
                 )
@@ -444,7 +436,6 @@ class BrainstormService:
                 self._event_bus.emit(event)
                 yield event
 
-                # Collect result content and session ID
                 if agentic_msg.type == AgenticMessageType.RESULT:
                     if agentic_msg.content:
                         assistant_content_parts.append(agentic_msg.content)
@@ -458,13 +449,11 @@ class BrainstormService:
             if artifact_event:
                 yield artifact_event
 
-            # Update driver session ID if we got one
             if driver_session_id and driver_session_id != session.driver_session_id:
                 session.driver_session_id = driver_session_id
                 session.updated_at = datetime.now(UTC)
                 await self._repository.update_session(session)
 
-            # Extract token usage from driver
             message_usage: MessageUsage | None = None
             driver_usage = driver.get_usage()
             if driver_usage:
@@ -473,7 +462,6 @@ class BrainstormService:
                     fallback_model=getattr(driver, "model", None),
                 )
 
-            # Save assistant message
             assistant_sequence = user_sequence + 1
             assistant_content = "\n".join(assistant_content_parts)
             assistant_message = Message(
@@ -487,7 +475,6 @@ class BrainstormService:
             )
             await self._repository.save_message(assistant_message)
 
-        # Emit message complete event
         complete_event = await self._build_complete_event(
             session_id, assistant_message.id, message_usage
         )
@@ -667,7 +654,6 @@ class BrainstormService:
                     tool_input=agentic_msg.tool_input,
                 )
 
-        # Build message from content
         message = agentic_msg.content or ""
         if agentic_msg.type == AgenticMessageType.TOOL_CALL:
             message = f"Calling {agentic_msg.tool_name or 'tool'}"
@@ -756,19 +742,15 @@ class BrainstormService:
         """
         path_lower = path.lower()
 
-        # Check for ADR pattern
         if "/adr/" in path_lower or "adr-" in path_lower:
             return "adr"
 
-        # Check for spec pattern
         if "/spec/" in path_lower or "-spec" in path_lower or "_spec" in path_lower:
             return "spec"
 
-        # Check for readme pattern
         if "readme" in path_lower:
             return "readme"
 
-        # Check for design/plan pattern
         if (
             "/design/" in path_lower
             or "/plans/" in path_lower
@@ -777,7 +759,6 @@ class BrainstormService:
         ):
             return "design"
 
-        # Default to document
         return "document"
 
     async def handoff_to_implementation(
@@ -810,7 +791,6 @@ class BrainstormService:
         if session is None:
             raise ValueError(f"Session not found: {session_id}")
 
-        # Validate artifact exists
         artifacts = await self._repository.get_artifacts(session_id)
         artifact = next((a for a in artifacts if a.path == artifact_path), None)
         if artifact is None:
@@ -827,7 +807,6 @@ class BrainstormService:
         sid_prefix = str(session_id)[:8]
         issue_id = f"{slug}-{sid_prefix}" if slug else f"brainstorm-{sid_prefix}"
 
-        # Queue workflow with orchestrator
         request = CreateWorkflowRequest(
             issue_id=issue_id,
             worktree_path=worktree_path,
@@ -838,12 +817,10 @@ class BrainstormService:
         )
         workflow_id = await orchestrator.queue_workflow(request)
 
-        # Update session status to completed
         session.status = SessionStatus.COMPLETED
         session.updated_at = datetime.now(UTC)
         await self._repository.update_session(session)
 
-        # Emit session completed event
         event = WorkflowEvent(
             id=uuid4(),
             workflow_id=session_id,

--- a/amelia/server/services/brainstormer_agent.py
+++ b/amelia/server/services/brainstormer_agent.py
@@ -21,7 +21,6 @@ from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.types import Command
 
 
-# Tool description for the write_design_doc tool (markdown-only write)
 WRITE_DESIGN_DOC_DESCRIPTION = """Write a design document (markdown file) to the filesystem.
 
 Usage:
@@ -77,7 +76,6 @@ def _write_design_doc_tool_generator(
         runtime: ToolRuntime[None, FilesystemState],
     ) -> Command[Any] | str:
         """Synchronous write_design_doc implementation."""
-        # Validate markdown extension
         if not file_path.lower().endswith(".md"):
             return (
                 f"Error: write_design_doc only allows markdown files (.md). "
@@ -95,7 +93,6 @@ def _write_design_doc_tool_generator(
         runtime: ToolRuntime[None, FilesystemState],
     ) -> Command[Any] | str:
         """Asynchronous write_design_doc implementation."""
-        # Validate markdown extension
         if not file_path.lower().endswith(".md"):
             return (
                 f"Error: write_design_doc only allows markdown files (.md). "
@@ -115,7 +112,6 @@ def _write_design_doc_tool_generator(
     )
 
 
-# Custom restricted filesystem prompt for brainstormer
 BRAINSTORMER_FILESYSTEM_PROMPT = """## Filesystem Tools
 
 You have access to: `ls`, `read_file`, `glob`, `grep`, `write_design_doc`
@@ -129,7 +125,6 @@ You have access to: `ls`, `read_file`, `glob`, `grep`, `write_design_doc`
 Use the read tools to understand the codebase. Use `write_design_doc` to save your final design."""
 
 
-# System prompt for the brainstormer agent - defines role and behavior
 BRAINSTORMER_SYSTEM_PROMPT = """# Role
 
 You are a design collaborator that helps turn ideas into fully formed designs through natural dialogue.
@@ -176,7 +171,6 @@ You are a design collaborator that helps turn ideas into fully formed designs th
 - **Design documents only - no implementation code**
 """
 
-# User prompt template for the first message in a session
 BRAINSTORMER_USER_PROMPT_TEMPLATE = "Help me design: {idea}"
 
 

--- a/amelia/services/classifier.py
+++ b/amelia/services/classifier.py
@@ -222,35 +222,30 @@ async def classify_comments(
             count=len(comments),
         )
 
-    # Build prompts
     system_prompt_template = PROMPT_DEFAULTS["classifier.system"].content
     system_prompt = system_prompt_template.format(
         aggressiveness_level=config.aggressiveness.name,
     )
     user_prompt = _build_user_prompt(comments)
 
-    # P1 (generate()-style): record the classification call as one invocation
     if recorder is not None:
         invocation = recorder.begin_invocation(
             "classifier", model=getattr(driver, "model", None)
         )
         driver = RecordingDriver(driver, invocation)
 
-    # Call LLM
     output, _session_id = await driver.generate(
         prompt=user_prompt,
         system_prompt=system_prompt,
         schema=ClassificationOutput,
     )
 
-    # Process classifications
     result: dict[int, CommentClassification] = {}
     classification_output: ClassificationOutput = output
 
     for classification in classification_output.classifications:
         final = classification
 
-        # Apply confidence threshold
         if classification.confidence < config.confidence_threshold:
             logger.debug(
                 "Classification below confidence threshold",
@@ -261,7 +256,6 @@ async def classify_comments(
             if final.actionable:
                 final = final.model_copy(update={"actionable": False})
 
-        # Apply aggressiveness filter
         if final.actionable and not is_actionable(
             final.category, config.aggressiveness
         ):

--- a/amelia/services/github_pr.py
+++ b/amelia/services/github_pr.py
@@ -185,7 +185,6 @@ class GitHubPRService:
         )
         graphql_data = json.loads(graphql_raw)
 
-        # Build mapping: comment database ID -> thread info
         threads = (
             graphql_data
             .get("data", {})
@@ -202,7 +201,6 @@ class GitHubPRService:
                 pr_number=pr_number,
             )
 
-        # Map comment databaseId -> (thread_id, is_resolved)
         comment_thread_map: dict[int, tuple[str, bool]] = {}
         for thread in thread_nodes:
             thread_id = thread["id"]
@@ -212,7 +210,6 @@ class GitHubPRService:
                 if db_id is not None:
                     comment_thread_map[db_id] = (thread_id, is_resolved)
 
-        # Build PRReviewComment instances, filtering as needed
         result: list[PRReviewComment] = []
         for comment in comments_data:
             comment_id = comment["id"]

--- a/amelia/tools/file_bundler.py
+++ b/amelia/tools/file_bundler.py
@@ -222,7 +222,6 @@ def _resolve_globs(
                 if _should_exclude_non_git(abs_path, resolved_dir):
                     continue
 
-            # Apply exclude patterns
             if exclude_patterns:
                 excluded = False
                 for ep in exclude_patterns:

--- a/amelia/tools/git_utils.py
+++ b/amelia/tools/git_utils.py
@@ -94,10 +94,8 @@ class LocalWorktree:
         Raises:
             ValueError: If git worktree add fails.
         """
-        # Ensure parent dir exists
         self._worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove stale worktree if path already exists
         if self._worktree_path.exists():
             logger.warning(
                 "Removing stale worktree path",
@@ -122,10 +120,8 @@ class LocalWorktree:
             self._repo_root, "worktree", "prune", check=False
         )
 
-        # Fetch origin
         await _run_git_cmd(self._repo_root, "fetch", "origin")
 
-        # Create detached worktree at origin/<branch>
         try:
             await _run_git_cmd(
                 self._repo_root,
@@ -191,7 +187,6 @@ class LocalWorktree:
                 error=str(cleanup_exc),
             )
             shutil.rmtree(self._worktree_path, ignore_errors=True)
-            # Also prune stale worktree entries
             with contextlib.suppress(Exception):
                 await _run_git_cmd(
                     self._repo_root,
@@ -490,19 +485,16 @@ class GitOperations:
         if branch in PROTECTED_BRANCHES:
             raise ValueError(f"Refusing to push to protected branch: {branch}")
 
-        # Fetch remote state (don't fail if branch doesn't exist)
         await self._run_git("fetch", "origin", branch, check=False)
 
         local_sha = await self._run_git("rev-parse", "HEAD")
 
-        # Check if remote branch exists
         remote_sha: str | None = None
         try:
             remote_sha = await self._run_git("rev-parse", f"origin/{branch}")
         except ValueError:
             remote_sha = None  # New branch, no remote tracking
 
-        # Divergence check
         if remote_sha is not None and remote_sha != local_sha:
             merge_base = await self._run_git("merge-base", local_sha, remote_sha)
             logger.info(

--- a/amelia/tools/shell_executor.py
+++ b/amelia/tools/shell_executor.py
@@ -1,4 +1,3 @@
-# amelia/tools/shell_executor.py
 """Shell command execution utilities."""
 
 import asyncio

--- a/amelia/tools/write_plan.py
+++ b/amelia/tools/write_plan.py
@@ -59,7 +59,6 @@ async def execute_write_plan(
         WritePlanValidationError: If tool_input fails schema validation.
         ValueError: If the resolved path escapes root_dir.
     """
-    # Validate structured input
     try:
         plan = WritePlanInput(**tool_input)
     except ValidationError as exc:
@@ -70,10 +69,8 @@ async def execute_write_plan(
         logger.warning("write_plan validation failed", errors=errors)
         raise WritePlanValidationError(errors, exc) from exc
 
-    # Render to markdown
     markdown = render_plan_markdown(plan)
 
-    # Resolve file path
     file_path = Path(plan.file_path)
     root = Path(root_dir)
     if file_path.is_absolute() and file_path.is_relative_to(root):
@@ -94,10 +91,8 @@ async def execute_write_plan(
             f"which is outside root_dir {root_resolved}"
         )
 
-    # Ensure parent directory exists
     await asyncio.to_thread(resolved.parent.mkdir, parents=True, exist_ok=True)
 
-    # Write markdown file
     await asyncio.to_thread(resolved.write_text, markdown, encoding="utf-8")
     logger.info(
         "write_plan: wrote plan file",

--- a/amelia/tools/write_plan_renderer.py
+++ b/amelia/tools/write_plan_renderer.py
@@ -25,7 +25,6 @@ def render_plan_markdown(plan: WritePlanInput) -> str:
     """
     parts: list[str] = []
 
-    # Header
     parts.append(f"# {plan.goal} Implementation Plan")
     parts.append("")
     parts.append(f"**Goal:** {plan.goal}")
@@ -38,12 +37,10 @@ def render_plan_markdown(plan: WritePlanInput) -> str:
     parts.append("---")
     parts.append("")
 
-    # Tasks
     for task in plan.tasks:
         parts.append(_render_task(task))
         parts.append("")
 
-    # Summary
     parts.append("---")
     parts.append("")
     parts.append("## Summary")
@@ -71,7 +68,6 @@ def _render_task(task: PlanTask) -> str:
     lines.append(f"### Task {task.number}: {task.title}")
     lines.append("")
 
-    # Files section
     has_files = task.files_to_create or task.files_to_modify
     if has_files:
         lines.append("**Files:**")
@@ -81,7 +77,6 @@ def _render_task(task: PlanTask) -> str:
             lines.append(f"- Modify: `{f}`")
         lines.append("")
 
-    # Steps
     for step in task.steps:
         lines.append(step)
         lines.append("")

--- a/dashboard/src/__tests__/fixtures.ts
+++ b/dashboard/src/__tests__/fixtures.ts
@@ -12,10 +12,6 @@ import {
 } from '../types';
 import { type Profile, type SandboxConfig } from '../api/settings';
 
-// ============================================================================
-// Factory Functions
-// ============================================================================
-
 /**
  * Creates a mock WorkflowSummary with sensible defaults.
  * @param overrides - Optional partial object to override default values
@@ -140,7 +136,6 @@ export function createMockWorkflowDetail(
     pr_title: null,
     pr_comment_count: null,
     token_usage: null,
-    // Agentic execution fields
     goal: 'Test goal for implementation',
     plan_markdown: null,
     plan_path: null,

--- a/dashboard/src/actions/__tests__/workflows.test.ts
+++ b/dashboard/src/actions/__tests__/workflows.test.ts
@@ -75,7 +75,6 @@ describe('Workflow Actions', () => {
 
     it('should return error if feedback is missing', async () => {
       const formData = new FormData();
-      // No feedback field
 
       const result = await rejectAction(createActionArgs({ id: 'wf-1' }, { body: formData }));
 

--- a/dashboard/src/api/__tests__/client.test.ts
+++ b/dashboard/src/api/__tests__/client.test.ts
@@ -4,12 +4,7 @@ import type { GitHubIssuesResponse } from '@/types';
 import { createMockWorkflowSummary, createMockWorkflowDetail } from '@/__tests__/fixtures';
 import { mockFetchSuccess, mockFetchError } from '@/test/mocks/fetch';
 
-// Mock fetch globally
 global.fetch = vi.fn();
-
-// ============================================================================
-// Tests
-// ============================================================================
 
 describe('API Client', () => {
   beforeEach(() => {
@@ -205,13 +200,11 @@ describe('API Client', () => {
 
   describe('request timeout', () => {
     it('should convert AbortError to ApiError with timeout code', async () => {
-      // Mock fetch that immediately throws AbortError (simulating timeout)
       const abortError = new Error('The operation was aborted');
       abortError.name = 'AbortError';
 
       (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(abortError);
 
-      // The ApiError should be thrown with timeout details
       await expect(api.getWorkflows()).rejects.toMatchObject({
         message: 'Request timeout',
         code: 'TIMEOUT',
@@ -286,7 +279,6 @@ describe('API Client', () => {
         '/api/workflows?status=cancelled',
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
-      // Should be sorted by started_at descending
       expect(result).toHaveLength(3);
       expect(result[0]!.id).toBe('wf-2'); // Most recent (11:00)
       expect(result[1]!.id).toBe('wf-1'); // 10:00
@@ -294,8 +286,6 @@ describe('API Client', () => {
     });
 
     it('should handle HTTP errors', async () => {
-      // getWorkflowHistory makes 3 parallel requests, mock the first to fail
-      // (Promise.all will reject on first error)
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: false,
@@ -314,10 +304,6 @@ describe('API Client', () => {
       await expect(api.getWorkflowHistory()).rejects.toThrow('Internal server error');
     });
   });
-
-  // ==========================================================================
-  // Queue Workflow Methods
-  // ==========================================================================
 
   describe('startWorkflow', () => {
     it('should POST to /api/workflows/{id}/start', async () => {
@@ -474,10 +460,6 @@ describe('API Client', () => {
       await expect(api.getGitHubIssues('noop-profile')).rejects.toThrow();
     });
   });
-
-  // ==========================================================================
-  // Config and Files API Methods
-  // ==========================================================================
 
   describe('getConfig', () => {
     it('returns config with repo_root', async () => {

--- a/dashboard/src/api/__tests__/prompts.test.ts
+++ b/dashboard/src/api/__tests__/prompts.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { api } from '../client';
 import { mockFetchSuccess, mockFetchError } from '@/test/mocks/fetch';
 
-// Mock fetch globally
 global.fetch = vi.fn();
-
-// ============================================================================
-// Tests
-// ============================================================================
 
 describe('Prompts API', () => {
   beforeEach(() => {

--- a/dashboard/src/api/__tests__/settings.test.ts
+++ b/dashboard/src/api/__tests__/settings.test.ts
@@ -47,10 +47,6 @@ describe("settings API", () => {
     expect(err).toMatchObject({ status: 404, message: "Profile not found" });
   });
 
-  // ===========================================================================
-  // Server Settings
-  // ===========================================================================
-
   describe("getServerSettings", () => {
     it("fetches server settings", async () => {
       const mockSettings: ServerSettings = {
@@ -116,10 +112,6 @@ describe("settings API", () => {
       expect(result).toEqual(mockSettings);
     });
   });
-
-  // ===========================================================================
-  // Profiles
-  // ===========================================================================
 
   describe("getProfiles", () => {
     it("fetches all profiles", async () => {

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -224,7 +224,6 @@ export const api = {
         return data.workflows;
       })
     );
-    // Flatten and sort by started_at descending (most recent first)
     return results
       .flat()
       .sort((a, b) => {
@@ -399,10 +398,6 @@ export const api = {
     });
   },
 
-  // ==========================================================================
-  // Prompts API
-  // ==========================================================================
-
   /**
    * Get all prompts with current version info.
    *
@@ -540,10 +535,6 @@ export const api = {
     return request<DefaultContent>(`/prompts/${promptId}/default`);
   },
 
-  // ==========================================================================
-  // Config API
-  // ==========================================================================
-
   /**
    * Retrieves server configuration for dashboard.
    *
@@ -559,10 +550,6 @@ export const api = {
   async getConfig(): Promise<ConfigResponse> {
     return request<ConfigResponse>('/config');
   },
-
-  // ==========================================================================
-  // Files API
-  // ==========================================================================
 
   /**
    * Reads file content for design document import.
@@ -585,10 +572,6 @@ export const api = {
       body: { path },
     });
   },
-
-  // ==========================================================================
-  // Path Validation API
-  // ==========================================================================
 
   /**
    * Validates a filesystem path and returns git repository info.
@@ -613,10 +596,6 @@ export const api = {
       signal,
     });
   },
-
-  // ==========================================================================
-  // Usage API
-  // ==========================================================================
 
   /**
    * Retrieves usage metrics for a date range.
@@ -647,10 +626,6 @@ export const api = {
     return request<UsageResponse>('/usage', { params: queryParams });
   },
 
-  // ==========================================================================
-  // Knowledge API
-  // ==========================================================================
-
   /**
    * List all knowledge documents.
    *
@@ -676,7 +651,6 @@ export const api = {
     name: string,
     tags: string[]
   ): Promise<KnowledgeDocument> {
-    // Validate tags don't contain commas
     const invalidTag = tags.find(tag => tag.includes(','));
     if (invalidTag) {
       throw new ApiError(`Tag "${invalidTag}" cannot contain commas`, 'VALIDATION_ERROR', 400);
@@ -725,10 +699,6 @@ export const api = {
     });
   },
 
-  // ==========================================================================
-  // Review API
-  // ==========================================================================
-
   /**
    * Requests an on-demand code review for a workflow.
    *
@@ -743,10 +713,6 @@ export const api = {
   ): Promise<void> {
     await request(`/workflows/${workflowId}/review`, { method: 'POST', body: payload });
   },
-
-  // ==========================================================================
-  // PR Auto-Fix Metrics API
-  // ==========================================================================
 
   /**
    * Retrieves PR auto-fix metrics for a date range.

--- a/dashboard/src/api/settings.ts
+++ b/dashboard/src/api/settings.ts
@@ -6,10 +6,6 @@
 
 import { request } from './utils';
 
-// =============================================================================
-// Types
-// =============================================================================
-
 /**
  * Server-wide settings configuration.
  */
@@ -126,10 +122,6 @@ export interface ProfileUpdate {
   pr_autofix?: PRAutoFixConfig | null;
 }
 
-// =============================================================================
-// Settings API
-// =============================================================================
-
 /**
  * Retrieves current server settings.
  *
@@ -164,10 +156,6 @@ export async function updateServerSettings(
 ): Promise<ServerSettings> {
   return request<ServerSettings>("/settings", { method: "PUT", body: updates });
 }
-
-// =============================================================================
-// Profiles API
-// =============================================================================
 
 /**
  * Retrieves all profiles.

--- a/dashboard/src/api/utils.ts
+++ b/dashboard/src/api/utils.ts
@@ -37,7 +37,6 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
 
-  // Combine timeout signal with optional abort signal
   const signal = abortSignal
     ? AbortSignal.any([timeoutSignal, abortSignal])
     : timeoutSignal;

--- a/dashboard/src/components/CostsTrendChart.test.tsx
+++ b/dashboard/src/components/CostsTrendChart.test.tsx
@@ -28,7 +28,6 @@ describe('CostsTrendChart', () => {
   it('should render chart container', () => {
     render(<CostsTrendChart data={mockTrend} />);
 
-    // Chart container should exist
     expect(screen.getByRole('figure')).toBeInTheDocument();
   });
 

--- a/dashboard/src/components/CostsTrendChart.tsx
+++ b/dashboard/src/components/CostsTrendChart.tsx
@@ -44,9 +44,7 @@ function formatChartDate(dateStr: string): string {
 export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
   const [chartType, setChartType] = useState<ChartType>('stacked');
 
-  // Extract unique models sorted by total cost descending
   const { models, chartData, chartConfig } = useMemo(() => {
-    // Aggregate total cost per model across all days
     const modelTotals: Record<string, number> = {};
     for (const point of data) {
       if (point.by_model) {
@@ -56,12 +54,10 @@ export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
       }
     }
 
-    // Sort models by total cost descending
     const sortedModels = Object.entries(modelTotals)
       .sort((a, b) => b[1] - a[1])
       .map(([model]) => model);
 
-    // If no by_model data, fall back to single series
     if (sortedModels.length === 0) {
       return {
         models: [],
@@ -75,7 +71,6 @@ export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
       };
     }
 
-    // Transform data for recharts (flatten by_model into top-level keys)
     const transformedData = data.map((point) => ({
       date: point.date,
       ...Object.fromEntries(
@@ -83,7 +78,6 @@ export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
       ),
     }));
 
-    // Build chart config for legend
     const config: ChartConfig = {};
     sortedModels.forEach((model, index) => {
       config[model] = {
@@ -111,7 +105,6 @@ export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
     );
   }
 
-  // Single series fallback (no by_model data)
   if (models.length === 0) {
     return (
       <div data-slot="costs-trend-chart" className={className}>
@@ -169,7 +162,6 @@ export function CostsTrendChart({ data, className }: CostsTrendChartProps) {
     );
   }
 
-  // Multi-model chart
   return (
     <div data-slot="costs-trend-chart" className={className}>
       <div className="flex justify-end mb-4">

--- a/dashboard/src/components/DashboardSidebar.test.tsx
+++ b/dashboard/src/components/DashboardSidebar.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/react';
 import { useDemoMode } from '@/hooks/useDemoMode';
 import { renderSidebar } from '@/test/helpers';
 
-// Mock the workflow store (inline due to vi.mock hoisting)
 vi.mock('@/store/workflowStore', () => ({
   useWorkflowStore: vi.fn((selector) => {
     const state = { isConnected: true };
@@ -11,7 +10,6 @@ vi.mock('@/store/workflowStore', () => ({
   }),
 }));
 
-// Mock the demo mode hook (inline due to vi.mock hoisting)
 vi.mock('@/hooks/useDemoMode', () => ({
   useDemoMode: vi.fn(() => ({ isDemo: false, demoType: null })),
 }));
@@ -55,7 +53,6 @@ describe('DashboardSidebar', () => {
   it('applies active styling to current route', () => {
     renderSidebar({ initialRoute: '/workflows' });
     const link = screen.getByRole('link', { name: /Active Jobs/ });
-    // NavLink sets aria-current="page" when active
     expect(link).toHaveAttribute('aria-current', 'page');
   });
 

--- a/dashboard/src/components/DashboardSidebar.tsx
+++ b/dashboard/src/components/DashboardSidebar.tsx
@@ -64,7 +64,6 @@ interface SidebarNavLinkProps {
  * @returns A SidebarMenuItem element containing either a NavLink or disabled placeholder.
  */
 function SidebarNavLink({ to, icon: Icon, label, onClick, comingSoon, badge }: SidebarNavLinkProps) {
-  // Coming soon items render as non-clickable placeholders
   if (comingSoon) {
     return (
       <SidebarMenuItem>
@@ -139,7 +138,6 @@ function SidebarNavLink({ to, icon: Icon, label, onClick, comingSoon, badge }: S
  * @returns React element for the dashboard sidebar navigation
  */
 export function DashboardSidebar() {
-  // Get connection status from store
   const isConnected = useWorkflowStore((state) => state.isConnected);
   const { state } = useSidebar();
   const isCollapsed = state === 'collapsed';

--- a/dashboard/src/components/DashboardSidebarA11y.test.tsx
+++ b/dashboard/src/components/DashboardSidebarA11y.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderSidebar } from '@/test/helpers';
 
-// Mock the workflow store (inline due to vi.mock hoisting)
 vi.mock('@/store/workflowStore', () => ({
   useWorkflowStore: vi.fn((selector) => {
     const state = { isConnected: true };
@@ -10,7 +9,6 @@ vi.mock('@/store/workflowStore', () => ({
   }),
 }));
 
-// Mock the demo mode hook (inline due to vi.mock hoisting)
 vi.mock('@/hooks/useDemoMode', () => ({
   useDemoMode: vi.fn(() => ({ isDemo: false, demoType: null })),
 }));
@@ -24,7 +22,6 @@ describe('DashboardSidebar Accessibility', () => {
     renderSidebar({ open: true });
     // getByRole throws if element not found, no need for toBeInTheDocument()
     const status = screen.getByRole('status');
-    // In expanded mode, it should contain text "Connected"
     expect(status).toHaveTextContent('Connected');
   });
 

--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -17,7 +17,6 @@ export function RootErrorBoundary() {
   const error = useRouteError();
   const navigate = useNavigate();
 
-  // Handle HTTP error responses (404, 500, etc.)
   if (isRouteErrorResponse(error)) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground p-8">
@@ -43,7 +42,6 @@ export function RootErrorBoundary() {
     );
   }
 
-  // Handle JavaScript errors
   const errorMessage = error instanceof Error ? error.message : 'Unknown error';
   const errorStack = error instanceof Error ? error.stack : undefined;
 

--- a/dashboard/src/components/GitHubIssueCombobox.tsx
+++ b/dashboard/src/components/GitHubIssueCombobox.tsx
@@ -87,7 +87,6 @@ export function GitHubIssueCombobox({ id, profile, onSelect, value, onClear }: G
     [profile],
   );
 
-  // Fetch on mount and when profile changes
   useEffect(() => {
     fetchIssues();
     return () => {

--- a/dashboard/src/components/Layout.test.tsx
+++ b/dashboard/src/components/Layout.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { Layout } from './Layout';
 
-// Mock the hooks
 const mockUseWebSocket = vi.fn();
 vi.mock('@/hooks/useWebSocket', () => ({
   useWebSocket: () => mockUseWebSocket(),

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -23,7 +23,6 @@ import { useWebSocket } from '@/hooks/useWebSocket';
 export function Layout() {
   const navigation = useNavigation();
 
-  // Initialize WebSocket connection
   useWebSocket();
 
   const isNavigating = navigation.state !== 'idle';

--- a/dashboard/src/components/MobileCommandBar.test.tsx
+++ b/dashboard/src/components/MobileCommandBar.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-// Mock the sidebar hook
 const mockToggleSidebar = vi.fn();
 vi.mock('@/components/ui/sidebar', () => ({
   useSidebar: () => ({ toggleSidebar: mockToggleSidebar }),
@@ -10,7 +9,6 @@ vi.mock('@/components/ui/sidebar', () => ({
 // Mutable state for tests - must be declared before vi.mock
 let mockIsConnected = true;
 
-// Mock the workflow store with selector support
 vi.mock('@/store/workflowStore', () => ({
   useWorkflowStore: vi.fn((selector) => {
     const state = { isConnected: mockIsConnected };
@@ -23,7 +21,7 @@ import { MobileCommandBar } from './MobileCommandBar';
 describe('MobileCommandBar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsConnected = true; // Reset to connected state
+    mockIsConnected = true;
   });
 
   it('renders on mobile viewport with AMELIA branding', () => {
@@ -63,11 +61,9 @@ describe('MobileCommandBar', () => {
     mockIsConnected = true;
     render(<MobileCommandBar />);
 
-    // Verify sidebar button has correct aria-label
     const sidebarButton = screen.getByRole('button', { name: 'Toggle sidebar' });
     expect(sidebarButton).toHaveAttribute('aria-label', 'Toggle sidebar');
 
-    // Verify status indicator has role="status" and appropriate aria-label
     const statusIndicator = screen.getByRole('status');
     expect(statusIndicator).toHaveAttribute('aria-label', 'Connected');
   });

--- a/dashboard/src/components/PRFixMetricsTab.tsx
+++ b/dashboard/src/components/PRFixMetricsTab.tsx
@@ -62,7 +62,6 @@ const breakdownChartConfig: ChartConfig = {
 export function PRFixMetricsTab({ metrics, preset }: PRFixMetricsTabProps) {
   const { summary, daily, by_aggressiveness } = metrics;
 
-  // Empty state when no data
   if (daily.length === 0 && by_aggressiveness.length === 0 && summary.total_runs === 0) {
     return (
       <div className="flex flex-col gap-6">

--- a/dashboard/src/components/PageHeader.tsx
+++ b/dashboard/src/components/PageHeader.tsx
@@ -53,7 +53,6 @@ interface TitleProps extends TypographyProps {
  * @returns An h2 element with display font styling.
  */
 function Title({ children, title, className }: TitleProps) {
-  // Use explicit title prop if provided, otherwise fall back to children if it's a string
   const tooltipText = title ?? (typeof children === 'string' ? children : undefined);
 
   return (
@@ -198,7 +197,6 @@ interface PageHeaderProps {
  * ```
  */
 function PageHeader({ children, className }: PageHeaderProps) {
-  // Extract slot children by displayName
   let leftSlot: ReactNode = null;
   let centerSlot: ReactNode = null;
   let rightSlot: ReactNode = null;
@@ -220,7 +218,6 @@ function PageHeader({ children, className }: PageHeaderProps) {
     }
   });
 
-  // Determine grid columns based on which slots are present
   const hasCenter = centerSlot !== null;
   const hasRight = rightSlot !== null;
 
@@ -252,7 +249,6 @@ function PageHeader({ children, className }: PageHeaderProps) {
   );
 }
 
-// Attach sub-components
 PageHeader.Left = Left;
 PageHeader.Center = Center;
 PageHeader.Right = Right;

--- a/dashboard/src/components/PlanImportSection.tsx
+++ b/dashboard/src/components/PlanImportSection.tsx
@@ -103,11 +103,9 @@ export function PlanImportSection({
   const isInitialMount = useRef(true);
   const previewRequestId = useRef(0);
 
-  // Update preview when content changes
   useEffect(() => {
     if (mode === 'paste' && content.trim()) {
       const parsed = parsePlanPreview(content);
-      // Only show preview if we extracted something meaningful
       if (parsed.goal || parsed.taskCount > 0 || parsed.keyFiles.length > 0) {
         setPreview(parsed);
       } else {
@@ -139,12 +137,11 @@ export function PlanImportSection({
     }
   }, [mode, filePath, content, filePreview, preview, onPlanChange]);
 
-  // Fetch file list when in file mode and planOutputDir is available
   useEffect(() => {
     if (mode !== 'file' || !planOutputDir || !worktreePath) return;
 
     setFilesLoading(true);
-    setFileError(null); // Clear previous errors
+    setFileError(null);
     api.listFiles(planOutputDir, '*.md', worktreePath)
       .then((res) => {
         setFiles(res.files);
@@ -152,7 +149,6 @@ export function PlanImportSection({
       .catch((err) => {
         setFiles([]);
 
-        // Show helpful error message to user
         const errorMsg = err instanceof ApiError
           ? err.message
           : 'Failed to load plan files';
@@ -275,7 +271,6 @@ export function PlanImportSection({
     }
   }, []);
 
-  // Auto-trigger preview when a file is selected from the combobox
   const selectedFileRef = useRef<FileEntry | null>(null);
   useEffect(() => {
     if (selectedFile && selectedFile !== selectedFileRef.current && filePath.trim() && worktreePath) {
@@ -284,7 +279,6 @@ export function PlanImportSection({
     }
   }, [selectedFile, filePath, worktreePath, handlePreview]);
 
-  // Derived state: select active preview based on current input mode
   const activePreview = mode === 'paste' ? preview : filePreview;
 
   return (

--- a/dashboard/src/components/Sparkline.tsx
+++ b/dashboard/src/components/Sparkline.tsx
@@ -18,7 +18,6 @@ export function Sparkline({ data, color, className }: SparklineProps) {
   const height = 24;
   const padding = 2;
 
-  // Handle edge cases
   if (data.length === 0) {
     return (
       <svg
@@ -30,7 +29,6 @@ export function Sparkline({ data, color, className }: SparklineProps) {
     );
   }
 
-  // Normalize data to fit in viewBox
   const max = Math.max(...data);
   const min = Math.min(...data);
   const range = max - min || 1; // Avoid division by zero
@@ -39,7 +37,6 @@ export function Sparkline({ data, color, className }: SparklineProps) {
     return height - padding - ((value - min) / range) * (height - padding * 2);
   };
 
-  // Generate points for polyline
   const xStep = data.length > 1 ? (width - padding * 2) / (data.length - 1) : 0;
   const points = data
     .map((value, index) => {

--- a/dashboard/src/components/UsageCard.test.tsx
+++ b/dashboard/src/components/UsageCard.test.tsx
@@ -22,7 +22,6 @@ describe('UsageCard', () => {
       });
       render(<UsageCard tokenUsage={tokenUsage} />);
 
-      // Check summary line content
       expect(screen.getByText('$0.42')).toBeInTheDocument();
       expect(screen.getByText('16.7K tokens')).toBeInTheDocument();
       expect(screen.getByText('2m 34s')).toBeInTheDocument();
@@ -48,10 +47,8 @@ describe('UsageCard', () => {
       render(<UsageCard tokenUsage={tokenUsage} />);
 
       const rows = screen.getAllByRole('row');
-      // Header row + 3 agent rows
       expect(rows).toHaveLength(4);
 
-      // Check agent names are present
       expect(screen.getByText('architect')).toBeInTheDocument();
       expect(screen.getByText('developer')).toBeInTheDocument();
       expect(screen.getByText('reviewer')).toBeInTheDocument();
@@ -61,7 +58,6 @@ describe('UsageCard', () => {
       const tokenUsage = createMockTokenSummary();
       render(<UsageCard tokenUsage={tokenUsage} />);
 
-      // Architect row: claude-sonnet-4-20250514, 2.1K input, 500 output, 1.8K cache, $0.08, 15s
       const architectRow = screen.getByText('architect').closest('tr');
       expect(architectRow).toBeInTheDocument();
       expect(
@@ -78,7 +74,6 @@ describe('UsageCard', () => {
       const tokenUsage = createMockTokenSummary();
       render(<UsageCard tokenUsage={tokenUsage} />);
 
-      // Developer row: 8.4K input, 2.1K output, 6.2K cache, $0.28, 1m 37s
       const developerRow = screen.getByText('developer').closest('tr');
       expect(developerRow).toBeInTheDocument();
       expect(within(developerRow!).getByText('8.4K')).toBeInTheDocument();
@@ -117,7 +112,6 @@ describe('UsageCard', () => {
       expect(screen.getByText('$0.00')).toBeInTheDocument();
       expect(screen.getByText('0 tokens')).toBeInTheDocument();
 
-      // Table should still have header row
       const rows = screen.getAllByRole('row');
       expect(rows).toHaveLength(1); // Just header row
     });
@@ -143,7 +137,6 @@ describe('UsageCard', () => {
       const table = screen.getByRole('table');
       expect(table).toBeInTheDocument();
 
-      // Check for columnheaders
       const columnHeaders = screen.getAllByRole('columnheader');
       expect(columnHeaders).toHaveLength(7);
     });
@@ -152,7 +145,6 @@ describe('UsageCard', () => {
       const tokenUsage = createMockTokenSummary();
       render(<UsageCard tokenUsage={tokenUsage} />);
 
-      // USAGE should be in an h3
       const heading = screen.getByRole('heading', { level: 3 });
       expect(heading).toHaveTextContent('USAGE');
     });

--- a/dashboard/src/components/UsageCard.tsx
+++ b/dashboard/src/components/UsageCard.tsx
@@ -26,7 +26,6 @@ interface UsageCardProps {
  * @returns The usage card UI or null if no data
  */
 export function UsageCard({ tokenUsage, className }: UsageCardProps) {
-  // Don't render if no token usage data
   if (!tokenUsage) {
     return null;
   }

--- a/dashboard/src/components/WorktreePathField.tsx
+++ b/dashboard/src/components/WorktreePathField.tsx
@@ -94,9 +94,7 @@ function getPathLabel(path: string): string {
  */
 function getPathSegments(path: string): string[] {
   if (!path) return [];
-  // For absolute paths, keep the leading slash context
   const segments = path.split('/').filter(Boolean);
-  // Show last 3 segments max for readability
   if (segments.length > 3) {
     return ['...', ...segments.slice(-3)];
   }
@@ -128,10 +126,8 @@ export function WorktreePathField({
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Build the list of path suggestions
   const suggestions: RecentPath[] = [];
 
-  // Add server repo_root as primary suggestion (if not empty)
   if (serverWorkingDir) {
     suggestions.push({
       path: serverWorkingDir,
@@ -140,7 +136,6 @@ export function WorktreePathField({
     });
   }
 
-  // Add unique recent paths (excluding server default)
   const seen = new Set(suggestions.map((s) => s.path));
   for (const path of recentPaths) {
     if (!seen.has(path)) {
@@ -227,7 +222,6 @@ export function WorktreePathField({
     // Validation handled by useEffect with proper AbortSignal
   };
 
-  // Get the status icon from the pre-defined lookup
   const statusIcon = statusIcons[status];
 
   /**

--- a/dashboard/src/components/__tests__/PRCommentSection.test.tsx
+++ b/dashboard/src/components/__tests__/PRCommentSection.test.tsx
@@ -81,7 +81,6 @@ describe('PRCommentSection', () => {
 
   it('handles empty comments array gracefully', () => {
     renderComments([]);
-    // Should render without crashing, showing zero counts
     expect(screen.getByText('0 fixed')).toBeInTheDocument();
     expect(screen.getByText('0 failed')).toBeInTheDocument();
     expect(screen.getByText('0 skipped')).toBeInTheDocument();
@@ -96,7 +95,6 @@ describe('PRCommentSection', () => {
     renderComments();
     // The failed comment (3rd row, index 2) has status_reason 'Circular dependency detected'
     const triggers = screen.getAllByRole('button');
-    // Click the 3rd trigger to expand the failed comment
     await triggers[2]!.click();
     expect(screen.getByText(/Circular dependency detected/)).toBeInTheDocument();
   });

--- a/dashboard/src/components/__tests__/PendingWorkflowControls.test.tsx
+++ b/dashboard/src/components/__tests__/PendingWorkflowControls.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event';
 import { PendingWorkflowControls } from '../PendingWorkflowControls';
 import { api } from '@/api/client';
 
-// Mock react-router-dom's useRevalidator
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
@@ -19,7 +18,6 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-// Mock the API client
 vi.mock('@/api/client', () => ({
   api: {
     startWorkflow: vi.fn(),
@@ -38,7 +36,6 @@ vi.mock('@/api/client', () => ({
   },
 }));
 
-// Mock sonner toast
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -102,7 +99,6 @@ describe('PendingWorkflowControls', () => {
 
       await user.click(screen.getByRole('button', { name: /set plan/i }));
 
-      // Modal should open
       await waitFor(() => {
         expect(screen.getByRole('dialog')).toBeInTheDocument();
       });
@@ -114,7 +110,6 @@ describe('PendingWorkflowControls', () => {
 
       await user.click(screen.getByRole('button', { name: /set plan/i }));
 
-      // Modal should show workflow-specific content
       await waitFor(() => {
         expect(screen.getByRole('dialog')).toBeInTheDocument();
       });
@@ -126,7 +121,6 @@ describe('PendingWorkflowControls', () => {
 
       await user.click(screen.getByRole('button', { name: /set plan/i }));
 
-      // Modal should have overwrite checkbox since hasPlan is true
       await waitFor(() => {
         expect(screen.getByLabelText(/overwrite/i)).toBeInTheDocument();
       });
@@ -145,7 +139,6 @@ describe('PendingWorkflowControls', () => {
 
       await user.click(screen.getByRole('button', { name: /set plan/i }));
 
-      // Select a file via combobox
       await waitFor(() => {
         expect(screen.getByRole('combobox')).toBeInTheDocument();
       });
@@ -155,13 +148,11 @@ describe('PendingWorkflowControls', () => {
       });
       await user.click(screen.getByText('plan.md'));
 
-      // Apply the plan
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /apply/i })).not.toBeDisabled();
       });
       await user.click(screen.getByRole('button', { name: /apply/i }));
 
-      // Modal should close
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       });

--- a/dashboard/src/components/__tests__/PlanImportSection.test.tsx
+++ b/dashboard/src/components/__tests__/PlanImportSection.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event';
 import { PlanImportSection } from '../PlanImportSection';
 import { api, ApiError } from '@/api/client';
 
-// Mock the API client
 vi.mock('@/api/client', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@/api/client')>();
   return {
@@ -28,7 +27,6 @@ describe('PlanImportSection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset listFiles default
     vi.mocked(api.listFiles).mockResolvedValue({ files: [], directory: '' });
   });
 
@@ -40,7 +38,6 @@ describe('PlanImportSection', () => {
 
     it('renders collapsed by default', () => {
       render(<PlanImportSection {...defaultProps} />);
-      // Content should not be visible when collapsed
       expect(screen.queryByPlaceholderText(/relative path/i)).not.toBeInTheDocument();
     });
 
@@ -50,7 +47,6 @@ describe('PlanImportSection', () => {
 
       await user.click(screen.getByText(/external plan/i));
 
-      // Content should now be visible
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/relative path/i)).toBeInTheDocument();
       });
@@ -66,9 +62,7 @@ describe('PlanImportSection', () => {
     it('shows "File Path" mode by default', () => {
       render(<PlanImportSection {...defaultProps} defaultExpanded />);
 
-      // File path input should be visible
       expect(screen.getByPlaceholderText(/relative path/i)).toBeInTheDocument();
-      // Textarea should not be visible
       expect(screen.queryByPlaceholderText(/paste.*plan.*markdown/i)).not.toBeInTheDocument();
     });
 
@@ -76,14 +70,11 @@ describe('PlanImportSection', () => {
       const user = userEvent.setup();
       render(<PlanImportSection {...defaultProps} defaultExpanded />);
 
-      // Click the "Paste" toggle
       await user.click(screen.getByRole('radio', { name: /paste/i }));
 
-      // Textarea should be visible
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/paste.*plan.*markdown/i)).toBeInTheDocument();
       });
-      // File path input should not be visible
       expect(screen.queryByPlaceholderText(/relative path/i)).not.toBeInTheDocument();
     });
 
@@ -91,12 +82,9 @@ describe('PlanImportSection', () => {
       const user = userEvent.setup();
       render(<PlanImportSection {...defaultProps} defaultExpanded />);
 
-      // Switch to Paste
       await user.click(screen.getByRole('radio', { name: /paste/i }));
-      // Switch back to File
       await user.click(screen.getByRole('radio', { name: /file/i }));
 
-      // File path input should be visible again
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/relative path/i)).toBeInTheDocument();
       });
@@ -146,7 +134,6 @@ describe('PlanImportSection', () => {
       const onPlanChange = vi.fn();
       render(<PlanImportSection onPlanChange={onPlanChange} defaultExpanded planOutputDir={undefined} />);
 
-      // Switch to paste mode
       await user.click(screen.getByRole('radio', { name: /paste/i }));
 
       const textarea = screen.getByPlaceholderText(/paste.*plan.*markdown/i);
@@ -165,7 +152,6 @@ describe('PlanImportSection', () => {
       const user = userEvent.setup();
       render(<PlanImportSection {...defaultProps} defaultExpanded />);
 
-      // Switch to paste mode
       await user.click(screen.getByRole('radio', { name: /paste/i }));
 
       const markdown = `# Plan
@@ -182,7 +168,6 @@ Implement user authentication.
       const textarea = screen.getByPlaceholderText(/paste.*plan.*markdown/i);
       await user.type(textarea, markdown);
 
-      // Preview should show extracted info (in the preview card, not textarea)
       await waitFor(() => {
         const preview = screen.getByTestId('plan-preview');
         expect(preview).toHaveTextContent(/implement user authentication/i);
@@ -209,7 +194,6 @@ Implement user authentication.
       const onPlanChange = vi.fn();
       render(<PlanImportSection onPlanChange={onPlanChange} defaultExpanded planOutputDir={undefined} />);
 
-      // Switch to paste mode to enable drop target
       const user = userEvent.setup();
       await user.click(screen.getByRole('radio', { name: /paste/i }));
 
@@ -309,7 +293,6 @@ Add new feature.
     it('does not show preview card when content is empty', () => {
       render(<PlanImportSection {...defaultProps} defaultExpanded />);
 
-      // No preview should be visible
       expect(screen.queryByTestId('plan-preview')).not.toBeInTheDocument();
     });
   });
@@ -468,14 +451,12 @@ Add new feature.
         />
       );
 
-      // First, get a preview
       await user.type(screen.getByPlaceholderText(/relative path/i), 'docs/plan.md');
       await user.click(screen.getByRole('button', { name: /preview/i }));
       await waitFor(() => {
         expect(screen.getByTestId('plan-preview')).toBeInTheDocument();
       });
 
-      // Change path — preview should clear
       await user.type(screen.getByPlaceholderText(/relative path/i), '-v2');
       expect(screen.queryByTestId('plan-preview')).not.toBeInTheDocument();
     });
@@ -522,7 +503,6 @@ Add new feature.
         />
       );
 
-      // Should show combobox, not text input
       expect(screen.queryByPlaceholderText(/relative path/i)).not.toBeInTheDocument();
       expect(screen.getByRole('combobox')).toBeInTheDocument();
     });
@@ -543,7 +523,6 @@ Add new feature.
         />
       );
 
-      // Open combobox
       await user.click(screen.getByRole('combobox'));
 
       await waitFor(() => {
@@ -567,12 +546,10 @@ Add new feature.
         />
       );
 
-      // Wait for files to load
       await waitFor(() => {
         expect(api.listFiles).toHaveBeenCalled();
       });
 
-      // Open combobox
       await user.click(screen.getByRole('combobox'));
 
       await waitFor(() => {
@@ -602,12 +579,10 @@ Add new feature.
         />
       );
 
-      // Wait for files to load
       await waitFor(() => {
         expect(api.listFiles).toHaveBeenCalled();
       });
 
-      // Open combobox and select a file
       await user.click(screen.getByRole('combobox'));
       await waitFor(() => {
         expect(screen.getByText('plan-1.md')).toBeInTheDocument();
@@ -644,12 +619,10 @@ Add new feature.
         />
       );
 
-      // Wait for files to load
       await waitFor(() => {
         expect(api.listFiles).toHaveBeenCalled();
       });
 
-      // Open combobox and select a file
       await user.click(screen.getByRole('combobox'));
       await waitFor(() => {
         expect(screen.getByText('plan-1.md')).toBeInTheDocument();

--- a/dashboard/src/components/__tests__/ProfileSelect.test.tsx
+++ b/dashboard/src/components/__tests__/ProfileSelect.test.tsx
@@ -8,7 +8,6 @@ import { ProfileSelect } from '../ProfileSelect';
 import { getProfiles } from '@/api/settings';
 import { mockProfiles } from '@/__tests__/fixtures';
 
-// Mock the settings API
 vi.mock('@/api/settings', () => ({
   getProfiles: vi.fn(),
 }));
@@ -52,10 +51,8 @@ describe('ProfileSelect', () => {
     it('renders profiles after loading', async () => {
       await renderReady();
 
-      // Open the select dropdown
       fireEvent.click(screen.getByRole('combobox'));
 
-      // Check that profiles are rendered
       await waitFor(() => {
         expect(screen.getByText('work')).toBeInTheDocument();
         expect(screen.getByText('personal')).toBeInTheDocument();
@@ -124,7 +121,6 @@ describe('ProfileSelect', () => {
 
       // Find the "None" option in the dropdown (not the trigger)
       await waitFor(() => {
-        // The dropdown content has role="listbox"
         const listbox = screen.getByRole('listbox');
         const noneOption = within(listbox).getByText('None (use server default)');
         expect(noneOption).toBeInTheDocument();
@@ -142,7 +138,6 @@ describe('ProfileSelect', () => {
     it('displays selected profile value', async () => {
       await renderReady({ value: 'work' });
 
-      // The combobox should display the selected profile
       await waitFor(() => {
         expect(screen.getByRole('combobox')).toHaveTextContent('work');
       });
@@ -163,13 +158,10 @@ describe('ProfileSelect', () => {
       try {
         await renderReady();
 
-        // Wait for the error to be processed - the component should still be functional
         await waitFor(() => {
-          // The select should be enabled after loading fails
           expect(screen.getByRole('combobox')).not.toBeDisabled();
         });
 
-        // Verify error message is displayed to the user
         expect(screen.getByText('Failed to load profiles')).toBeInTheDocument();
 
         expect(consoleSpy).toHaveBeenCalledWith(
@@ -188,32 +180,25 @@ describe('ProfileSelect', () => {
       try {
         await renderReady();
 
-        // Wait for error state
         await waitFor(() => {
           expect(screen.getByText('Failed to load profiles')).toBeInTheDocument();
         });
 
-        // Verify retry button is shown
         const retryButton = screen.getByRole('button', { name: 'Retry' });
         expect(retryButton).toBeInTheDocument();
 
-        // Mock successful response for retry
         vi.mocked(getProfiles).mockResolvedValueOnce(mockProfiles);
 
-        // Click retry
         fireEvent.click(retryButton);
 
-        // Verify profiles are fetched again
         await waitFor(() => {
           expect(getProfiles).toHaveBeenCalledTimes(2);
         });
 
-        // Verify error message is cleared and profiles are loaded
         await waitFor(() => {
           expect(screen.queryByText('Failed to load profiles')).not.toBeInTheDocument();
         });
 
-        // Verify profiles are now available
         fireEvent.click(screen.getByRole('combobox'));
         await waitFor(() => {
           expect(screen.getByText('work')).toBeInTheDocument();
@@ -231,7 +216,6 @@ describe('ProfileSelect', () => {
       const combobox = screen.getByRole('combobox');
       expect(combobox).toHaveAttribute('id', 'test-profile');
 
-      // Label should be associated
       expect(screen.getByText('Profile')).toBeInTheDocument();
     });
 

--- a/dashboard/src/components/__tests__/RequestReviewDialog.test.tsx
+++ b/dashboard/src/components/__tests__/RequestReviewDialog.test.tsx
@@ -62,7 +62,6 @@ describe('RequestReviewDialog', () => {
     await user.click(securityBtn);
     expect(securityBtn.className).toContain('border-primary');
 
-    // Deselect security
     await user.click(securityBtn);
     expect(securityBtn.className).not.toContain('bg-primary/10');
   });
@@ -89,7 +88,6 @@ describe('RequestReviewDialog', () => {
     await user.click(screen.getByText('Security'));
     await user.click(screen.getByText('Review & Fix'));
 
-    // Click the submit button (the one inside the dialog, not the trigger)
     const submitButtons = screen.getAllByRole('button', { name: /Request Review/i });
     const submitBtn = submitButtons.at(-1)!;
     await user.click(submitBtn);
@@ -110,7 +108,6 @@ describe('RequestReviewDialog', () => {
 
     await user.click(screen.getByText('Request Review'));
 
-    // Deselect the default 'general' type
     await user.click(screen.getByText('General'));
 
     const submitButtons = screen.getAllByRole('button', { name: /Request Review/i });

--- a/dashboard/src/components/__tests__/SetPlanModal.test.tsx
+++ b/dashboard/src/components/__tests__/SetPlanModal.test.tsx
@@ -10,7 +10,6 @@ import { api, ApiError } from '@/api/client';
 import type { SetPlanResponse } from '@/types';
 import { toast } from 'sonner';
 
-// Mock the API client
 vi.mock('@/api/client', () => ({
   api: {
     setPlan: vi.fn(),
@@ -27,7 +26,6 @@ vi.mock('@/api/client', () => ({
   },
 }));
 
-// Mock sonner toast
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -55,7 +53,6 @@ describe('SetPlanModal', () => {
   });
 
   afterEach(() => {
-    // Ensure cleanup happens before moving to next test
     cleanup();
   });
 
@@ -66,10 +63,8 @@ describe('SetPlanModal', () => {
   async function renderAndWaitForInit(props = defaultProps) {
     const result = render(<SetPlanModal {...props} />);
     // Wait for PlanImportSection's useEffect to run (the one that updates on mount)
-    // If open, the component renders and effects run
     if (props.open !== false) {
       await waitFor(() => {
-        // Just waiting a tick for effects to settle
         expect(result.container).toBeInTheDocument();
       });
     }
@@ -83,14 +78,12 @@ describe('SetPlanModal', () => {
     });
 
     it('does not render when closed', () => {
-      // When modal is closed, no async operations occur
       render(<SetPlanModal {...defaultProps} open={false} />);
       expect(screen.queryByText(/set plan/i)).not.toBeInTheDocument();
     });
 
     it('renders PlanImportSection expanded', async () => {
       await renderAndWaitForInit();
-      // PlanImportSection content should be visible
       expect(screen.getByPlaceholderText(/relative path/i)).toBeInTheDocument();
     });
 
@@ -157,7 +150,6 @@ describe('SetPlanModal', () => {
       const user = userEvent.setup();
       await renderAndWaitForInit();
 
-      // Switch to paste mode
       await user.click(screen.getByRole('radio', { name: /paste/i }));
 
       const textarea = screen.getByPlaceholderText(/paste.*plan.*markdown/i);
@@ -266,12 +258,10 @@ describe('SetPlanModal', () => {
       await user.type(input, 'docs/plan.md');
       await user.click(screen.getByRole('button', { name: /apply/i }));
 
-      // Check for loading indicator
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /applying/i })).toBeInTheDocument();
       });
 
-      // Resolve the promise and wait for the submission to complete
       await act(async () => {
         resolvePromise!({ status: 'ready', goal: 'Test', key_files: [], total_tasks: 1 });
       });

--- a/dashboard/src/components/__tests__/WorktreePathField.test.tsx
+++ b/dashboard/src/components/__tests__/WorktreePathField.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event';
 import { WorktreePathField } from '../WorktreePathField';
 import { api } from '@/api/client';
 
-// Mock the API client
 vi.mock('@/api/client', () => ({
   api: {
     validatePath: vi.fn(),
@@ -110,7 +109,6 @@ describe('WorktreePathField', () => {
 
       render(<WorktreePathField {...defaultProps} value="/valid/git/repo" />);
 
-      // Wait for validation to complete
       await waitFor(
         () => {
           expect(api.validatePath).toHaveBeenCalledWith('/valid/git/repo', expect.any(AbortSignal));
@@ -196,7 +194,6 @@ describe('WorktreePathField', () => {
 
       render(<WorktreePathField {...defaultProps} value="/some/path" />);
 
-      // Wait for validation to be called
       await waitFor(() => {
         expect(api.validatePath).toHaveBeenCalled();
       });
@@ -249,7 +246,6 @@ describe('WorktreePathField', () => {
         />
       );
 
-      // Open dropdown
       const recentButton = screen.getByRole('button', { name: /recent/i });
       await user.click(recentButton);
 
@@ -276,11 +272,9 @@ describe('WorktreePathField', () => {
         />
       );
 
-      // Open dropdown
       const recentButton = screen.getByRole('button', { name: /recent/i });
       await user.click(recentButton);
 
-      // Click on the recent path
       const pathOption = await screen.findByText('/recent/path');
       await user.click(pathOption);
 
@@ -304,7 +298,6 @@ describe('WorktreePathField', () => {
     it('highlights last segment', () => {
       render(<WorktreePathField {...defaultProps} value="/a/b/repo" />);
 
-      // The last segment should be highlighted with primary color
       const repoSegment = screen.getByText('repo');
       expect(repoSegment).toHaveClass('text-primary');
     });

--- a/dashboard/src/components/ai-elements/__tests__/AskUserQuestionCard.test.tsx
+++ b/dashboard/src/components/ai-elements/__tests__/AskUserQuestionCard.test.tsx
@@ -143,9 +143,7 @@ describe("AskUserQuestionCard", () => {
       <AskUserQuestionCard payload={singleSelectPayload} onAnswer={onAnswer} />
     );
 
-    // Select an option first
     await user.click(screen.getByText("Option A"));
-    // Then also type in Other
     const otherInput = screen.getByPlaceholderText("Other...");
     await user.type(otherInput, "Custom answer");
     await user.click(screen.getByRole("button", { name: /submit/i }));
@@ -251,7 +249,6 @@ describe("AskUserQuestionCard", () => {
 
     expect(screen.getByText("First")).toBeInTheDocument();
     expect(screen.getByText("Second")).toBeInTheDocument();
-    // Ensure no description elements are rendered
     expect(screen.queryByText(/description/i)).not.toBeInTheDocument();
   });
 

--- a/dashboard/src/components/ai-elements/message.tsx
+++ b/dashboard/src/components/ai-elements/message.tsx
@@ -202,7 +202,6 @@ export const MessageBranchContent = ({
     [children]
   );
 
-  // Use useEffect to update branches when they change
   useEffect(() => {
     if (branches.length !== childrenArray.length) {
       setBranches(childrenArray);
@@ -234,7 +233,6 @@ export const MessageBranchSelector = ({
 }: MessageBranchSelectorProps) => {
   const { totalBranches } = useMessageBranch();
 
-  // Don't render if there's only one branch
   if (totalBranches <= 1) {
     return null;
   }

--- a/dashboard/src/components/ai-elements/prompt-input-utils.ts
+++ b/dashboard/src/components/ai-elements/prompt-input-utils.ts
@@ -12,10 +12,6 @@ import {
 } from "react";
 import { nanoid } from "nanoid";
 
-// ============================================================================
-// Provider Context & Types
-// ============================================================================
-
 export type AttachmentsContext = {
   files: (FileUIPart & { id: string })[];
   add: (files: File[] | FileList) => void;
@@ -98,11 +94,9 @@ export type PromptInputProviderProps = PropsWithChildren<{
  * Separated for use with React.createElement in the main component file.
  */
 export function usePromptInputProviderState(initialTextInput: string = "") {
-  // ----- textInput state
   const [textInput, setTextInput] = useState(initialTextInput);
   const clearInput = useCallback(() => setTextInput(""), []);
 
-  // ----- attachments state (global when wrapped)
   const [attachmentFiles, setAttachmentFiles] = useState<
     (FileUIPart & { id: string })[]
   >([]);

--- a/dashboard/src/components/ai-elements/prompt-input.tsx
+++ b/dashboard/src/components/ai-elements/prompt-input.tsx
@@ -267,7 +267,6 @@ export type PromptInputProps = Omit<
   globalDrop?: boolean;
   // Render a hidden input with given name and keep it in sync for native form posts. Default false.
   syncHiddenInput?: boolean;
-  // Minimal constraints
   maxFiles?: number;
   maxFileSize?: number; // bytes
   onError?: (err: {
@@ -293,11 +292,9 @@ export const PromptInput = ({
   children,
   ...props
 }: PromptInputProps) => {
-  // Try to use a provider controller if present
   const controller = useOptionalPromptInputController();
   const usingProvider = !!controller;
 
-  // Refs
   const inputRef = useRef<HTMLInputElement | null>(null);
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -549,7 +546,6 @@ export const PromptInput = ({
     }
 
     try {
-      // Convert blob URLs to data URLs asynchronously
       const convertedFiles: FileUIPart[] = await Promise.all(
         files.map(async ({ id: _id, ...item }) => {
           if (item.url && item.url.startsWith("blob:")) {
@@ -589,7 +585,6 @@ export const PromptInput = ({
     }
   };
 
-  // Render with or without local provider
   const inner = (
     <>
       <input
@@ -662,7 +657,6 @@ export const PromptInputTextarea = forwardRef<
         }
         e.preventDefault();
 
-        // Check if the submit button is disabled before submitting
         const form = e.currentTarget.form;
         const submitButton = form?.querySelector(
           'button[type="submit"]'
@@ -674,7 +668,6 @@ export const PromptInputTextarea = forwardRef<
         form?.requestSubmit();
       }
 
-      // Remove last attachment when Backspace is pressed and textarea is empty
       if (
         e.key === "Backspace" &&
         e.currentTarget.value === "" &&

--- a/dashboard/src/components/ai-elements/reasoning.tsx
+++ b/dashboard/src/components/ai-elements/reasoning.tsx
@@ -47,7 +47,6 @@ export const Reasoning = memo(
     const [hasAutoClosed, setHasAutoClosed] = useState(false);
     const [startTime, setStartTime] = useState<number | null>(null);
 
-    // Track duration when streaming starts and ends
     useEffect(() => {
       if (isStreaming) {
         if (startTime === null) {

--- a/dashboard/src/components/ai-elements/tool-execution-strip.tsx
+++ b/dashboard/src/components/ai-elements/tool-execution-strip.tsx
@@ -89,7 +89,6 @@ export const ToolExecutionStrip = memo(
       return null;
     }
 
-    // Build summary text
     const summaryParts: string[] = [];
     if (stats.completed > 0) {
       summaryParts.push(`${stats.completed} completed`);

--- a/dashboard/src/components/brainstorm/HandoffDialog.tsx
+++ b/dashboard/src/components/brainstorm/HandoffDialog.tsx
@@ -30,7 +30,6 @@ export function HandoffDialog({
 }: HandoffDialogProps) {
   const [issueTitle, setIssueTitle] = useState("");
 
-  // Pre-fill title from artifact
   useEffect(() => {
     if (artifact?.title) {
       setIssueTitle(`Implement ${artifact.title}`);

--- a/dashboard/src/components/brainstorm/MessageMetadata.tsx
+++ b/dashboard/src/components/brainstorm/MessageMetadata.tsx
@@ -38,13 +38,11 @@ function formatTimestamp(isoString: string): string {
   const diffHours = Math.floor(diffMins / 60);
   const diffDays = Math.floor(diffHours / 24);
 
-  // Within last hour - show relative
   if (diffMins < 1) return "just now";
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
 
-  // Older - show date
   return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",

--- a/dashboard/src/components/brainstorm/__tests__/MessageMetadata.test.tsx
+++ b/dashboard/src/components/brainstorm/__tests__/MessageMetadata.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { MessageMetadata } from "../MessageMetadata";
 import type { MessageUsage } from "@/types/api";
 
-// Mock the copyToClipboard utility
 vi.mock("@/lib/utils", async () => {
   const actual = await vi.importActual("@/lib/utils");
   return {
@@ -13,7 +12,6 @@ vi.mock("@/lib/utils", async () => {
   };
 });
 
-// Import the mocked function for assertions
 import { copyToClipboard } from "@/lib/utils";
 
 beforeEach(() => {
@@ -35,12 +33,10 @@ describe("MessageMetadata", () => {
       />
     );
 
-    // Should render the copy button
     expect(
       screen.getByRole("button", { name: /copy message/i })
     ).toBeInTheDocument();
 
-    // Should not render token count or cost
     expect(screen.queryByText(/tok$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$\d+\.\d+/)).not.toBeInTheDocument();
   });
@@ -54,15 +50,12 @@ describe("MessageMetadata", () => {
       />
     );
 
-    // Should render total tokens (input + output = 12400 -> "12.4K tok")
     expect(screen.getByText("12.4K tok")).toBeInTheDocument();
 
-    // Should render cost
     expect(screen.getByText("$0.05")).toBeInTheDocument();
   });
 
   it("formats tokens with K notation for thousands", () => {
-    // Test 1500 tokens -> "1.5K tok"
     const { rerender } = render(
       <MessageMetadata
         timestamp="2026-01-18T10:00:00Z"
@@ -82,7 +75,6 @@ describe("MessageMetadata", () => {
     );
     expect(screen.getByText("500 tok")).toBeInTheDocument();
 
-    // Test exactly 1000 tokens -> "1.0K tok"
     rerender(
       <MessageMetadata
         timestamp="2026-01-18T10:00:00Z"
@@ -102,10 +94,8 @@ describe("MessageMetadata", () => {
       />
     );
 
-    // The diamond separator character should not be present
     expect(screen.queryByText("◈")).not.toBeInTheDocument();
 
-    // Token and cost text should not be present
     expect(screen.queryByText(/tok$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
   });
@@ -149,7 +139,6 @@ describe("MessageMetadata", () => {
     const copyButton = screen.getByRole("button", { name: /copy message/i });
     await user.click(copyButton);
 
-    // After clicking, the button label should change to "Copied"
     expect(
       screen.getByRole("button", { name: /copied/i })
     ).toBeInTheDocument();

--- a/dashboard/src/components/brainstorm/__tests__/SessionInfoBar.test.tsx
+++ b/dashboard/src/components/brainstorm/__tests__/SessionInfoBar.test.tsx
@@ -26,10 +26,8 @@ describe("SessionInfoBar", () => {
       />
     );
 
-    // Should render message count
     expect(screen.getByText("5")).toBeInTheDocument();
 
-    // Should not render cost
     expect(screen.queryByText(/\$\d+\.\d{2}/)).not.toBeInTheDocument();
   });
 
@@ -43,7 +41,6 @@ describe("SessionInfoBar", () => {
       />
     );
 
-    // Should render the total cost
     expect(screen.getByText("$0.42")).toBeInTheDocument();
   });
 
@@ -62,7 +59,6 @@ describe("SessionInfoBar", () => {
       />
     );
 
-    // Should not render cost when it's 0
     expect(screen.queryByText(/\$\d+\.\d{2}/)).not.toBeInTheDocument();
   });
 
@@ -76,7 +72,6 @@ describe("SessionInfoBar", () => {
     );
 
     // Should render formatted model name (formatModel capitalizes and adds spaces)
-    // "claude-sonnet-4.5" -> "Claude Sonnet 4.5"
     expect(screen.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
 
     // Should render formatted driver (formatDriver returns "CLAUDE" for non-prefixed strings)
@@ -152,11 +147,9 @@ describe("SessionInfoBar", () => {
       />
     );
 
-    // Should still render status and message count
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
 
-    // Should not render model or driver
     expect(screen.queryByText("Claude Sonnet 4.5")).not.toBeInTheDocument();
     // Note: "Claude" might appear elsewhere, so we check for the model specifically
   });

--- a/dashboard/src/components/brainstorm/__tests__/SessionListItem.test.tsx
+++ b/dashboard/src/components/brainstorm/__tests__/SessionListItem.test.tsx
@@ -112,7 +112,6 @@ describe("SessionListItem", () => {
       />
     );
 
-    // Click delete button
     await userEvent.click(screen.getByRole("button", { name: /delete session/i }));
 
     expect(onDelete).toHaveBeenCalledWith("s1");

--- a/dashboard/src/components/model-picker/ApiModelSelect.tsx
+++ b/dashboard/src/components/model-picker/ApiModelSelect.tsx
@@ -53,11 +53,10 @@ export function ApiModelSelect({ agentKey, value, onChange, error, className }: 
     setManualModelId(value);
   }, [value]);
 
-  // Get recent models that exist in the store
   const recentModels = recentModelIds
     .map((id) => models.find((m) => m.id === id))
     .filter((m): m is ModelInfo => m !== undefined)
-    .slice(0, 5); // Show max 5 in dropdown
+    .slice(0, 5);
 
   // Ensure current value is always represented in dropdown items
   const currentInRecent = recentModels.some((m) => m.id === value);

--- a/dashboard/src/components/model-picker/ModelList.tsx
+++ b/dashboard/src/components/model-picker/ModelList.tsx
@@ -111,7 +111,6 @@ export function ModelList({
     return <EmptyState />;
   }
 
-  // Split into recent and all models
   const recentModels = recentModelIds
     .map((id) => models.find((m) => m.id === id))
     .filter((m): m is ModelInfo => m !== undefined);

--- a/dashboard/src/components/model-picker/ModelPickerSheet.tsx
+++ b/dashboard/src/components/model-picker/ModelPickerSheet.tsx
@@ -54,7 +54,6 @@ function filterModels(
   minContext: number | null
 ): ModelInfo[] {
   return models.filter((model) => {
-    // Search query (name or provider)
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       const matchesName = model.name.toLowerCase().includes(query);
@@ -64,19 +63,16 @@ function filterModels(
       }
     }
 
-    // User-selected capabilities filter
     for (const cap of capabilities) {
       if (cap === 'reasoning' && !model.capabilities.reasoning) return false;
       if (cap === 'structured_output' && !model.capabilities.structured_output) return false;
     }
 
-    // User-selected price tier filter
     if (priceTier) {
       const modelTier = getPriceTier(model.cost.output);
       if (modelTier !== priceTier) return false;
     }
 
-    // User-selected context size filter
     if (minContext && (model.limit.context === null || model.limit.context < minContext)) {
       return false;
     }
@@ -110,14 +106,12 @@ export function ModelPickerSheet({
   const error = useModelsStore((state) => state.error);
   const refreshModels = useModelsStore((state) => state.refreshModels);
 
-  // Fetch fresh models when sheet opens
   useEffect(() => {
     if (open) {
       refreshModels();
     }
   }, [open, refreshModels]);
 
-  // Get agent-filtered models
   const agentModels = useMemo(() => {
     const requirements = AGENT_MODEL_REQUIREMENTS[agentKey];
     if (!requirements) {
@@ -126,7 +120,6 @@ export function ModelPickerSheet({
     return filterModelsByRequirements(models, requirements);
   }, [agentKey, models]);
 
-  // Apply user filters
   const filteredModels = useMemo(
     () =>
       filterModels(

--- a/dashboard/src/components/model-picker/ProviderLogo.tsx
+++ b/dashboard/src/components/model-picker/ProviderLogo.tsx
@@ -100,7 +100,6 @@ export function ProviderLogo({ provider, className }: ProviderLogoProps) {
   const LogoComponent = BUNDLED_LOGOS[provider];
   const [imageError, setImageError] = useState(false);
 
-  // Reset error state when provider changes
   useEffect(() => {
     setImageError(false);
   }, [provider]);

--- a/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ApiModelSelect.test.tsx
@@ -30,7 +30,6 @@ function ControlledApiModelSelect({
   );
 }
 
-// Mock the store
 vi.mock('@/store/useModelsStore');
 
 // Mock useRecentModels hook with vi.fn() so it can be overridden per-test
@@ -49,7 +48,6 @@ describe('ApiModelSelect', () => {
     vi.clearAllMocks();
     addRecentModel = vi.fn<(modelId: string) => void>();
 
-    // Default useRecentModels return value; override per-test as needed
     mockUseRecentModels.mockReturnValue({
       recentModelIds: ['claude-sonnet-4'],
       addRecentModel,
@@ -75,7 +73,6 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    // When a model is selected, the Select shows the model name from the matching SelectItem
     expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
   });
 
@@ -100,7 +97,6 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    // Open dropdown
     fireEvent.click(screen.getByRole('combobox'));
 
     expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
@@ -116,10 +112,8 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    // Open dropdown
     fireEvent.click(screen.getByRole('combobox'));
 
-    // Select model
     fireEvent.click(screen.getByText('Claude Sonnet 4'));
 
     expect(onChange).toHaveBeenCalledWith('claude-sonnet-4');
@@ -149,7 +143,6 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    // "Browse all models..." is a SelectItem inside the dropdown
     fireEvent.click(screen.getByRole('combobox'));
     fireEvent.click(screen.getByText(/browse all models/i));
 
@@ -213,7 +206,6 @@ describe('ApiModelSelect', () => {
       />
     );
 
-    // Open dropdown and click "Browse all models..."
     fireEvent.click(screen.getByRole('combobox'));
     fireEvent.click(screen.getByText(/browse all models/i));
 

--- a/dashboard/src/components/model-picker/__tests__/ModelListItem.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ModelListItem.test.tsx
@@ -39,7 +39,6 @@ describe('ModelListItem', () => {
   it('should render capability icons', () => {
     render(<ModelListItem model={mockModel} onSelect={vi.fn()} />);
 
-    // Check for capability indicators (using aria-labels)
     expect(screen.getByLabelText('Tool calling')).toBeInTheDocument();
     expect(screen.getByLabelText('Reasoning')).toBeInTheDocument();
     expect(screen.getByLabelText('Structured output')).toBeInTheDocument();
@@ -48,7 +47,6 @@ describe('ModelListItem', () => {
   it('should show details when expanded', () => {
     render(<ModelListItem model={mockModel} onSelect={vi.fn()} isExpanded />);
 
-    // Shows pricing details when expanded
     expect(screen.getByText('$3.00 / 1M')).toBeInTheDocument();
     expect(screen.getByText('$15.00 / 1M')).toBeInTheDocument();
   });
@@ -68,7 +66,6 @@ describe('ModelListItem', () => {
     const onSelect = vi.fn();
     render(<ModelListItem model={mockModel} onSelect={onSelect} isExpanded />);
 
-    // Click select (already expanded)
     fireEvent.click(screen.getByRole('button', { name: /select/i }));
 
     expect(onSelect).toHaveBeenCalledWith('claude-sonnet-4');

--- a/dashboard/src/components/model-picker/__tests__/ModelPickerSheet.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ModelPickerSheet.test.tsx
@@ -6,10 +6,8 @@ import { useModelsStore } from '@/store/useModelsStore';
 import { makeMockModelsStore, mockModels } from '@/test/mocks/modelsStore';
 import type { ModelInfo } from '../types';
 
-// Mock the store with selector support
 vi.mock('@/store/useModelsStore');
 
-// Mock useRecentModels hook
 vi.mock('@/hooks/useRecentModels', () => ({
   useRecentModels: () => ({
     recentModelIds: [],
@@ -79,14 +77,12 @@ describe('ModelPickerSheet', () => {
       />
     );
 
-    // Open sheet
     fireEvent.click(screen.getByText('Browse'));
 
     await waitFor(() => {
       expect(screen.getByText('Claude Sonnet 4')).toBeInTheDocument();
     });
 
-    // Expand and select
     fireEvent.click(screen.getByRole('button', { name: /expand/i }));
     fireEvent.click(screen.getByRole('button', { name: /select/i }));
 
@@ -131,7 +127,6 @@ describe('ModelPickerSheet', () => {
       expect(screen.getByText('GPT-4o')).toBeInTheDocument();
     });
 
-    // Search for "claude"
     await user.type(screen.getByPlaceholderText(/search/i), 'claude');
 
     await waitFor(() => {

--- a/dashboard/src/components/model-picker/__tests__/ModelSearchFilters.test.tsx
+++ b/dashboard/src/components/model-picker/__tests__/ModelSearchFilters.test.tsx
@@ -37,7 +37,6 @@ describe('ModelSearchFilters', () => {
   it('should render filter dropdowns', () => {
     render(<ModelSearchFilters {...defaultProps} />);
 
-    // Verify all three filter dropdowns are rendered
     expect(screen.getByText('Capabilities')).toBeInTheDocument();
     expect(screen.getByText('All prices')).toBeInTheDocument();
     expect(screen.getByText('Any context')).toBeInTheDocument();

--- a/dashboard/src/components/prompts/PromptEditModal.tsx
+++ b/dashboard/src/components/prompts/PromptEditModal.tsx
@@ -134,7 +134,6 @@ export function PromptEditModal({
   // Get agent-specific accent styles (always defined due to fallback)
   const accentStyle = getAgentAccentStyle(agent);
 
-  // Load prompt content when modal opens
   useEffect(() => {
     if (!open || !promptId) {
       return;
@@ -143,14 +142,11 @@ export function PromptEditModal({
     const loadContent = async () => {
       setIsLoading(true);
       try {
-        // Get default content
         const defaultContent = await api.getPromptDefault(promptId);
         setDefaultData(defaultContent);
 
-        // Get current version if exists
         const prompt = await api.getPrompt(promptId);
         if (prompt.current_version_id) {
-          // Fetch the current version content
           const currentVersion = await api.getPromptVersion(
             promptId,
             prompt.current_version_id
@@ -158,7 +154,6 @@ export function PromptEditModal({
           setContent(currentVersion.content);
           setOriginalContent(currentVersion.content);
         } else {
-          // No custom version, use default
           setContent(defaultContent.content);
           setOriginalContent(defaultContent.content);
         }
@@ -173,7 +168,6 @@ export function PromptEditModal({
     loadContent();
   }, [open, promptId]);
 
-  // Reset state when modal closes
   useEffect(() => {
     if (!open) {
       setContent('');

--- a/dashboard/src/components/settings/ProfileCard.tsx
+++ b/dashboard/src/components/settings/ProfileCard.tsx
@@ -84,7 +84,6 @@ const formatModel = (model: string): string => {
 
 export const ProfileCard = forwardRef<HTMLDivElement, ProfileCardProps>(
   function ProfileCard({ profile, onConfigure, onDelete, onActivate }, ref) {
-  // Get primary agents configuration
   const primaryAgents = PRIMARY_AGENT_KEYS;
   const agentConfigs = primaryAgents.map(key => ({
     key,
@@ -92,7 +91,6 @@ export const ProfileCard = forwardRef<HTMLDivElement, ProfileCardProps>(
     model: profile.agents?.[key]?.model ?? 'unknown',
   }));
 
-  // Count utility agents for badge
   const utilityAgentCount = Object.keys(profile.agents ?? {}).filter(
     k => !primaryAgents.includes(k as typeof primaryAgents[number])
   ).length;

--- a/dashboard/src/components/settings/__tests__/PRAutoFixSection.test.tsx
+++ b/dashboard/src/components/settings/__tests__/PRAutoFixSection.test.tsx
@@ -68,9 +68,7 @@ describe('PRAutoFixSection', () => {
   it('calls onChange with updated aggressiveness when changed', async () => {
     const user = userEvent.setup();
     const { onChange } = renderSection({ enabled: true, config: DEFAULT_CONFIG });
-    // Open the aggressiveness select
     await user.click(screen.getByRole('combobox'));
-    // Select "Thorough"
     await user.click(screen.getByRole('option', { name: /thorough/i }));
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ aggressiveness: 'thorough' })

--- a/dashboard/src/components/settings/profile-form/AgentsSection.tsx
+++ b/dashboard/src/components/settings/profile-form/AgentsSection.tsx
@@ -38,10 +38,6 @@ const AGENT_COLORS: Record<string, { line: string; icon: string }> = {
   brainstormer: { line: 'bg-muted-foreground/40', icon: 'text-muted-foreground' },
 };
 
-// =============================================================================
-// Agent Row
-// =============================================================================
-
 interface AgentRowProps {
   agent: AgentDefinition;
   config: AgentFormData;
@@ -113,10 +109,6 @@ function AgentRow({ agent, config, error, onChange }: AgentRowProps) {
     </div>
   );
 }
-
-// =============================================================================
-// Bulk Apply
-// =============================================================================
 
 interface BulkApplyProps {
   onApply: (driver: string, model: string, targets: 'all' | 'primary' | 'utility') => void;
@@ -226,10 +218,6 @@ function BulkApply({ onApply }: BulkApplyProps) {
     </Collapsible>
   );
 }
-
-// =============================================================================
-// Agents Section
-// =============================================================================
 
 interface AgentsSectionProps {
   agents: Record<string, AgentFormData>;

--- a/dashboard/src/components/settings/profile-form/__tests__/AgentsSection.test.tsx
+++ b/dashboard/src/components/settings/profile-form/__tests__/AgentsSection.test.tsx
@@ -6,10 +6,8 @@ import { useModelsStore } from '@/store/useModelsStore';
 import { makeMockModelsStore } from '@/test/mocks/modelsStore';
 import type { AgentFormData } from '../types';
 
-// Mock the models store (used by ApiModelSelect for the api driver)
 vi.mock('@/store/useModelsStore');
 
-// Mock useRecentModels (used by ApiModelSelect)
 vi.mock('@/hooks/useRecentModels', () => ({
   useRecentModels: () => ({
     recentModelIds: ['claude-sonnet-4'],
@@ -42,7 +40,6 @@ describe('AgentsSection', () => {
         onBulkApply={vi.fn()}
       />
     );
-    // architect/developer/reviewer visible
     expect(screen.getByText(/architect/i)).toBeInTheDocument();
     expect(screen.getByText(/developer/i)).toBeInTheDocument();
     expect(screen.getByText(/reviewer/i)).toBeInTheDocument();
@@ -61,7 +58,6 @@ describe('AgentsSection', () => {
         onBulkApply={vi.fn()}
       />
     );
-    // The architect driver select is the first combobox.
     const driverSelect = screen.getAllByRole('combobox')[0]!; // Safe: AgentsSection always renders driver selects
     await user.click(driverSelect);
     await user.click(screen.getByRole('option', { name: /codex/i }));

--- a/dashboard/src/components/settings/profile-form/useProfileForm.ts
+++ b/dashboard/src/components/settings/profile-form/useProfileForm.ts
@@ -214,7 +214,6 @@ export interface UseProfileForm {
  * ignore_authors.
  */
 function isProfileFormDataEqual(a: ProfileFormData, b: ProfileFormData): boolean {
-  // Scalar top-level fields.
   if (
     a.id !== b.id ||
     a.tracker !== b.tracker ||
@@ -225,7 +224,6 @@ function isProfileFormDataEqual(a: ProfileFormData, b: ProfileFormData): boolean
     return false;
   }
 
-  // agents: Record<string, {driver, model}>
   const aKeys = Object.keys(a.agents);
   const bKeys = Object.keys(b.agents);
   if (aKeys.length !== bKeys.length) return false;
@@ -237,7 +235,6 @@ function isProfileFormDataEqual(a: ProfileFormData, b: ProfileFormData): boolean
     }
   }
 
-  // sandbox
   const as = a.sandbox;
   const bs = b.sandbox;
   if (
@@ -261,7 +258,6 @@ function isProfileFormDataEqual(a: ProfileFormData, b: ProfileFormData): boolean
     return false;
   }
 
-  // pr_autofix
   if (a.pr_autofix === null && b.pr_autofix === null) return true;
   if (a.pr_autofix === null || b.pr_autofix === null) return false;
   const ap = a.pr_autofix;

--- a/dashboard/src/hooks/__tests__/use-tablet.test.ts
+++ b/dashboard/src/hooks/__tests__/use-tablet.test.ts
@@ -60,7 +60,6 @@ describe('useIsTablet', () => {
     const { result } = renderHook(() => useIsTablet());
     expect(result.current).toBe(false);
 
-    // Simulate resize to tablet
     act(() => {
       vi.stubGlobal('innerWidth', 800);
       listeners.forEach((cb) => cb());

--- a/dashboard/src/hooks/__tests__/useBrainstormSession.test.ts
+++ b/dashboard/src/hooks/__tests__/useBrainstormSession.test.ts
@@ -147,7 +147,6 @@ describe("useBrainstormSession", () => {
       });
 
       expect(brainstormApi.sendMessage).toHaveBeenCalledWith("s1", "Hello");
-      // User message should be optimistically added, plus assistant placeholder
       expect(useBrainstormStore.getState().messages).toHaveLength(2);
       expect(useBrainstormStore.getState().messages[0]!.role).toBe("user");
       expect(useBrainstormStore.getState().messages[1]!.role).toBe("assistant");
@@ -190,7 +189,6 @@ describe("useBrainstormSession", () => {
 
   describe("handleWebSocketDisconnect", () => {
     it("marks streaming message as error on WebSocket disconnect", () => {
-      // Setup: message is streaming
       useBrainstormStore.setState({
         messages: [
           {
@@ -208,13 +206,11 @@ describe("useBrainstormSession", () => {
         streamingMessageId: "m1",
       });
 
-      // Simulate disconnect by calling the handler
       const { handleWebSocketDisconnect } = useBrainstormStore.getState();
       act(() => {
         handleWebSocketDisconnect();
       });
 
-      // Verify message status changed to error
       const state = useBrainstormStore.getState();
       const message = state.messages.find((m) => m.id === "m1");
       expect(message?.status).toBe("error");
@@ -223,7 +219,6 @@ describe("useBrainstormSession", () => {
     });
 
     it("does nothing if no streaming message", () => {
-      // Setup: no streaming message
       useBrainstormStore.setState({
         messages: [
           {
@@ -240,13 +235,11 @@ describe("useBrainstormSession", () => {
         streamingMessageId: null,
       });
 
-      // Calling disconnect should not throw
       const { handleWebSocketDisconnect } = useBrainstormStore.getState();
       act(() => {
         handleWebSocketDisconnect();
       });
 
-      // Message should be unchanged
       const state = useBrainstormStore.getState();
       const message = state.messages.find((m) => m.id === "m1");
       expect(message?.status).toBeUndefined();

--- a/dashboard/src/hooks/__tests__/useElapsedTime.test.tsx
+++ b/dashboard/src/hooks/__tests__/useElapsedTime.test.tsx
@@ -5,7 +5,6 @@ import { createMockWorkflowDetail } from '../../__tests__/fixtures';
 import type { WorkflowDetail } from '../../types';
 import * as workflowUtils from '../../utils/workflow';
 
-// Mock formatElapsedTime to track calls and provide controlled output
 vi.mock('../../utils/workflow', () => ({
   formatElapsedTime: vi.fn(),
 }));
@@ -66,14 +65,12 @@ describe('useElapsedTime', () => {
     expect(result.current).toBe('2h 30m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Advance time by 60 seconds
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
     expect(result.current).toBe('2h 31m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(3);
 
-    // Advance another 60 seconds
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -96,7 +93,6 @@ describe('useElapsedTime', () => {
     expect(result.current).toBe('2h 30m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Advance time by 60 seconds
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -123,7 +119,6 @@ describe('useElapsedTime', () => {
     expect(result.current).toBe('1h 15m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Advance time by 60 seconds
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -148,7 +143,6 @@ describe('useElapsedTime', () => {
     expect(result.current).toBe('0h 45m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Advance time by 60 seconds
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -171,10 +165,8 @@ describe('useElapsedTime', () => {
     // Initial render sets up interval (calls formatElapsedTime twice: useState + useEffect)
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Unmount should clear the interval
     unmount();
 
-    // Advance time - should not trigger any more calls
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -206,16 +198,13 @@ describe('useElapsedTime', () => {
       { initialProps: { workflow: workflow1 } }
     );
 
-    // Initial render with workflow1
     expect(result.current).toBe('1h 00m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledWith(workflow1);
 
-    // Re-render with workflow2
     act(() => {
       rerender({ workflow: workflow2 });
     });
 
-    // Should immediately update to workflow2's elapsed time
     expect(result.current).toBe('2h 30m');
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledWith(workflow2);
   });
@@ -241,13 +230,10 @@ describe('useElapsedTime', () => {
       { initialProps: { workflow: inProgressWorkflow } }
     );
 
-    // Initial render - interval should be set up
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Change to completed
     rerender({ workflow: completedWorkflow });
 
-    // After rerender, useEffect should have run
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(3);
 
     // Advance time - should not trigger any more calls (interval cleared)
@@ -275,13 +261,10 @@ describe('useElapsedTime', () => {
 
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(2);
 
-    // Change to null
     rerender({ workflow: null });
 
-    // After rerender, useEffect should have run
     expect(workflowUtils.formatElapsedTime).toHaveBeenCalledTimes(3);
 
-    // Advance time - should not trigger any more calls
     vi.clearAllMocks();
     act(() => {
       vi.advanceTimersByTime(60_000);

--- a/dashboard/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/dashboard/src/hooks/__tests__/useWebSocket.test.tsx
@@ -7,7 +7,6 @@ import { createMockEvent } from '../../__tests__/fixtures';
 import { suppressConsoleLogs } from '@/test/helpers';
 import type { WebSocketMessage } from '../../types';
 
-// Mock WebSocket
 class MockWebSocket {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -23,7 +22,6 @@ class MockWebSocket {
 
   constructor(url: string) {
     this.url = url;
-    // Store instance for test access
     MockWebSocket.instances.push(this);
   }
 
@@ -32,7 +30,6 @@ class MockWebSocket {
     this.readyState = MockWebSocket.CLOSED;
   });
 
-  // Test helpers
   static instances: MockWebSocket[] = [];
   static clearInstances() {
     MockWebSocket.instances = [];
@@ -56,7 +53,6 @@ class MockWebSocket {
   }
 }
 
-// Install mock
 global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
 
 describe('useWebSocket', () => {
@@ -151,21 +147,18 @@ describe('useWebSocket', () => {
 
     expect(useWorkflowStore.getState().isConnected).toBe(false);
 
-    // First reconnect after 1s
     vi.advanceTimersByTime(1000);
     expect(MockWebSocket.instances.length).toBe(2);
 
     const ws2 = MockWebSocket.getLatestInstance()!;
     ws2.triggerClose(1006, 'Abnormal closure');
 
-    // Second reconnect after 2s
     vi.advanceTimersByTime(2000);
     expect(MockWebSocket.instances.length).toBe(3);
 
     const ws3 = MockWebSocket.getLatestInstance()!;
     ws3.triggerClose(1006, 'Abnormal closure');
 
-    // Third reconnect after 4s
     vi.advanceTimersByTime(4000);
     expect(MockWebSocket.instances.length).toBe(4);
   });
@@ -178,7 +171,6 @@ describe('useWebSocket', () => {
     const ws = MockWebSocket.getLatestInstance()!;
     expect(ws.url).toContain('?since=evt-42');
   });
-
 
   it('should handle backfill_expired by clearing lastEventId', () => {
     useWorkflowStore.setState({ lastEventId: 'evt-old' });
@@ -211,7 +203,6 @@ describe('useWebSocket', () => {
       vi.advanceTimersByTime(expectedDelay);
     }
 
-    // Verify the final delay is capped at 30s
     const lastWs = MockWebSocket.getLatestInstance()!;
     lastWs.triggerClose(1006, 'Abnormal closure');
 
@@ -259,16 +250,13 @@ describe('useWebSocket', () => {
   it('should reset reconnect counter on successful connection', () => {
     renderHook(() => useWebSocket());
 
-    // First connection fails
     const ws1 = MockWebSocket.getLatestInstance()!;
     ws1.triggerOpen();
     ws1.triggerClose(1006, 'Abnormal closure');
 
-    // Reconnect after 1s
     vi.advanceTimersByTime(1000);
     expect(MockWebSocket.instances.length).toBe(2);
 
-    // Second connection succeeds
     const ws2 = MockWebSocket.getLatestInstance()!;
     ws2.triggerOpen();
 
@@ -416,7 +404,6 @@ describe('handleBrainstormMessage', () => {
   it('handles artifact_created event', () => {
     const createdAt = new Date().toISOString();
 
-    // Add a session so updateSession has something to update
     useBrainstormStore.setState({
       ...useBrainstormStore.getState(),
       sessions: [

--- a/dashboard/src/hooks/useAutoRevalidation.ts
+++ b/dashboard/src/hooks/useAutoRevalidation.ts
@@ -58,19 +58,16 @@ export function useAutoRevalidation(workflowId?: string) {
   const lastProcessedTimestampRef = useRef<number>(0);
 
   useEffect(() => {
-    // Get events for specific workflow or all workflows
     const events = workflowId
       ? eventsByWorkflow[workflowId] ?? []
       : Object.values(eventsByWorkflow).flat();
 
-    // Find the latest status-changing event within the 5-second window
     const latestStatusEvent = events
       .filter((e) => STATUS_EVENTS.includes(e.event_type as (typeof STATUS_EVENTS)[number]))
       .map((e) => new Date(e.timestamp).getTime())
       .filter((timestamp) => Date.now() - timestamp < 5000)
       .sort((a, b) => b - a)[0];
 
-    // Only revalidate if we have a new event we haven't processed yet
     if (
       latestStatusEvent &&
       latestStatusEvent > lastProcessedTimestampRef.current &&

--- a/dashboard/src/hooks/useBrainstormSession.ts
+++ b/dashboard/src/hooks/useBrainstormSession.ts
@@ -47,14 +47,12 @@ export function useBrainstormSession() {
 
   const createSession = useCallback(
     async (profileId: string, firstMessage: string) => {
-      // Create session with first message as topic
       const { session, profile } = await brainstormApi.createSession(profileId, firstMessage);
       addSession(session);
       setActiveSessionId(session.id);
       setActiveProfile(profile ?? null);
       clearMessages();
       setArtifacts([]);
-      // Initialize usage to zeros for new sessions
       setSessionUsage({
         total_input_tokens: 0,
         total_output_tokens: 0,
@@ -62,7 +60,6 @@ export function useBrainstormSession() {
         message_count: 0,
       });
 
-      // Add optimistic user message
       const userMessage = {
         id: nanoid(),
         session_id: session.id,
@@ -95,7 +92,6 @@ export function useBrainstormSession() {
         replaceMessageId(tempAssistantId, response.message_id);
         setStreaming(true, response.message_id);
       } catch (error) {
-        // Rollback optimistic messages
         removeMessage(tempAssistantId);
         removeMessage(userMessage.id);
         setStreaming(false, null);
@@ -129,7 +125,6 @@ export function useBrainstormSession() {
         addMessage(userMessage);
         clearStaleStreaming();
 
-        // Get updated count after user message was added
         const newLength = useBrainstormStore.getState().messages.length;
         const assistantMessage = {
           id: tempAssistantId,
@@ -148,7 +143,6 @@ export function useBrainstormSession() {
         replaceMessageId(tempAssistantId, response.message_id);
         setStreaming(true, response.message_id);
       } catch (error) {
-        // Rollback optimistic messages
         removeMessage(tempAssistantId);
         removeMessage(optimisticId);
         setStreaming(false, null);

--- a/dashboard/src/hooks/useElapsedTime.ts
+++ b/dashboard/src/hooks/useElapsedTime.ts
@@ -24,15 +24,13 @@ export function useElapsedTime(workflow: WorkflowDetail | null): string {
   const [elapsed, setElapsed] = useState(() => formatElapsedTime(workflow));
 
   useEffect(() => {
-    // Re-compute immediately when workflow changes
     setElapsed(formatElapsedTime(workflow));
 
-    // Only set up interval for active (in_progress/blocked) workflows
     if (!workflow || (workflow.status !== 'in_progress' && workflow.status !== 'blocked')) return;
 
     const interval = setInterval(() => {
       setElapsed(formatElapsedTime(workflow));
-    }, 60_000); // Update every 60 seconds
+    }, 60_000);
 
     return () => clearInterval(interval);
   }, [workflow]);

--- a/dashboard/src/hooks/useRecentModels.ts
+++ b/dashboard/src/hooks/useRecentModels.ts
@@ -8,7 +8,6 @@ export function useRecentModels() {
   const [recentModelIds, setRecentModelIds] = useState<string[]>([]);
   const [hasParseError, setHasParseError] = useState(false);
 
-  // Load from localStorage on mount
   useEffect(() => {
     try {
       const stored = localStorage.getItem(RECENT_MODELS_KEY);
@@ -19,7 +18,6 @@ export function useRecentModels() {
         }
       }
     } catch (error) {
-      // Invalid JSON, start fresh
       console.warn('Failed to load recent models from localStorage:', error);
       setRecentModelIds([]);
       setHasParseError(true);
@@ -28,12 +26,9 @@ export function useRecentModels() {
 
   const addRecentModel = useCallback((modelId: string) => {
     setRecentModelIds((prev) => {
-      // Remove if already exists (will be added to front)
       const filtered = prev.filter((id) => id !== modelId);
-      // Add to front and limit size
       const updated = [modelId, ...filtered].slice(0, MAX_RECENT_MODELS);
 
-      // Persist to localStorage
       try {
         localStorage.setItem(RECENT_MODELS_KEY, JSON.stringify(updated));
       } catch (error) {

--- a/dashboard/src/hooks/useWebSocket.ts
+++ b/dashboard/src/hooks/useWebSocket.ts
@@ -137,7 +137,6 @@ const POLL_ERROR_TOAST_INTERVAL_MS = 30_000;
  * @returns WebSocket URL (ws://host/ws/events or wss://host/ws/events)
  */
 function deriveWebSocketUrl(): string {
-  // Handle SSR/tests where window might not exist
   if (typeof window === 'undefined') {
     return 'ws://localhost:8420/ws/events';
   }
@@ -156,12 +155,12 @@ const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || deriveWebSocketUrl();
 /**
  * Maximum delay between reconnection attempts in milliseconds (30 seconds).
  */
-const MAX_RECONNECT_DELAY = 30000; // 30 seconds
+const MAX_RECONNECT_DELAY = 30000;
 
 /**
  * Initial delay for the first reconnection attempt in milliseconds (1 second).
  */
-const INITIAL_RECONNECT_DELAY = 1000; // 1 second
+const INITIAL_RECONNECT_DELAY = 1000;
 
 /**
  * Handle incoming brainstorm streaming events.
@@ -172,7 +171,6 @@ const INITIAL_RECONNECT_DELAY = 1000; // 1 second
 export function handleBrainstormMessage(msg: BrainstormStreamEvent): void {
   const state = useBrainstormStore.getState();
 
-  // Ignore events for different sessions
   if (msg.session_id !== state.activeSessionId) return;
 
   switch (msg.event_type) {
@@ -215,7 +213,6 @@ export function handleBrainstormMessage(msg: BrainstormStreamEvent): void {
           ),
         }));
       }
-      // Update session usage totals
       if (sessionUsage) {
         state.setSessionUsage(sessionUsage);
       }
@@ -352,7 +349,6 @@ export function useWebSocket() {
       const workflowId = event.workflow_id;
       const lastSequence = lastSequenceRef.current.get(workflowId);
 
-      // Detect sequence gaps
       if (lastSequence !== undefined && event.sequence !== lastSequence + 1) {
         logger.warn('Sequence gap detected', {
           workflow_id: workflowId,
@@ -361,13 +357,10 @@ export function useWebSocket() {
         });
       }
 
-      // Update sequence tracker
       lastSequenceRef.current.set(workflowId, event.sequence);
 
-      // Add to store
       addEvent(event);
 
-      // Show deduplicated toast for pr_poll_error events
       if (event.event_type === 'pr_poll_error') {
         const now = Date.now();
         if (now - lastPollErrorToastMs > POLL_ERROR_TOAST_INTERVAL_MS) {
@@ -376,7 +369,6 @@ export function useWebSocket() {
         }
       }
 
-      // Dispatch custom event for revalidation hints
       window.dispatchEvent(
         new CustomEvent('workflow-event', {
           detail: event,
@@ -391,12 +383,10 @@ export function useWebSocket() {
    * Uses connectRef to avoid circular dependency with connect.
    */
   const scheduleReconnect = useCallback(() => {
-    // Clear any existing timeout
     if (reconnectTimeoutRef.current !== null) {
       clearTimeout(reconnectTimeoutRef.current);
     }
 
-    // Calculate delay with exponential backoff (1s, 2s, 4s, 8s, ..., max 30s)
     const delay = Math.min(
       INITIAL_RECONNECT_DELAY * Math.pow(2, reconnectAttemptRef.current),
       MAX_RECONNECT_DELAY
@@ -413,28 +403,23 @@ export function useWebSocket() {
    * Connect to WebSocket server.
    */
   const connect = useCallback(() => {
-    // Build URL with optional ?since= parameter for backfill
     let url = WS_BASE_URL;
     const currentLastEventId = useWorkflowStore.getState().lastEventId;
     if (currentLastEventId) {
       url += `?since=${encodeURIComponent(currentLastEventId)}`;
     }
 
-    // Create WebSocket
     const ws = new WebSocket(url);
     wsRef.current = ws;
 
-    // Connection opened
     ws.onopen = () => {
       logger.info('WebSocket connected');
       setConnected(true);
-      reconnectAttemptRef.current = 0; // Reset reconnect counter
+      reconnectAttemptRef.current = 0;
 
-      // Subscribe to all workflows
       ws.send(JSON.stringify({ type: 'subscribe_all' }));
     };
 
-    // Message received
     ws.onmessage = (event) => {
       try {
         const message: WebSocketMessage = JSON.parse(event.data);
@@ -469,13 +454,11 @@ export function useWebSocket() {
       }
     };
 
-    // Connection closed
     ws.onclose = (event) => {
       logger.info('WebSocket disconnected', { code: event.code, reason: event.reason });
       setConnected(false);
       wsRef.current = null;
 
-      // Mark any streaming messages as errored
       useBrainstormStore.getState().handleWebSocketDisconnect();
 
       // Reconnect unless it was a normal closure
@@ -484,14 +467,12 @@ export function useWebSocket() {
       }
     };
 
-    // Error occurred
     ws.onerror = (error) => {
       logger.error('WebSocket error', error);
       setConnected(false, 'WebSocket error');
     };
   }, [handleEvent, scheduleReconnect, setConnected, setLastEventId]);
 
-  // Keep connectRef in sync with connect
   connectRef.current = connect;
 
   /**
@@ -505,17 +486,14 @@ export function useWebSocket() {
     connect();
   }, [connect]);
 
-  // Connect on mount, disconnect on unmount
   useEffect(() => {
     connect();
 
     return () => {
-      // Clear reconnect timeout
       if (reconnectTimeoutRef.current !== null) {
         clearTimeout(reconnectTimeoutRef.current);
       }
 
-      // Close WebSocket
       if (wsRef.current) {
         wsRef.current.close();
       }

--- a/dashboard/src/lib/__tests__/preview.test.ts
+++ b/dashboard/src/lib/__tests__/preview.test.ts
@@ -36,7 +36,6 @@ describe('extractDocumentPreview', () => {
   });
 
   it('truncates at word boundary when no clear break found', () => {
-    // Create a long text without sentence breaks
     const text = 'a'.repeat(500);
     const result = extractDocumentPreview(text, 100);
     expect(result.length).toBeLessThanOrEqual(100);

--- a/dashboard/src/lib/constants.ts
+++ b/dashboard/src/lib/constants.ts
@@ -20,10 +20,6 @@ import packageJson from '../../package.json';
 /** Current application version from package.json. */
 export const APP_VERSION = packageJson.version;
 
-// =============================================================================
-// Driver Model Lists
-// =============================================================================
-
 /** Default models (Claude CLI) */
 export const CLAUDE_MODELS = ['opus', 'sonnet', 'haiku'] as const;
 
@@ -96,10 +92,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, AgentRequirements> = {
   },
 };
 
-// =============================================================================
-// Agent Definitions
-// =============================================================================
-
 export interface AgentDefinition {
   key: string;
   label: string;
@@ -111,7 +103,6 @@ export interface AgentDefinition {
 
 /** All agents in the system with their metadata. */
 export const AGENT_DEFINITIONS: AgentDefinition[] = [
-  // Primary agents - always visible
   {
     key: 'architect',
     label: 'Architect',
@@ -136,7 +127,6 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
     defaultModel: 'sonnet',
     category: 'primary',
   },
-  // Utility agents - collapsed by default
   {
     key: 'plan_validator',
     label: 'Plan Validator',

--- a/dashboard/src/lib/design-doc.ts
+++ b/dashboard/src/lib/design-doc.ts
@@ -10,7 +10,6 @@
  * // Returns: 'Queue Workflows'
  */
 export function extractTitle(markdown: string): string {
-  // Match first H1 heading: # Title (strip common document-type suffixes)
   const match = markdown.match(/^#\s+(.+?)(?:\s+(?:Design|Plan|Spec|RFC|Proposal))?\s*$/mi);
   if (!match || !match[1]) {
     return 'Untitled';
@@ -26,9 +25,7 @@ export function extractTitle(markdown: string): string {
  * // Returns: 'queue-workflows-design'
  */
 export function extractTitleFromFilename(filename: string): string {
-  // Remove extension
   const withoutExt = filename.replace(/\.[^.]+$/, '');
-  // Remove date prefix (YYYY-MM-DD-)
   const withoutDate = withoutExt.replace(/^\d{4}-\d{2}-\d{2}-/, '');
   return withoutDate;
 }

--- a/dashboard/src/lib/models-utils.ts
+++ b/dashboard/src/lib/models-utils.ts
@@ -36,11 +36,9 @@ export function flattenModelsData(data: OpenRouterModel[]): ModelInfo[] {
   const models: ModelInfo[] = [];
 
   for (const model of data) {
-    // Extract provider from model ID (e.g., "anthropic/claude-sonnet-4" -> "anthropic")
     const slashIndex = model.id.indexOf('/');
     const provider = slashIndex !== -1 ? model.id.substring(0, slashIndex) : 'unknown';
 
-    // Parse and validate cost values
     const inputParsed = parseFloat(model.pricing.prompt);
     const inputCost = isNaN(inputParsed) ? null : inputParsed * 1_000_000; // Convert per-token to per-1M tokens
     const outputParsed = parseFloat(model.pricing.completion);
@@ -106,17 +104,14 @@ function matchesPriceTier(model: ModelInfo, requiredTier: AgentRequirements['pri
 
   const modelTier = getPriceTier(model.cost.output);
 
-  // Budget tier only matches budget models (strict cost constraint)
   if (requiredTier === 'budget') {
     return modelTier === 'budget';
   }
 
-  // Standard tier matches budget and standard (moderate cost constraint)
   if (requiredTier === 'standard') {
     return modelTier === 'budget' || modelTier === 'standard';
   }
 
-  // Premium tier matches all models (no cost constraint)
   return true;
 }
 
@@ -128,19 +123,16 @@ export function filterModelsByRequirements(
   requirements: AgentRequirements
 ): ModelInfo[] {
   return models.filter((model) => {
-    // Check all required capabilities
     for (const cap of requirements.capabilities) {
       if (!model.capabilities[cap]) {
         return false;
       }
     }
 
-    // Check minimum context size
     if (model.limit.context === null || model.limit.context < requirements.minContext) {
       return false;
     }
 
-    // Check price tier
     if (!matchesPriceTier(model, requirements.priceTier)) {
       return false;
     }

--- a/dashboard/src/lib/plan-parser.ts
+++ b/dashboard/src/lib/plan-parser.ts
@@ -46,7 +46,6 @@ function extractSection(markdown: string, headingName: string): string {
   const startIndex = match.index + match[0].length;
   const remainingContent = markdown.slice(startIndex);
 
-  // Find next ## heading or end of string
   const nextHeadingMatch = remainingContent.match(/^##\s+\w/m);
   const endIndex = nextHeadingMatch?.index ?? remainingContent.length;
 
@@ -63,7 +62,6 @@ function parseGoal(markdown: string): string {
     return '';
   }
 
-  // Collapse multiple lines into one, preserving sentence structure
   return section
     .split('\n')
     .map((line) => line.trim())
@@ -77,19 +75,16 @@ function parseGoal(markdown: string): string {
  * Priority: ### Task headings > checklist items > numbered lists
  */
 function countTasks(markdown: string): number {
-  // First, try ### Task headings (most explicit)
   const taskHeadings = markdown.match(/^###\s+Task\s+\d+/gim);
   if (taskHeadings && taskHeadings.length > 0) {
     return taskHeadings.length;
   }
 
-  // Fall back to checklist items (- [ ] or - [x])
   const checklistItems = markdown.match(/^-\s+\[[ x]\]/gim);
   if (checklistItems && checklistItems.length > 0) {
     return checklistItems.length;
   }
 
-  // Fall back to numbered list items in Tasks section
   const tasksSection = extractSection(markdown, 'Tasks');
   if (tasksSection) {
     const numberedItems = tasksSection.match(/^\d+\.\s+/gm);
@@ -116,7 +111,6 @@ function parseKeyFiles(markdown: string): string[] {
 
   const files: string[] = [];
 
-  // Extract from code blocks first
   const codeBlockMatch = section.match(/```[\s\S]*?```/);
   if (codeBlockMatch) {
     const codeContent = codeBlockMatch[0].replace(/```/g, '').trim();
@@ -128,7 +122,6 @@ function parseKeyFiles(markdown: string): string[] {
     }
   }
 
-  // Extract from list items (- path or - `path`)
   const listItemPattern = /^-\s+`?([^`\n]+)`?\s*$/gm;
   let match;
   while ((match = listItemPattern.exec(section)) !== null) {
@@ -138,7 +131,6 @@ function parseKeyFiles(markdown: string): string[] {
     }
   }
 
-  // Deduplicate and limit to 5
   const uniqueFiles = [...new Set(files)];
   return uniqueFiles.slice(0, 5);
 }

--- a/dashboard/src/lib/preview.ts
+++ b/dashboard/src/lib/preview.ts
@@ -15,18 +15,15 @@ export function extractDocumentPreview(
   rawText: string | null | undefined,
   maxLength: number = 300
 ): string {
-  // Handle null/undefined/empty
   if (!rawText) {
     return '';
   }
 
-  // Trim leading/trailing whitespace
   const text = rawText.trim();
   if (!text) {
     return '';
   }
 
-  // Try to extract first paragraph (text before double newline)
   const paragraphSplit = text.split('\n\n');
   if (paragraphSplit.length > 1 && paragraphSplit[0]) {
     const firstParagraph = paragraphSplit[0].trim();
@@ -35,8 +32,6 @@ export function extractDocumentPreview(
     }
   }
 
-  // Try to extract first 2-3 sentences
-  // Match sentences ending with . ? ! followed by space or end of string
   const sentences = [];
   const sentenceRegex = /[^.!?]+[.!?]+/g;
   let match;
@@ -44,7 +39,6 @@ export function extractDocumentPreview(
   while ((match = sentenceRegex.exec(text)) !== null) {
     sentences.push(match[0]);
 
-    // Stop after exactly 3 sentences
     if (sentences.length >= 3) {
       break;
     }
@@ -52,11 +46,9 @@ export function extractDocumentPreview(
 
   if (sentences.length > 0) {
     const combined = sentences.join('').trim();
-    // If we have exactly what we need (2-3 sentences under maxLength), return it
     if (combined.length <= maxLength) {
       return combined;
     }
-    // If combined sentences exceed maxLength, truncate at word boundary
     const truncated = combined.substring(0, maxLength);
     const lastSpace = truncated.lastIndexOf(' ');
     if (lastSpace > 0) {
@@ -65,17 +57,14 @@ export function extractDocumentPreview(
     return truncated.trim();
   }
 
-  // For very short documents (< 200 chars) without sentence breaks, return full text
   if (text.length < 200) {
     return text;
   }
 
-  // Fallback: truncate at word boundary
   if (text.length <= maxLength) {
     return text;
   }
 
-  // Find last space before maxLength
   const truncated = text.substring(0, maxLength);
   const lastSpace = truncated.lastIndexOf(' ');
 
@@ -83,6 +72,5 @@ export function extractDocumentPreview(
     return truncated.substring(0, lastSpace).trim();
   }
 
-  // No space found, return truncated text
   return truncated.trim();
 }

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -84,11 +84,9 @@ export function formatDriver(driver: string): string {
  * ```
  */
 export function formatModel(model: string): string {
-  // Handle simple names like "sonnet", "opus", "haiku"
   if (/^(sonnet|opus|haiku)$/i.test(model)) {
     return model.charAt(0).toUpperCase() + model.slice(1).toLowerCase();
   }
-  // Handle longer model names - capitalize and clean up
   return model
     .split(/[-_]/)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
@@ -115,7 +113,6 @@ export function formatModel(model: string): string {
  * ```
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
-  // Try modern Clipboard API first
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
@@ -125,7 +122,6 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     }
   }
 
-  // Fallback for iOS and older browsers
   const textArea = document.createElement('textarea');
   textArea.value = text;
 

--- a/dashboard/src/loaders/__tests__/workflows.test.ts
+++ b/dashboard/src/loaders/__tests__/workflows.test.ts
@@ -19,7 +19,6 @@ function createLoaderArgs(params: Record<string, string>): LoaderFunctionArgs {
   } as unknown as LoaderFunctionArgs;
 }
 
-
 describe('Workflow Loaders', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/dashboard/src/loaders/costs.ts
+++ b/dashboard/src/loaders/costs.ts
@@ -42,7 +42,6 @@ export async function costsLoader({
   const start = url.searchParams.get('start');
   const end = url.searchParams.get('end');
 
-  // Determine API params
   let apiParams: { preset?: string; start?: string; end?: string };
   if (start && end) {
     apiParams = { start, end };

--- a/dashboard/src/loaders/workflows.ts
+++ b/dashboard/src/loaders/workflows.ts
@@ -30,7 +30,6 @@ export async function workflowsLoader({ request, params }: LoaderFunctionArgs): 
   if (isDemo && demoType === 'infinite') {
     const workflows = getMockActiveWorkflows();
     const active = getActiveWorkflow(workflows);
-    // Use id param if provided, otherwise use active workflow
     const targetId = params?.id ?? active?.id;
     const detail = targetId ? getMockWorkflowDetail(targetId) : null;
     return { workflows, detail };
@@ -40,9 +39,6 @@ export async function workflowsLoader({ request, params }: LoaderFunctionArgs): 
 
   const active = getActiveWorkflow(workflows);
 
-  // Determine which workflow detail to fetch:
-  // 1. If id param exists, fetch that specific workflow
-  // 2. Otherwise, fetch the active workflow detail
   const targetId = params?.id ?? active?.id;
   let detail = null;
   let detailError: string | null = null;

--- a/dashboard/src/mocks/infinite-mode.ts
+++ b/dashboard/src/mocks/infinite-mode.ts
@@ -55,10 +55,6 @@ function planToMarkdown(plan: MockPlan): string {
   return md;
 }
 
-// ============================================================================
-// Utility Functions
-// ============================================================================
-
 /**
  * Generate a deterministic UUID from a string seed.
  * Uses a simple hash to create consistent UUIDs for demos.
@@ -124,13 +120,8 @@ const PR_DEFAULTS = {
   pr_comment_count: null as number | null,
 };
 
-// ============================================================================
-// Active Workflows (8 items - includes completed ones)
-// ============================================================================
-
 export function getMockActiveWorkflows(): WorkflowSummary[] {
   return ([
-    // Completed workflows first (most recent first)
     {
       id: generateUUID('NAV-777'),
       issue_id: 'NAV-777',
@@ -170,7 +161,6 @@ export function getMockActiveWorkflows(): WorkflowSummary[] {
       total_tokens: 240000,
       total_duration_ms: 90000,
     },
-    // Running workflows
     {
       id: generateUUID('INFRA-2847'),
       issue_id: 'INFRA-2847',
@@ -210,7 +200,6 @@ export function getMockActiveWorkflows(): WorkflowSummary[] {
       total_tokens: 822000,
       total_duration_ms: 154000,
     },
-    // Blocked workflows at bottom
     {
       id: generateUUID('DEVOPS-∞'),
       issue_id: 'DEVOPS-∞',
@@ -239,10 +228,6 @@ export function getMockActiveWorkflows(): WorkflowSummary[] {
     },
   ] as Omit<WorkflowSummary, keyof typeof PR_DEFAULTS>[]).map(w => ({ ...PR_DEFAULTS, ...w }));
 }
-
-// ============================================================================
-// Past Workflows (10 items)
-// ============================================================================
 
 export function getMockHistoryWorkflows(): WorkflowSummary[] {
   return ([
@@ -378,10 +363,6 @@ export function getMockHistoryWorkflows(): WorkflowSummary[] {
     },
   ] as Omit<WorkflowSummary, keyof typeof PR_DEFAULTS>[]).map(w => ({ ...PR_DEFAULTS, ...w }));
 }
-
-// ============================================================================
-// Execution Plans for Batch Visualization
-// ============================================================================
 
 /**
  * Execution plan for INFRA-2847 (heat shields)
@@ -583,10 +564,6 @@ function getEscapeVelocityExecutionPlan(): MockPlan {
   };
 }
 
-// ============================================================================
-// Token Usage
-// ============================================================================
-
 /**
  * Creates a TokenUsage entry for a specific agent.
  */
@@ -621,7 +598,6 @@ function createTokenUsage(
 function getTokenUsage(workflowId: string, issueId: string): TokenSummary | null {
   const breakdown: TokenUsage[] = [];
 
-  // Different token counts based on the workflow theme
   switch (issueId) {
     case 'INFRA-2847':
       breakdown.push(createTokenUsage(workflowId, 'architect', 100000, 23456, 6.17, 45000, 4));
@@ -652,7 +628,6 @@ function getTokenUsage(workflowId: string, issueId: string): TokenSummary | null
     return null;
   }
 
-  // Calculate totals from breakdown
   const totalInputTokens = breakdown.reduce((sum, u) => sum + u.input_tokens, 0);
   const totalOutputTokens = breakdown.reduce((sum, u) => sum + u.output_tokens, 0);
   const totalCacheReadTokens = breakdown.reduce((sum, u) => sum + u.cache_read_tokens, 0);
@@ -671,10 +646,6 @@ function getTokenUsage(workflowId: string, issueId: string): TokenSummary | null
   };
 }
 
-// ============================================================================
-// Workflow Detail Generator
-// ============================================================================
-
 export function getMockWorkflowDetail(id: string): WorkflowDetail | null {
   const activeWorkflows = getMockActiveWorkflows();
   const historyWorkflows = getMockHistoryWorkflows();
@@ -685,7 +656,6 @@ export function getMockWorkflowDetail(id: string): WorkflowDetail | null {
     return null;
   }
 
-  // Generate detailed information based on issue_id
   let executionPlan: MockPlan | null = null;
   let completedAt: string | null = null;
   let failureReason: string | null = null;
@@ -693,7 +663,6 @@ export function getMockWorkflowDetail(id: string): WorkflowDetail | null {
   const startedAt = summary.started_at || new Date().toISOString();
 
   switch (summary.issue_id) {
-    // Active workflows
     case 'INFRA-2847':
       executionPlan = getHeatShieldsExecutionPlan();
       break;
@@ -746,7 +715,6 @@ export function getMockWorkflowDetail(id: string): WorkflowDetail | null {
       break;
 
     default:
-      // Generic completed workflow
       completedAt = new Date(new Date(startedAt).getTime() + 1 * 60 * 60 * 1000).toISOString();
   }
 
@@ -756,7 +724,6 @@ export function getMockWorkflowDetail(id: string): WorkflowDetail | null {
     completed_at: completedAt,
     failure_reason: failureReason,
     token_usage: getTokenUsage(id, summary.issue_id),
-    // Agentic execution fields
     goal: executionPlan?.goal ?? null,
     plan_markdown: executionPlan ? planToMarkdown(executionPlan) : null,
     plan_path: executionPlan ? `/docs/plans/${summary.issue_id.toLowerCase()}-plan.md` : null,

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -106,7 +106,6 @@ export default function AnalyticsPage() {
     setSearchParams({ preset });
   };
 
-  // Calculate cost delta
   const costDelta = calculateDelta(
     usage.summary.total_cost_usd,
     usage.summary.previous_period_cost_usd
@@ -118,7 +117,6 @@ export default function AnalyticsPage() {
     [usage.by_model]
   );
 
-  // Create color lookup based on cost rank
   const modelColorMap = useMemo(() => {
     const map: Record<string, string> = {};
     sortedModels.forEach((model, index) => {
@@ -127,7 +125,6 @@ export default function AnalyticsPage() {
     return map;
   }, [sortedModels]);
 
-  // Table columns for costs breakdown
   const columns: ColumnDef<UsageByModel>[] = useMemo(
     () => [
       {
@@ -331,7 +328,6 @@ function CostsTabContent({
   modelColorMap: Record<string, string>;
   onPresetChange: (preset: string) => void;
 }) {
-  // Empty state
   if (usage.summary.total_workflows === 0) {
     return (
       <div className="pt-4">

--- a/dashboard/src/pages/CostsPage.tsx
+++ b/dashboard/src/pages/CostsPage.tsx
@@ -82,9 +82,7 @@ function escapeCsvField(value: string | number): string {
   if (/^[=+\-@\t\0]/.test(text)) {
     text = `'${text}`;
   }
-  // Check if quoting is needed
   const needsQuote = /[",\n\r]/.test(text);
-  // Escape existing double quotes
   text = text.replace(/"/g, '""');
   return needsQuote ? `"${text}"` : text;
 }
@@ -139,7 +137,6 @@ export default function CostsPage() {
     navigate(`/history?model=${encodeURIComponent(model.model)}`);
   };
 
-  // Calculate cost delta
   const costDelta = calculateDelta(
     usage.summary.total_cost_usd,
     usage.summary.previous_period_cost_usd
@@ -151,7 +148,6 @@ export default function CostsPage() {
     [usage.by_model]
   );
 
-  // Create color lookup based on cost rank
   const modelColorMap = useMemo(() => {
     const map: Record<string, string> = {};
     sortedModels.forEach((model, index) => {
@@ -160,7 +156,6 @@ export default function CostsPage() {
     return map;
   }, [sortedModels]);
 
-  // Table columns
   const columns: ColumnDef<UsageByModel>[] = useMemo(
     () => [
       {
@@ -260,7 +255,6 @@ export default function CostsPage() {
     [modelColorMap, usage.summary.total_cost_usd]
   );
 
-  // Empty state
   if (usage.summary.total_workflows === 0) {
     return (
       <div className="flex flex-col w-full">

--- a/dashboard/src/pages/DevelopPage.tsx
+++ b/dashboard/src/pages/DevelopPage.tsx
@@ -110,7 +110,6 @@ export default function DevelopPage() {
   const descriptionValue = watch('task_description');
   const descriptionLength = descriptionValue?.length ?? 0;
 
-  // Fetch server config on mount
   useEffect(() => {
     let mounted = true;
 
@@ -134,7 +133,6 @@ export default function DevelopPage() {
     return () => { mounted = false; };
   }, [setValue]);
 
-  // Fetch profiles to determine tracker type
   useEffect(() => {
     let mounted = true;
     const controller = new AbortController();
@@ -152,7 +150,6 @@ export default function DevelopPage() {
     return () => { mounted = false; controller.abort(); };
   }, []);
 
-  // Update tracker type when profile changes
   useEffect(() => {
     if (profileValue) {
       const profile = profiles.find((p) => p.id === profileValue);
@@ -253,7 +250,6 @@ export default function DevelopPage() {
     setOriginalDescription(null);
   }, [originalDescription, setValue]);
 
-  // Design document import handlers
   const populateFromContent = useCallback(
     (content: string, filename: string) => {
       let title = extractTitle(content);

--- a/dashboard/src/pages/HistoryPage.test.tsx
+++ b/dashboard/src/pages/HistoryPage.test.tsx
@@ -5,7 +5,6 @@ import HistoryPage from './HistoryPage';
 import { createMockWorkflowSummary } from '@/__tests__/fixtures';
 import type { WorkflowSummary } from '@/types';
 
-// Mock loader data
 vi.mock('react-router-dom', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react-router-dom')>();
   return {
@@ -80,7 +79,6 @@ describe('HistoryPage', () => {
   it('should display duration, tokens, and cost when available', () => {
     renderHistory();
 
-    // First workflow has all values
     expect(screen.getByText('2m 34s')).toBeInTheDocument();
     expect(screen.getByText('15.2K')).toBeInTheDocument();
     expect(screen.getByText('$0.42')).toBeInTheDocument();
@@ -89,7 +87,6 @@ describe('HistoryPage', () => {
   it('should display "-" when duration, tokens, or cost are null', () => {
     renderHistory();
 
-    // Second workflow has null values - should show "-" for each
     const dashElements = screen.getAllByText('-');
     expect(dashElements.length).toBeGreaterThanOrEqual(3);
   });

--- a/dashboard/src/pages/KnowledgePage.tsx
+++ b/dashboard/src/pages/KnowledgePage.tsx
@@ -206,9 +206,8 @@ function getDocumentColumns(onDelete: (id: string) => void): ColumnDef<Knowledge
   return [
     {
       id: 'expand',
-      size: 40, // Fixed narrow width
+      size: 40,
       cell: ({ row }) => {
-        // Disable expand for processing/failed status
         const canExpand = row.original.status === 'ready';
 
         return (
@@ -292,10 +291,8 @@ export default function KnowledgePage() {
   const loaderData = useLoaderData() as KnowledgeLoaderData;
   const revalidator = useRevalidator();
 
-  // Local state: merge loader data with real-time updates from WebSocket
   const [documents, setDocuments] = useState<KnowledgeDocument[]>(loaderData.documents);
 
-  // Search state
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[] | null>(null);
   const [isSearching, setIsSearching] = useState(false);
@@ -306,7 +303,6 @@ export default function KnowledgePage() {
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const isMountedRef = useRef(true);
 
-  // Upload dialog state
   const [uploadOpen, setUploadOpen] = useState(false);
   const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [uploadName, setUploadName] = useState('');
@@ -315,7 +311,6 @@ export default function KnowledgePage() {
 
   const executeSearch = useCallback(
     async (query: string) => {
-      // Cancel any in-flight search request
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -348,7 +343,6 @@ export default function KnowledgePage() {
     const query = searchQuery.trim();
     if (!query) return;
 
-    // Clear any pending debounced search
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
@@ -363,7 +357,6 @@ export default function KnowledgePage() {
         const query = searchQuery.trim();
         if (!query) return;
 
-        // Clear any pending debounced search
         if (debounceTimerRef.current) {
           clearTimeout(debounceTimerRef.current);
           debounceTimerRef.current = null;
@@ -413,18 +406,15 @@ export default function KnowledgePage() {
 
   const columns = getDocumentColumns(handleDelete);
 
-  // Sync local state when loader data changes
   useEffect(() => {
     setDocuments(loaderData.documents);
   }, [loaderData.documents]);
 
-  // Listen for knowledge domain events from WebSocket
   useEffect(() => {
     const handleKnowledgeEvent = (event: Event) => {
       const customEvent = event as CustomEvent<import('../types').WorkflowEvent>;
       const { domain, workflow_id: documentId, event_type, data } = customEvent.detail;
 
-      // Only handle knowledge domain events
       if (domain !== 'knowledge') return;
 
       switch (event_type) {
@@ -478,14 +468,12 @@ export default function KnowledgePage() {
     };
   }, []);
 
-  // Focus search input when switching to search tab
   useEffect(() => {
     if (activeTab === 'search') {
       searchInputRef.current?.focus();
     }
   }, [activeTab]);
 
-  // Cleanup: abort pending search and clear debounce timer on unmount
   useEffect(() => {
     return () => {
       isMountedRef.current = false;

--- a/dashboard/src/pages/LogsPage.tsx
+++ b/dashboard/src/pages/LogsPage.tsx
@@ -79,7 +79,6 @@ function formatToolInput(toolInput: Record<string, unknown>): string {
   for (const [key, value] of Object.entries(toolInput)) {
     if (value === null || value === undefined) continue;
     const strValue = typeof value === 'string' ? value : JSON.stringify(value);
-    // Truncate long values
     const displayValue = strValue.length > 100 ? strValue.slice(0, 100) + '...' : strValue;
     parts.push(`${key}: ${displayValue}`);
   }
@@ -157,7 +156,6 @@ export default function LogsPage() {
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [typeFilter, setTypeFilter] = useState<TraceEventType | 'all'>('all');
 
-  // Collect and filter trace events from all workflows
   const traceEvents = useMemo(() => {
     const allEvents: WorkflowEvent[] = [];
     for (const events of Object.values(eventsByWorkflow)) {
@@ -167,17 +165,14 @@ export default function LogsPage() {
         }
       }
     }
-    // Sort by timestamp, most recent last
     return allEvents.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   }, [eventsByWorkflow]);
 
-  // Filter events by type if filter is active
   const filteredEvents =
     typeFilter === 'all'
       ? traceEvents
       : traceEvents.filter((e) => e.event_type === typeFilter);
 
-  // Clear events function (resets store for all workflows)
   const clearEvents = useCallback(() => {
     useWorkflowStore.setState({
       eventsByWorkflow: {},
@@ -194,7 +189,6 @@ export default function LogsPage() {
     overscan: 5,
   });
 
-  // Get measureElement ref for dynamic row height measurement
   const measureElement = rowVirtualizer.measureElement;
 
   // Auto-scroll to bottom when new events arrive (if already at bottom)
@@ -206,7 +200,6 @@ export default function LogsPage() {
     }
   }, [filteredEvents.length, isAtBottom, rowVirtualizer]);
 
-  // Track scroll position to determine if user is at bottom
   const handleScroll = useCallback(() => {
     if (!parentRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = parentRef.current;

--- a/dashboard/src/pages/PromptConfigPage.test.tsx
+++ b/dashboard/src/pages/PromptConfigPage.test.tsx
@@ -10,7 +10,6 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import PromptConfigPage from './PromptConfigPage';
 import type { PromptSummary } from '@/types';
 
-// Mock the API client
 vi.mock('@/api/client', () => ({
   api: {
     resetPromptToDefault: vi.fn(),
@@ -94,7 +93,6 @@ describe('PromptConfigPage', () => {
     it('should display all four agent sections', async () => {
       renderWithRouter(mockPromptsWithoutDeveloper);
 
-      // All four agent sections should be visible
       expect(await screen.findByText('Architect')).toBeInTheDocument();
       expect(screen.getByText('Developer')).toBeInTheDocument();
       expect(screen.getByText('Reviewer')).toBeInTheDocument();
@@ -106,7 +104,6 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // Get all section elements and extract their heading text
       const sections = document.querySelectorAll('section');
       const sectionHeadings = Array.from(sections).map(
         (s) => s.querySelector('h2')?.textContent
@@ -126,7 +123,6 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // Each section header should have the agent color class
       expect(screen.getByText('Architect')).toHaveClass('text-agent-architect');
       expect(screen.getByText('Developer')).toHaveClass('text-agent-developer');
       expect(screen.getByText('Reviewer')).toHaveClass('text-agent-reviewer');
@@ -136,17 +132,13 @@ describe('PromptConfigPage', () => {
     it('should display prompt cards for agents with prompts', async () => {
       renderWithRouter(mockPromptsWithoutDeveloper);
 
-      // Wait for page to load
       await screen.findByText('Architect');
 
-      // Architect should have 2 prompt cards
       expect(screen.getByText('System Prompt')).toBeInTheDocument();
       expect(screen.getByText('Plan Format')).toBeInTheDocument();
 
-      // Reviewer should have 1 prompt card
       expect(screen.getByText('Structured Review')).toBeInTheDocument();
 
-      // Evaluator should have 1 prompt card
       expect(screen.getByText('Evaluator System')).toBeInTheDocument();
     });
   });
@@ -155,14 +147,11 @@ describe('PromptConfigPage', () => {
     it('should show placeholder card when developer has no prompts', async () => {
       renderWithRouter(mockPromptsWithoutDeveloper);
 
-      // Wait for page to load
       await screen.findByText('Architect');
 
-      // Developer section should exist
       const developerSection = screen.getByText('Developer').closest('section');
       expect(developerSection).toBeInTheDocument();
 
-      // Should show the placeholder card with explanatory text
       expect(
         within(developerSection!).getByText('No Configurable Prompt')
       ).toBeInTheDocument();
@@ -173,11 +162,9 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // Find the developer section
       const developerSection = screen.getByText('Developer').closest('section');
       expect(developerSection).toBeInTheDocument();
 
-      // Should contain generic placeholder explanation
       expect(
         within(developerSection!).getByText(/no prompt template available/i)
       ).toBeInTheDocument();
@@ -188,16 +175,13 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // Developer section should show the actual prompt, not placeholder
       const developerSection = screen.getByText('Developer').closest('section');
       expect(developerSection).toBeInTheDocument();
 
-      // Should show the actual prompt card
       expect(
         within(developerSection!).getByText('Developer System')
       ).toBeInTheDocument();
 
-      // Should NOT show the placeholder
       expect(
         within(developerSection!).queryByText('No Configurable Prompt')
       ).not.toBeInTheDocument();
@@ -210,7 +194,6 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // Should show total count of 4 prompts
       expect(screen.getByText('4')).toBeInTheDocument();
     });
 
@@ -219,7 +202,6 @@ describe('PromptConfigPage', () => {
 
       await screen.findByText('Architect');
 
-      // One prompt has a custom version (architect.plan)
       expect(screen.getByText('1')).toBeInTheDocument();
       expect(screen.getByText('customized')).toBeInTheDocument();
     });

--- a/dashboard/src/pages/PromptConfigPage.tsx
+++ b/dashboard/src/pages/PromptConfigPage.tsx
@@ -66,31 +66,24 @@ export default function SettingsPage() {
   const { prompts } = useLoaderData<typeof promptsLoader>();
   const revalidator = useRevalidator();
 
-  // Edit modal state
   const [editPromptId, setEditPromptId] = useState<string | null>(null);
   const [editPromptName, setEditPromptName] = useState('');
   const [editPromptAgent, setEditPromptAgent] = useState('');
 
-  // Reset confirmation state
   const [resetPromptId, setResetPromptId] = useState<string | null>(null);
   const [resetPromptName, setResetPromptName] = useState('');
   const [isResetting, setIsResetting] = useState(false);
 
-  // Group prompts by agent
   const groupedPrompts = useMemo(() => groupPromptsByAgent(prompts), [prompts]);
 
-  // Get ordered agents that exist in our data (plus always-show agents)
   const orderedAgents = useMemo(() => {
     const existingAgents = Object.keys(groupedPrompts);
-    // Combine existing agents with always-show agents
     const allAgents = [...new Set([...existingAgents, ...ALWAYS_SHOW_AGENTS])];
-    // First include agents in defined order, then any remaining agents
     const ordered = AGENT_ORDER.filter((agent) => allAgents.includes(agent));
     const remaining = allAgents.filter((agent) => !AGENT_ORDER.includes(agent));
     return [...ordered, ...remaining];
   }, [groupedPrompts]);
 
-  // Handle edit button click
   const handleEdit = useCallback((promptId: string) => {
     const prompt = prompts.find((p) => p.id === promptId);
     if (prompt) {
@@ -101,7 +94,6 @@ export default function SettingsPage() {
     }
   }, [prompts]);
 
-  // Handle reset button click
   const handleResetClick = useCallback((promptId: string) => {
     const prompt = prompts.find((p) => p.id === promptId);
     if (prompt) {
@@ -110,7 +102,6 @@ export default function SettingsPage() {
     }
   }, [prompts]);
 
-  // Confirm reset
   const handleResetConfirm = useCallback(async () => {
     if (!resetPromptId) return;
 
@@ -129,12 +120,10 @@ export default function SettingsPage() {
     }
   }, [resetPromptId, revalidator]);
 
-  // Handle save from edit modal
   const handleSave = useCallback(() => {
     revalidator.revalidate();
   }, [revalidator]);
 
-  // Count custom prompts
   const customCount = prompts.filter((p) => p.current_version_id !== null).length;
 
   return (

--- a/dashboard/src/pages/SettingsProfilesPage.tsx
+++ b/dashboard/src/pages/SettingsProfilesPage.tsx
@@ -200,7 +200,6 @@ export default function SettingsProfilesPage() {
     )[0];
   };
 
-  // Filter profiles
   const filteredProfiles = profiles.filter((p) => {
     if (search && !p.id.toLowerCase().includes(search.toLowerCase())) {
       return false;
@@ -215,7 +214,6 @@ export default function SettingsProfilesPage() {
     return true;
   });
 
-  // Sort: active first, then by name
   const sortedProfiles = [...filteredProfiles].sort((a, b) => {
     if (a.is_active && !b.is_active) return -1;
     if (!a.is_active && b.is_active) return 1;
@@ -265,7 +263,6 @@ export default function SettingsProfilesPage() {
     setDriverFilter('all');
   };
 
-  // Show empty state if no profiles exist
   if (profiles.length === 0) {
     return (
       <div className="container mx-auto py-6 px-4">

--- a/dashboard/src/pages/SpecBuilderPage.tsx
+++ b/dashboard/src/pages/SpecBuilderPage.tsx
@@ -52,7 +52,6 @@ import {
 import type { BrainstormArtifact } from "@/types/api";
 import type { ConfigProfileInfo } from "@/types";
 
-// Extract profile info from config, preferring brainstormer agent config
 async function fetchProfileInfo(
   activeProfile: string | null,
   fallbackInfo: ConfigProfileInfo | null,
@@ -135,7 +134,6 @@ function SpecBuilderPageContent() {
     prevIsStreamingRef.current = isStreaming;
   }, [isStreaming, messages]);
 
-  // Load sessions and config on mount
   useEffect(() => {
     let mounted = true;
 
@@ -192,11 +190,9 @@ function SpecBuilderPageContent() {
         if (activeSessionId) {
           await sendMessage(content);
         } else {
-          // Create new session with first message using active profile from config
           await createSession(activeProfileRef.current, content);
         }
         textInput.clear();
-        // Return focus to input after submit
         textareaRef.current?.focus();
       } catch {
         // Restore input on error
@@ -211,17 +207,14 @@ function SpecBuilderPageContent() {
 
   const handleQuestionAnswer = useCallback(
     async (messageId: string, answers: Record<string, string | string[]>) => {
-      // Format answers as readable text
       const content = formatQuestionAnswers(answers);
 
       // Disable card during submission to prevent double-submits
       setAnsweringQuestionId(messageId);
 
-      // Mark question as answered in store
       updateMessage(messageId, (m) => ({ ...m, questionAnswered: true }));
 
       try {
-        // Send formatted answer as a chat message
         await sendMessage(content);
       } catch (err) {
         // Revert state on failure
@@ -261,7 +254,6 @@ function SpecBuilderPageContent() {
       try {
         const result = await handoff(handoffArtifact.path, issueTitle);
         setHandoffArtifact(null);
-        // Navigate to the new workflow
         navigate(`/workflows/${result.workflow_id}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown error";

--- a/dashboard/src/pages/WorkflowDetailPage.test.tsx
+++ b/dashboard/src/pages/WorkflowDetailPage.test.tsx
@@ -19,7 +19,6 @@ vi.mock('@/store/workflowStore', () => ({
   }),
 }));
 
-// Mock modules
 vi.mock('@/utils/workflow', () => ({
   formatElapsedTime: vi.fn(() => '1h 30m'),
 }));
@@ -65,7 +64,6 @@ function renderWithRouter(loaderData: { workflow: typeof mockWorkflow | null }) 
 describe('WorkflowDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset mock state
     Object.keys(mockEventsByWorkflow).forEach(key => delete mockEventsByWorkflow[key]);
   });
 

--- a/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -37,7 +37,6 @@ export default function WorkflowDetailPage() {
     useCallback((state) => state.eventsByWorkflow[workflowId], [workflowId])
   );
 
-  // Auto-revalidate when this workflow's status changes (approval events, completion, etc.)
   useAutoRevalidation(workflow?.id);
 
   // Determine if this failed workflow can be resumed from checkpoint.

--- a/dashboard/src/pages/WorkflowsPage.test.tsx
+++ b/dashboard/src/pages/WorkflowsPage.test.tsx
@@ -6,7 +6,6 @@ import WorkflowsPage from './WorkflowsPage';
 import { createMockWorkflowSummary, createMockWorkflowDetail } from '@/__tests__/fixtures';
 import type { WorkflowSummary, WorkflowDetail } from '@/types';
 
-// Mock modules
 vi.mock('@/utils/workflow', () => ({
   getActiveWorkflow: vi.fn(),
   formatElapsedTime: vi.fn(),
@@ -14,7 +13,6 @@ vi.mock('@/utils/workflow', () => ({
 
 import { getActiveWorkflow, formatElapsedTime } from '@/utils/workflow';
 
-// Mock data using fixture factories
 const mockWorkflowSummary = createMockWorkflowSummary({
   id: 'wf-001',
   issue_id: 'PROJ-123',
@@ -34,7 +32,6 @@ const mockWorkflowDetail = createMockWorkflowDetail({
   goal: null,
 });
 
-// Second workflow for testing selection behavior
 const mockSecondWorkflowSummary = createMockWorkflowSummary({
   id: 'wf-002',
   issue_id: 'PROJ-456',
@@ -77,12 +74,10 @@ function renderPage(
             path: ':id',
             element: <WorkflowsPage />,
             loader: ({ params }) => {
-              // Return the appropriate detail based on the workflow ID
               // When workflows is empty (past workflow case), use loaderData.detail directly
               if (loaderData.workflows.length === 0 && loaderData.detail) {
                 return { workflows: loaderData.workflows, detail: loaderData.detail };
               }
-              // Otherwise, look up by ID for switching between workflows
               if (params.id === 'wf-002') {
                 return { workflows: loaderData.workflows, detail: mockSecondWorkflowDetail };
               }
@@ -119,14 +114,12 @@ describe('WorkflowsPage', () => {
   it('should display workflow detail when no active workflows but detail exists (past workflow)', async () => {
     vi.mocked(getActiveWorkflow).mockReturnValue(null);
 
-    // Simulate viewing a past workflow when no active workflows exist
     renderPage({ workflows: [], detail: mockWorkflowDetail }, '/workflows/wf-001');
 
     await waitFor(() => {
       // Should NOT show the WorkflowEmptyState component (uses data-slot="empty-state")
       const emptyState = document.querySelector('[data-slot="empty-state"]');
       expect(emptyState).not.toBeInTheDocument();
-      // Should show the workflow detail in the header
       const pageHeader = screen.getByRole('banner');
       expect(within(pageHeader).getByText('PROJ-123')).toBeInTheDocument();
     });
@@ -136,7 +129,6 @@ describe('WorkflowsPage', () => {
     renderPage({ workflows: [mockWorkflowSummary], detail: mockWorkflowDetail }, '/workflows');
 
     await waitFor(() => {
-      // PageHeader uses banner role
       const pageHeader = screen.getByRole('banner');
       expect(pageHeader).toBeInTheDocument();
 
@@ -170,7 +162,6 @@ describe('WorkflowsPage', () => {
     renderPage({ workflows: [mockWorkflowSummary], detail: mockWorkflowDetail }, '/workflows');
 
     await waitFor(() => {
-      // Query the job queue button directly by its accessible name
       const workflowButton = screen.getByRole('button', { name: /PROJ-123/ });
       expect(workflowButton).toBeInTheDocument();
       expect(workflowButton).toHaveAttribute('data-selected', 'true');
@@ -180,7 +171,6 @@ describe('WorkflowsPage', () => {
   it('should show active workflow detail when clicking back after selecting another workflow', async () => {
     const user = userEvent.setup();
 
-    // Render with two workflows, active workflow is wf-001
     renderPage(
       {
         workflows: [mockWorkflowSummary, mockSecondWorkflowSummary],
@@ -189,27 +179,22 @@ describe('WorkflowsPage', () => {
       '/workflows'
     );
 
-    // Wait for initial render showing active workflow (PROJ-123)
     await waitFor(() => {
       const pageHeader = screen.getByRole('banner');
       expect(within(pageHeader).getByText('PROJ-123')).toBeInTheDocument();
     });
 
-    // Click the second workflow (PROJ-456) - should navigate to /workflows/wf-002
     const secondWorkflowButton = screen.getByRole('button', { name: /PROJ-456/ });
     await user.click(secondWorkflowButton);
 
-    // Wait for the workflow detail to display (loaded via URL param)
     await waitFor(() => {
       const pageHeader = screen.getByRole('banner');
       expect(within(pageHeader).getByText('PROJ-456')).toBeInTheDocument();
     });
 
-    // Click back to the active workflow (PROJ-123) - should navigate to /workflows/wf-001
     const firstWorkflowButton = screen.getByRole('button', { name: /PROJ-123/ });
     await user.click(firstWorkflowButton);
 
-    // Should show PROJ-123 detail from loader
     await waitFor(() => {
       const pageHeader = screen.getByRole('banner');
       expect(within(pageHeader).getByText('PROJ-123')).toBeInTheDocument();

--- a/dashboard/src/pages/WorkflowsPage.tsx
+++ b/dashboard/src/pages/WorkflowsPage.tsx
@@ -44,10 +44,8 @@ export default function WorkflowsPage() {
   const isTablet = useIsTablet();
   const [activeTab, setActiveTab] = useState('all');
 
-  // Auto-revalidate when any workflow's status changes (approval events, completion, etc.)
   useAutoRevalidation();
 
-  // Filter workflows by pipeline type tab
   const filteredWorkflows = useMemo(() => {
     if (activeTab === 'all') return workflows;
     return workflows.filter((w: WorkflowSummary) => {
@@ -56,12 +54,10 @@ export default function WorkflowsPage() {
     });
   }, [workflows, activeTab]);
 
-  // Determine which workflow is displayed
   const activeWorkflow = getActiveWorkflow(workflows);
   const displayedId = params.id ?? activeWorkflow?.id ?? null;
   const elapsedTime = useElapsedTime(detail);
 
-  // Handle workflow selection by navigating to URL
   const handleSelect = useCallback((id: string | null) => {
     if (id) {
       navigate(`/workflows/${id}`);

--- a/dashboard/src/pages/__tests__/CostsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/CostsPage.test.tsx
@@ -6,7 +6,6 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import CostsPage from '../CostsPage';
 
-// Mock React Router
 vi.mock('react-router-dom', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react-router-dom')>();
   return {
@@ -19,7 +18,6 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 import { useLoaderData } from 'react-router-dom';
 
-// Mock loader data matching CostsLoaderData interface
 const mockLoaderData = {
   usage: {
     summary: {
@@ -92,7 +90,6 @@ describe('CostsPage', () => {
     );
 
     // Date range presets appear both in desktop buttons and mobile dropdown
-    // Check that at least one set is present
     const sevenDaysButtons = screen.getAllByRole('button', { name: '7 days' });
     expect(sevenDaysButtons.length).toBeGreaterThan(0);
     const thirtyDaysButtons = screen.getAllByRole('button', { name: '30 days' });
@@ -128,12 +125,10 @@ describe('CostsPage table enhancements', () => {
       </MemoryRouter>
     );
 
-    // Column headers should exist as buttons (sortable) in the DataTable
     // The table is rendered but hidden on mobile via CSS class
     const modelButton = container.querySelector('button[type="button"]');
     expect(modelButton).toBeInTheDocument();
 
-    // Verify we have sortable headers by checking for the DataTableColumnHeader buttons
     const sortButtons = container.querySelectorAll('th button');
     expect(sortButtons.length).toBeGreaterThan(0);
   });
@@ -196,7 +191,6 @@ describe('CostsPage table enhancements', () => {
     );
 
     // Success rate badge should show 95% (in mobile card view which is visible)
-    // Also shows 83% from summary
     const badges = screen.getAllByText(/\d+%/);
     expect(badges.some(b => b.textContent === '95%')).toBe(true);
   });
@@ -208,7 +202,6 @@ describe('CostsPage table enhancements', () => {
       </MemoryRouter>
     );
 
-    // Export CSV button appears in the BY MODEL section
     const exportButton = screen.getByRole('button', { name: /export csv/i });
     expect(exportButton).toBeInTheDocument();
   });

--- a/dashboard/src/pages/__tests__/DevelopPage.test.tsx
+++ b/dashboard/src/pages/__tests__/DevelopPage.test.tsx
@@ -45,14 +45,12 @@ vi.mock('@/components/ProfileSelect', () => ({
   ),
 }));
 
-// Mock PlanImportSection
 vi.mock('@/components/PlanImportSection', () => ({
   PlanImportSection: () => <div data-testid="plan-import-section" />,
 }));
 
 const LONG_BODY = 'x'.repeat(2001);
 
-// Mock GitHubIssueCombobox
 vi.mock('@/components/GitHubIssueCombobox', () => ({
   GitHubIssueCombobox: ({
     onSelect,
@@ -86,14 +84,12 @@ vi.mock('@/components/GitHubIssueCombobox', () => ({
   ),
 }));
 
-// Mock settings API for profile tracker lookup
 vi.mock('@/api/settings', () => ({
   getProfiles: vi.fn().mockResolvedValue([
     { id: 'test', tracker: 'github', repo_root: '/tmp/repo', is_active: true },
   ]),
 }));
 
-// Mock toast
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
@@ -167,7 +163,6 @@ describe('DevelopPage', () => {
       expect(screen.getByLabelText(/description/i)).toHaveValue('Login crashes on submit');
     });
 
-    // Fields should be read-only after issue selection
     expect(screen.getByLabelText(/task id/i)).toHaveAttribute('readonly');
     expect(screen.getByLabelText(/task title/i)).toHaveAttribute('readonly');
     expect(screen.getByLabelText(/description/i)).toHaveAttribute('readonly');
@@ -186,7 +181,6 @@ describe('DevelopPage', () => {
     await user.selectOptions(screen.getByTestId('profile-select'), 'test');
     await waitFor(() => expect(screen.getByTestId('issue-combobox')).toBeInTheDocument());
 
-    // Select an issue
     await user.click(screen.getByTestId('issue-combobox'));
 
     await waitFor(() => {
@@ -194,7 +188,6 @@ describe('DevelopPage', () => {
       expect(screen.getByLabelText(/task id/i)).toHaveAttribute('readonly');
     });
 
-    // Click the clear button exposed by mock
     await user.click(screen.getByTestId('clear-issue-btn'));
 
     await waitFor(() => {
@@ -287,14 +280,12 @@ describe('DevelopPage', () => {
     await user.selectOptions(screen.getByTestId('profile-select'), 'test');
     await waitFor(() => expect(screen.getByTestId('issue-combobox-long')).toBeInTheDocument());
 
-    // Select long issue and condense
     await user.click(screen.getByTestId('issue-combobox-long'));
     await waitFor(() => expect(screen.getByRole('button', { name: /condense with ai/i })).toBeInTheDocument());
 
     await user.click(screen.getByRole('button', { name: /condense with ai/i }));
     await waitFor(() => expect(screen.getByRole('button', { name: /restore original/i })).toBeInTheDocument());
 
-    // Select a new (short) issue — restore button should disappear
     await user.click(screen.getByTestId('issue-combobox'));
 
     await waitFor(() => {

--- a/dashboard/src/pages/__tests__/KnowledgePage.test.tsx
+++ b/dashboard/src/pages/__tests__/KnowledgePage.test.tsx
@@ -9,10 +9,8 @@ import KnowledgePage from '../KnowledgePage';
 import type { KnowledgeDocument } from '@/types/knowledge';
 import { api, ApiError } from '@/api/client';
 
-// Create mock revalidate function that can be accessed in tests
 const mockRevalidate = vi.fn();
 
-// Mock React Router
 vi.mock('react-router-dom', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react-router-dom')>();
   return {
@@ -22,7 +20,6 @@ vi.mock('react-router-dom', async (importOriginal) => {
   };
 });
 
-// Mock API client
 vi.mock('@/api/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/client')>();
   return {
@@ -35,7 +32,6 @@ vi.mock('@/api/client', async (importOriginal) => {
   };
 });
 
-// Mock Toast component
 vi.mock('@/components/Toast', () => ({
   error: vi.fn(),
   success: vi.fn(),
@@ -43,7 +39,6 @@ vi.mock('@/components/Toast', () => ({
   warning: vi.fn(),
 }));
 
-// Mock logger
 vi.mock('@/lib/logger', () => ({
   logger: {
     debug: vi.fn(),
@@ -129,7 +124,6 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage(mockDocuments);
 
-    // Mock successful search
     const mockSearchResults = [
       {
         chunk_id: 'chunk-1',
@@ -148,21 +142,17 @@ describe('KnowledgePage', () => {
     await user.type(searchInput, 'hooks');
     await user.click(screen.getByRole('button', { name: /search/i }));
 
-    // Verify search result is rendered
     expect(await screen.findByText('React hooks allow you to use state in functional components.')).toBeInTheDocument();
 
-    // Verify similarity score
     expect(screen.getByText('87%')).toBeInTheDocument();
 
     // Verify heading path (using › separator for better visual hierarchy)
     expect(screen.getByText('Getting Started › Hooks')).toBeInTheDocument();
 
-    // Verify document name and tags
     expect(screen.getByText('React Docs')).toBeInTheDocument();
     expect(screen.getByText('react')).toBeInTheDocument();
     expect(screen.getByText('frontend')).toBeInTheDocument();
 
-    // Verify AbortSignal was passed
     expect(api.searchKnowledge).toHaveBeenCalledWith('hooks', 5, undefined, expect.any(AbortSignal));
   });
 
@@ -170,7 +160,6 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // Mock search with AbortError
     const abortError = new DOMException('Request aborted', 'AbortError');
     vi.mocked(api.searchKnowledge).mockRejectedValueOnce(abortError);
 
@@ -178,7 +167,6 @@ describe('KnowledgePage', () => {
     await user.type(searchInput, 'test query');
     await user.click(screen.getByRole('button', { name: /search/i }));
 
-    // Wait for search to complete
     await waitFor(() => {
       expect(api.searchKnowledge).toHaveBeenCalled();
     });
@@ -192,7 +180,6 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // Mock search with ApiError ABORTED (thrown by fetchWithTimeout)
     const abortError = new ApiError('Request aborted', 'ABORTED', 0);
     vi.mocked(api.searchKnowledge).mockRejectedValueOnce(abortError);
 
@@ -213,7 +200,6 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // Mock search failure
     vi.mocked(api.searchKnowledge).mockRejectedValueOnce(new Error('Search service unavailable'));
 
     const searchInput = screen.getByPlaceholderText('Search documentation...');
@@ -228,29 +214,23 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // Mock upload failure
     vi.mocked(api.uploadKnowledgeDocument).mockRejectedValueOnce(new Error('File too large'));
 
-    // Open upload dialog
     await user.click(screen.getByRole('button', { name: /upload/i }));
 
-    // Create a test file
     const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' });
     const fileInput = screen.getByLabelText('File');
     await user.upload(fileInput, file);
 
-    // Fill in name
     const nameInput = screen.getByLabelText('Name');
     await user.clear(nameInput);
     await user.type(nameInput, 'Test Document');
 
-    // Submit - find the dialog's upload button
     const dialogButtons = screen.getAllByRole('button');
     const uploadButton = dialogButtons.find((btn) => btn.textContent === 'Upload');
     expect(uploadButton).toBeDefined();
     await user.click(uploadButton!);
 
-    // Wait for upload to complete (button returns to "Upload" state)
     await waitFor(() => {
       const dialogButtons = screen.getAllByRole('button');
       const uploadButton = dialogButtons.find((btn) => btn.textContent === 'Upload');
@@ -264,17 +244,13 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage(mockDocuments);
 
-    // Mock delete failure
     vi.mocked(api.deleteKnowledgeDocument).mockRejectedValueOnce(new Error('Permission denied'));
 
-    // Switch to Documents tab
     await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-    // Click delete button
     const deleteButton = await screen.findByTestId('delete-document');
     await user.click(deleteButton);
 
-    // Wait for async delete to complete and verify side effects occurred
     await waitFor(() => {
       expect(Toast.error).toHaveBeenCalledWith('Permission denied');
     });
@@ -285,7 +261,6 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // Mock successful upload
     const mockUploadedDoc: KnowledgeDocument = {
       id: 'doc-new',
       name: 'Test Document',
@@ -303,33 +278,27 @@ describe('KnowledgePage', () => {
     };
     vi.mocked(api.uploadKnowledgeDocument).mockResolvedValueOnce(mockUploadedDoc);
 
-    // Open upload dialog
     await user.click(screen.getByRole('button', { name: /upload/i }));
     expect(screen.getByRole('heading', { name: 'Upload Document' })).toBeInTheDocument();
 
-    // Create a test file
     const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' });
     const fileInput = screen.getByLabelText('File');
     await user.upload(fileInput, file);
 
-    // Fill in name
     const nameInput = screen.getByLabelText('Name');
     await user.clear(nameInput);
     await user.type(nameInput, 'Test Document');
 
-    // Submit - find the dialog's upload button
     const dialogButtons = screen.getAllByRole('button');
     const uploadButton = dialogButtons.find((btn) => btn.textContent === 'Upload');
     expect(uploadButton).toBeDefined();
     await user.click(uploadButton!);
 
-    // Wait for upload to complete and verify dialog closed
     await waitFor(() => {
       expect(api.uploadKnowledgeDocument).toHaveBeenCalledWith(file, 'Test Document', []);
       expect(screen.queryByRole('heading', { name: 'Upload Document' })).not.toBeInTheDocument();
     });
 
-    // Verify revalidation was called
     expect(mockRevalidate).toHaveBeenCalled();
   });
 
@@ -337,17 +306,13 @@ describe('KnowledgePage', () => {
     const user = userEvent.setup();
     renderPage(mockDocuments);
 
-    // Mock successful delete
     vi.mocked(api.deleteKnowledgeDocument).mockResolvedValueOnce(undefined);
 
-    // Switch to Documents tab
     await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-    // Click delete button
     const deleteButton = await screen.findByTestId('delete-document');
     await user.click(deleteButton);
 
-    // Wait for delete to complete and verify revalidation was called
     await waitFor(() => {
       expect(api.deleteKnowledgeDocument).toHaveBeenCalledWith('doc-1');
       expect(mockRevalidate).toHaveBeenCalled();
@@ -364,11 +329,9 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([pendingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
       expect(await screen.findByText('Pending')).toBeInTheDocument();
 
-      // Simulate WebSocket event for ingestion started
       act(() => {
         const event = new CustomEvent('workflow-event', {
           detail: {
@@ -381,7 +344,6 @@ describe('KnowledgePage', () => {
         window.dispatchEvent(event);
       });
 
-      // Verify status updated to processing
       expect(await screen.findByText('Processing')).toBeInTheDocument();
       expect(screen.queryByText('Pending')).not.toBeInTheDocument();
     });
@@ -397,11 +359,9 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([processingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
       expect(await screen.findByText('Processing')).toBeInTheDocument();
 
-      // Simulate WebSocket event for ingestion completed
       act(() => {
         const event = new CustomEvent('workflow-event', {
           detail: {
@@ -419,7 +379,6 @@ describe('KnowledgePage', () => {
         window.dispatchEvent(event);
       });
 
-      // Verify status updated to ready
       expect(await screen.findByText('Ready')).toBeInTheDocument();
       expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
@@ -433,11 +392,9 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([processingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
       expect(await screen.findByText('Processing')).toBeInTheDocument();
 
-      // Simulate WebSocket event for ingestion failed
       act(() => {
         const event = new CustomEvent('workflow-event', {
           detail: {
@@ -454,7 +411,6 @@ describe('KnowledgePage', () => {
         window.dispatchEvent(event);
       });
 
-      // Verify status updated to failed
       expect(await screen.findByText('Failed')).toBeInTheDocument();
       expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
@@ -468,7 +424,6 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([pendingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
       expect(await screen.findByText('Pending')).toBeInTheDocument();
 
@@ -485,7 +440,6 @@ describe('KnowledgePage', () => {
         window.dispatchEvent(event);
       });
 
-      // Wait a bit to ensure no update happened
       await waitFor(
         () => {
           expect(screen.getByText('Pending')).toBeInTheDocument();
@@ -502,14 +456,11 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([processingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Verify Processing badge with spinner
       const processingBadge = await screen.findByText('Processing');
       expect(processingBadge).toBeInTheDocument();
 
-      // Verify spinner is present (has animate-spin class)
       const spinner = processingBadge.parentElement?.querySelector('.animate-spin');
       expect(spinner).toBeInTheDocument();
     });
@@ -520,10 +471,8 @@ describe('KnowledgePage', () => {
       const user = userEvent.setup();
       renderPage(mockDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Verify expand button is present
       const expandButton = await screen.findByLabelText('Expand row');
       expect(expandButton).toBeInTheDocument();
       expect(expandButton).toBeEnabled();
@@ -537,10 +486,8 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([processingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Verify expand button is disabled
       const expandButton = await screen.findByLabelText('Expand row');
       expect(expandButton).toBeDisabled();
       expect(expandButton).toHaveAttribute('title', 'Processing...');
@@ -555,10 +502,8 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([failedDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Verify expand button is disabled
       const expandButton = await screen.findByLabelText('Expand row');
       expect(expandButton).toBeDisabled();
     });
@@ -567,14 +512,11 @@ describe('KnowledgePage', () => {
       const user = userEvent.setup();
       renderPage(mockDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Click expand button
       const expandButton = await screen.findByLabelText('Expand row');
       await user.click(expandButton);
 
-      // Verify preview is shown
       expect(await screen.findByText(/React is a JavaScript library/)).toBeInTheDocument();
     });
 
@@ -582,21 +524,16 @@ describe('KnowledgePage', () => {
       const user = userEvent.setup();
       renderPage(mockDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Expand row
       const expandButton = await screen.findByLabelText('Expand row');
       await user.click(expandButton);
 
-      // Verify preview is shown
       expect(await screen.findByText(/React is a JavaScript library/)).toBeInTheDocument();
 
-      // Collapse row
       const collapseButton = await screen.findByLabelText('Collapse row');
       await user.click(collapseButton);
 
-      // Verify preview is hidden
       await waitFor(() => {
         expect(screen.queryByText(/React is a JavaScript library/)).not.toBeInTheDocument();
       });
@@ -610,14 +547,11 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([docWithoutPreview]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Expand row
       const expandButton = await screen.findByLabelText('Expand row');
       await user.click(expandButton);
 
-      // Verify "No preview available" message
       expect(await screen.findByText('No preview available')).toBeInTheDocument();
     });
 
@@ -629,14 +563,11 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([docWithEmptyText]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Expand row
       const expandButton = await screen.findByLabelText('Expand row');
       await user.click(expandButton);
 
-      // Verify "No preview available" message
       expect(await screen.findByText('No preview available')).toBeInTheDocument();
     });
 
@@ -648,7 +579,6 @@ describe('KnowledgePage', () => {
       } as KnowledgeDocument;
       renderPage([processingDoc]);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
       // Note: expand button should be disabled for processing docs
@@ -662,7 +592,6 @@ describe('KnowledgePage', () => {
       const user = userEvent.setup();
       renderPage(mockDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
       // Click expand button (using e.stopPropagation internally)
@@ -691,20 +620,15 @@ describe('KnowledgePage', () => {
       ] as KnowledgeDocument[];
       renderPage(multipleDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Expand first row
       const expandButtons = await screen.findAllByLabelText('Expand row');
       await user.click(expandButtons[0]!); // Safe: findAllByLabelText ensures elements exist
 
-      // Verify first preview is shown
       expect(await screen.findByText(/React is a JavaScript library/)).toBeInTheDocument();
 
-      // Expand second row
       await user.click(expandButtons[1]!); // Safe: findAllByLabelText ensures elements exist
 
-      // Verify both previews are shown
       expect(screen.getByText(/React is a JavaScript library/)).toBeInTheDocument();
       expect(screen.getByText(/Vue is a progressive framework/)).toBeInTheDocument();
     });
@@ -713,27 +637,20 @@ describe('KnowledgePage', () => {
       const user = userEvent.setup();
       renderPage(mockDocuments);
 
-      // Switch to Documents tab
       await user.click(screen.getByRole('tab', { name: /documents/i }));
 
-      // Get expand button and chevron
       const expandButton = await screen.findByLabelText('Expand row');
       const chevron = expandButton.querySelector('svg');
 
-      // Verify chevron doesn't have rotate-90 class initially
       expect(chevron).not.toHaveClass('rotate-90');
 
-      // Expand row
       await user.click(expandButton);
 
-      // Verify chevron has rotate-90 class
       expect(chevron).toHaveClass('rotate-90');
 
-      // Collapse row
       const collapseButton = await screen.findByLabelText('Collapse row');
       await user.click(collapseButton);
 
-      // Verify chevron no longer has rotate-90 class
       const chevronAfterCollapse = collapseButton.querySelector('svg');
       expect(chevronAfterCollapse).not.toHaveClass('rotate-90');
     });

--- a/dashboard/src/pages/__tests__/LogsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/LogsPage.test.tsx
@@ -30,12 +30,10 @@ vi.mock('@tanstack/react-virtual', () => ({
   },
 }));
 
-// Helper to wrap component with Router
 const renderWithRouter = (ui: React.ReactElement) => {
   return render(<BrowserRouter>{ui}</BrowserRouter>);
 };
 
-// Helper to create mock debug-level trace events (WorkflowEvent with level: 'debug')
 const createTraceEvent = (
   eventType: EventType,
   overrides?: Partial<WorkflowEvent>
@@ -55,7 +53,6 @@ const createTraceEvent = (
 
 describe('LogsPage', () => {
   beforeEach(() => {
-    // Reset store before each test
     useWorkflowStore.setState({
       eventsByWorkflow: {},
       eventIdsByWorkflow: {},
@@ -124,11 +121,9 @@ describe('LogsPage', () => {
     });
     renderWithRouter(<LogsPage />);
 
-    // Find and click filter dropdown
     const filterSelect = screen.getByDisplayValue(/all events/i);
     fireEvent.change(filterSelect, { target: { value: 'claude_thinking' } });
 
-    // Should only show thinking event content (not the dropdown option)
     expect(screen.getByText(/thinking event content/i)).toBeInTheDocument();
     expect(screen.queryByText(/agent output content/i)).not.toBeInTheDocument();
     expect(screen.getByText(/1 event/i)).toBeInTheDocument();
@@ -145,11 +140,9 @@ describe('LogsPage', () => {
 
     expect(screen.getByText(/1 event/i)).toBeInTheDocument();
 
-    // Click clear button
     const clearButton = screen.getByRole('button', { name: /clear/i });
     fireEvent.click(clearButton);
 
-    // Should now show empty state
     expect(screen.getByText(/no trace events yet/i)).toBeInTheDocument();
   });
 
@@ -206,7 +199,6 @@ describe('LogsPage', () => {
     });
     renderWithRouter(<LogsPage />);
 
-    // Formatted time should be HH:MM:SS (8 chars from the ISO string)
     expect(screen.getByText(/10:30:45/)).toBeInTheDocument();
   });
 
@@ -244,7 +236,6 @@ describe('LogsPage', () => {
     });
     const { container } = renderWithRouter(<LogsPage />);
 
-    // Verify each event type is rendered with stable data-event-type attribute
     expect(container.querySelector('[data-event-type="claude_thinking"]')).toBeInTheDocument();
     expect(container.querySelector('[data-event-type="claude_tool_call"]')).toBeInTheDocument();
     expect(container.querySelector('[data-event-type="claude_tool_result"]')).toBeInTheDocument();
@@ -282,7 +273,6 @@ describe('LogsPage', () => {
     });
     renderWithRouter(<LogsPage />);
 
-    // Should only show debug trace event types, not info or non-trace debug
     expect(screen.getByText(/thinking event/i)).toBeInTheDocument();
     expect(screen.queryByText(/info level event/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/debug level event/i)).not.toBeInTheDocument();
@@ -303,14 +293,12 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify h2 element is rendered within the prose container (markdown content)
       // The page also has an h2 for "Logs" in the header, so we need to be specific
       const proseContainer = container.querySelector('.prose');
       expect(proseContainer).toBeInTheDocument();
       const heading = proseContainer?.querySelector('h2');
       expect(heading).toBeInTheDocument();
       expect(heading).toHaveTextContent('Header Level 2');
-      // Ensure the raw markdown syntax is not visible
       expect(screen.queryByText(/^## Header/)).not.toBeInTheDocument();
     });
 
@@ -327,17 +315,14 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify strong element for bold
       const strongElement = container.querySelector('strong');
       expect(strongElement).toBeInTheDocument();
       expect(strongElement).toHaveTextContent('bold text');
 
-      // Verify code element for inline code
       const codeElement = container.querySelector('code');
       expect(codeElement).toBeInTheDocument();
       expect(codeElement).toHaveTextContent('inline code');
 
-      // Ensure raw markdown syntax is not visible
       expect(screen.queryByText(/\*\*bold text\*\*/)).not.toBeInTheDocument();
       expect(screen.queryByText(/`inline code`/)).not.toBeInTheDocument();
     });
@@ -355,16 +340,13 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify pre element exists for code block
       const preElement = container.querySelector('pre');
       expect(preElement).toBeInTheDocument();
 
-      // Verify code element inside pre
       const codeElement = preElement?.querySelector('code');
       expect(codeElement).toBeInTheDocument();
       expect(codeElement).toHaveTextContent('const x = 1;');
 
-      // Ensure raw backticks are not visible
       expect(screen.queryByText(/```/)).not.toBeInTheDocument();
     });
 
@@ -381,18 +363,15 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify ul element exists
       const ulElement = container.querySelector('ul');
       expect(ulElement).toBeInTheDocument();
 
-      // Verify list items
       const listItems = container.querySelectorAll('li');
       expect(listItems).toHaveLength(3);
       expect(listItems[0]).toHaveTextContent('item 1');
       expect(listItems[1]).toHaveTextContent('item 2');
       expect(listItems[2]).toHaveTextContent('item 3');
 
-      // Ensure raw markdown list syntax is not visible
       expect(screen.queryByText(/^- item/)).not.toBeInTheDocument();
     });
 
@@ -409,11 +388,9 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify ol element exists
       const olElement = container.querySelector('ol');
       expect(olElement).toBeInTheDocument();
 
-      // Verify list items
       const listItems = container.querySelectorAll('li');
       expect(listItems).toHaveLength(3);
       expect(listItems[0]).toHaveTextContent('First step');
@@ -432,13 +409,11 @@ describe('LogsPage', () => {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify anchor element exists with correct href
       const anchor = container.querySelector('a');
       expect(anchor).toBeInTheDocument();
       expect(anchor).toHaveTextContent('this link');
       expect(anchor).toHaveAttribute('href', 'https://example.com');
 
-      // Ensure raw markdown link syntax is not visible
       expect(screen.queryByText(/\[this link\]/)).not.toBeInTheDocument();
     });
 
@@ -484,17 +459,14 @@ function fix() {
       });
       const { container } = renderWithRouter(<LogsPage />);
 
-      // Verify heading within prose container (page has "Logs" h2 in header)
       const proseContainer = container.querySelector('.prose');
       expect(proseContainer).toBeInTheDocument();
       expect(proseContainer?.querySelector('h2')).toHaveTextContent('Analysis Complete');
 
-      // Verify list with bold and inline code
       expect(proseContainer?.querySelector('ul')).toBeInTheDocument();
       expect(proseContainer?.querySelectorAll('strong')).toHaveLength(2);
       expect(proseContainer?.querySelector('code:not(pre code)')).toHaveTextContent('utils.ts');
 
-      // Verify code block
       expect(proseContainer?.querySelector('pre code')).toHaveTextContent('function fix()');
     });
   });

--- a/dashboard/src/pages/__tests__/ProfileDetailPage.test.tsx
+++ b/dashboard/src/pages/__tests__/ProfileDetailPage.test.tsx
@@ -10,10 +10,8 @@ import { makeMockModelsStore } from '@/test/mocks/modelsStore';
 import { activateProfile, createProfile, updateProfile } from '@/api/settings';
 import * as toast from '@/components/Toast';
 
-// Mock the models store
 vi.mock('@/store/useModelsStore');
 
-// Mock settings API
 vi.mock('@/api/settings', () => ({
   createProfile: vi.fn(),
   updateProfile: vi.fn(),
@@ -21,13 +19,11 @@ vi.mock('@/api/settings', () => ({
   getProfile: vi.fn(),
 }));
 
-// Mock toast notifications
 vi.mock('@/components/Toast', async () => {
   const actual = await vi.importActual<typeof import('@/components/Toast')>('@/components/Toast');
   return { ...actual, error: vi.fn(), success: vi.fn() };
 });
 
-// Mock useRecentModels
 vi.mock('@/hooks/useRecentModels', () => ({
   useRecentModels: () => ({
     recentModelIds: ['claude-sonnet-4'],

--- a/dashboard/src/pages/__tests__/SettingsProfilesPage.test.tsx
+++ b/dashboard/src/pages/__tests__/SettingsProfilesPage.test.tsx
@@ -11,7 +11,6 @@ import * as toast from '../../components/Toast';
 
 const navigateSpy = vi.fn();
 
-// Mock React Router
 vi.mock('react-router-dom', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react-router-dom')>();
   return {
@@ -22,13 +21,11 @@ vi.mock('react-router-dom', async (importOriginal) => {
   };
 });
 
-// Mock the API
 vi.mock('../../api/settings', () => ({
   deleteProfile: vi.fn(),
   activateProfile: vi.fn(),
 }));
 
-// Mock toast
 vi.mock('../../components/Toast', () => ({
   success: vi.fn(),
   error: vi.fn(),
@@ -130,14 +127,11 @@ describe('SettingsProfilesPage', () => {
       </MemoryRouter>
     );
 
-    // Click the Claude filter
     const user = userEvent.setup();
     const claudeButton = screen.getByRole('radio', { name: 'Claude' });
     await user.click(claudeButton);
 
-    // dev uses claude, should be visible
     expect(screen.getByText('dev')).toBeInTheDocument();
-    // prod uses api, should be hidden after animation
     await waitFor(() => {
       expect(screen.queryByText('prod')).not.toBeInTheDocument();
     });
@@ -212,7 +206,6 @@ describe('SettingsProfilesPage', () => {
       </MemoryRouter>
     );
 
-    // Check that driver badges are rendered
     expect(await screen.findByText('claude')).toBeInTheDocument();
     expect(screen.getByText('api')).toBeInTheDocument();
   });
@@ -225,7 +218,6 @@ describe('SettingsProfilesPage', () => {
     );
 
     const cards = await screen.findAllByText(/dev|prod/);
-    // Active profile (dev) should come first
     expect(cards[0]?.textContent).toBe('dev');
   });
 });
@@ -248,7 +240,6 @@ describe('SettingsProfilesPage actions', () => {
       </MemoryRouter>
     );
 
-    // Click the always-visible star on the prod card (inactive) to activate it
     const star = screen.getByRole('button', { name: /set prod active/i });
     await user.click(star);
 
@@ -268,11 +259,9 @@ describe('SettingsProfilesPage actions', () => {
       </MemoryRouter>
     );
 
-    // Find the delete button using accessible query
     const trashButton = screen.getByRole('button', { name: /delete profile dev/i });
     await user.click(trashButton);
 
-    // Wait for the AlertDialog to appear and click the Delete button
     const deleteButton = await screen.findByRole('button', { name: 'Delete' });
     await user.click(deleteButton);
 
@@ -291,11 +280,9 @@ describe('SettingsProfilesPage actions', () => {
       </MemoryRouter>
     );
 
-    // Find the delete button using accessible query
     const trashButton = screen.getByRole('button', { name: /delete profile dev/i });
     await user.click(trashButton);
 
-    // Wait for the AlertDialog to appear and click the Cancel button
     const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
     await user.click(cancelButton);
 
@@ -312,7 +299,6 @@ describe('SettingsProfilesPage actions', () => {
       </MemoryRouter>
     );
 
-    // Click the star on the prod card (inactive) to try activating it
     const star = screen.getByRole('button', { name: /set prod active/i });
     await user.click(star);
 
@@ -331,11 +317,9 @@ describe('SettingsProfilesPage actions', () => {
       </MemoryRouter>
     );
 
-    // Find the delete button using accessible query
     const trashButton = screen.getByRole('button', { name: /delete profile dev/i });
     await user.click(trashButton);
 
-    // Wait for the AlertDialog to appear and click the Delete button
     const deleteButton = await screen.findByRole('button', { name: 'Delete' });
     await user.click(deleteButton);
 

--- a/dashboard/src/pages/__tests__/SpecBuilderPage.test.tsx
+++ b/dashboard/src/pages/__tests__/SpecBuilderPage.test.tsx
@@ -44,7 +44,6 @@ function renderPage() {
  */
 async function renderPageAndWaitForInit() {
   const result = renderPage();
-  // Wait for loadSessions to be called (which means the init effect ran)
   await waitFor(() => {
     expect(brainstormApi.listSessions).toHaveBeenCalled();
   });
@@ -189,11 +188,9 @@ describe("SpecBuilderPage", () => {
 
     const { container } = renderPage();
 
-    // Should show the message content
     await waitFor(() => {
       expect(screen.getByText(/Here is my response/)).toBeInTheDocument();
     });
-    // Should have the expandable Reasoning component
     const collapsible = container.querySelector('[data-slot="collapsible"]');
     expect(collapsible).toBeInTheDocument();
   });
@@ -241,13 +238,11 @@ describe("SpecBuilderPage", () => {
 
     renderPage();
 
-    // Click the handoff button on the artifact card
     const handoffButton = await screen.findByRole("button", {
       name: /hand off to implementation/i,
     });
     await userEvent.click(handoffButton);
 
-    // Fill in the dialog and confirm
     const titleInput = await screen.findByLabelText(/issue title/i);
     await userEvent.clear(titleInput);
     await userEvent.type(titleInput, "Implement design");
@@ -331,12 +326,10 @@ describe("SpecBuilderPage", () => {
     await userEvent.type(textarea, "Test message");
     await userEvent.keyboard("{Enter}");
 
-    // Verify message was sent
     await waitFor(() => {
       expect(brainstormApi.sendMessage).toHaveBeenCalledWith("s1", "Test message");
     });
 
-    // Verify input was cleared and focus is maintained
     await waitFor(() => {
       expect(textarea).toHaveValue("");
       expect(document.activeElement).toBe(textarea);
@@ -366,10 +359,8 @@ describe("SpecBuilderPage", () => {
     renderPage();
 
     const textarea = screen.getByPlaceholderText(/what would you like to design/i);
-    // While streaming, textarea is disabled and not focused
     expect(textarea).toBeDisabled();
 
-    // Simulate streaming ending
     act(() => {
       useBrainstormStore.setState({ isStreaming: false });
     });

--- a/dashboard/src/pages/__tests__/WorkflowsPage.test.tsx
+++ b/dashboard/src/pages/__tests__/WorkflowsPage.test.tsx
@@ -9,16 +9,13 @@ import { api } from '../../api/client';
 import { createMockWorkflowSummary, createMockWorkflowDetail } from '@/__tests__/fixtures';
 import type { WorkflowSummary, WorkflowDetail } from '../../types';
 
-// Mock the API module
 vi.mock('../../api/client');
 
-// Mock the hooks module
 vi.mock('../../hooks', () => ({
   useElapsedTime: () => '0h 00m',
   useAutoRevalidation: () => {},
 }));
 
-// Mock React Router
 vi.mock('react-router-dom', async (importOriginal) => {
   const mod = await importOriginal<typeof import('react-router-dom')>();
   return {
@@ -105,10 +102,8 @@ describe('WorkflowsPage pending workflow actions', () => {
   it('should show "queued" for pending workflows', async () => {
     renderPage([pendingWorkflow], pendingWorkflowDetail);
 
-    // Look for the "queued" text in the pending workflow controls section
     const queuedElements = await screen.findAllByText(/queued/i);
     expect(queuedElements.length).toBeGreaterThan(0);
-    // At least one should be the status text in the PendingWorkflowControls
     expect(queuedElements.some(el => el.className.includes('text-muted-foreground'))).toBe(true);
   });
 
@@ -125,7 +120,6 @@ describe('WorkflowsPage pending workflow actions', () => {
 
     renderPage([plannedWorkflow], plannedWorkflowDetail);
 
-    // Look for plan indicator
     const planIndicator = await screen.findByText(/plan ready/i);
     expect(planIndicator).toBeInTheDocument();
   });
@@ -146,7 +140,6 @@ describe('WorkflowsPage pending workflow actions', () => {
 
     renderPage([runningWorkflow], runningWorkflowDetail);
 
-    // Wait for the workflow to render
     const issueElements = await screen.findAllByText('ISSUE-123');
     expect(issueElements.length).toBeGreaterThan(0);
 

--- a/dashboard/src/store/__tests__/brainstormStore.test.ts
+++ b/dashboard/src/store/__tests__/brainstormStore.test.ts
@@ -424,13 +424,10 @@ describe("useBrainstormStore", () => {
 
       const messages = useBrainstormStore.getState().messages;
       expect(messages).toHaveLength(3);
-      // User message unchanged
       expect(messages[0]!.content).toBe("Hello");
       expect(messages[0]!.status).toBeUndefined();
-      // Streaming message got error
       expect(messages[1]!.status).toBe("error");
       expect(messages[1]!.errorMessage).toBe("Connection lost. Please retry.");
-      // Completed message unchanged
       expect(messages[2]!.content).toBe("Done earlier");
       expect(messages[2]!.status).toBeUndefined();
     });

--- a/dashboard/src/store/__tests__/useModelsStore.test.ts
+++ b/dashboard/src/store/__tests__/useModelsStore.test.ts
@@ -2,14 +2,12 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { useModelsStore } from '../useModelsStore';
 import type { ModelInfo } from '@/components/model-picker/types';
 
-// Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 describe('useModelsStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset store state
     useModelsStore.setState({
       models: [],
       providers: [],

--- a/dashboard/src/store/__tests__/workflowStore.test.ts
+++ b/dashboard/src/store/__tests__/workflowStore.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useWorkflowStore, resetBatchState } from '../workflowStore';
 import { createMockEvent } from '../../__tests__/fixtures';
 
-// Mock sessionStorage
 const sessionStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
@@ -132,14 +131,12 @@ describe('workflowStore', () => {
       useWorkflowStore.getState().addEvent(event2);
       flushEvents();
 
-      // Try to add duplicate of first event
       useWorkflowStore.getState().addEvent(event1);
       flushEvents();
 
       // lastEventId should remain evt-2, not revert to evt-1
       expect(useWorkflowStore.getState().lastEventId).toBe('evt-2');
 
-      // Verify no duplicate was added
       const events = useWorkflowStore.getState().eventsByWorkflow['wf-1'];
       expect(events).toHaveLength(2);
     });
@@ -155,7 +152,6 @@ describe('workflowStore', () => {
       // Create distinct object with same id (simulates JSON deserialization)
       const event2 = { ...event1, message: 'Cloned event' };
 
-      // Verify they are different object references
       expect(event1).not.toBe(event2);
       expect(event1.id).toBe(event2.id);
 
@@ -255,7 +251,6 @@ describe('workflowStore', () => {
 
   describe('persistence', () => {
     it('should persist lastEventId but NOT events', () => {
-      // Add an event to update lastEventId
       useWorkflowStore.getState().addEvent(
         createMockEvent({
           id: 'evt-999',
@@ -269,7 +264,6 @@ describe('workflowStore', () => {
       expect(stored).not.toBeNull();
       const parsed = JSON.parse(stored!);
 
-      // Should persist lastEventId
       expect(parsed.state.lastEventId).toBe('evt-999');
 
       // Should NOT persist events
@@ -299,10 +293,8 @@ describe('workflowStore', () => {
       const stateBeforeFlush = useWorkflowStore.getState();
       expect(stateBeforeFlush.eventsByWorkflow['wf-1'] ?? []).toHaveLength(0);
 
-      // Flush the batch
       vi.advanceTimersByTime(100);
 
-      // After flush, all events should be in store
       const stateAfterFlush = useWorkflowStore.getState();
       expect(stateAfterFlush.eventsByWorkflow['wf-1']).toHaveLength(40);
     });
@@ -335,10 +327,8 @@ describe('workflowStore', () => {
       const MAX_WORKFLOWS = 100;
       const store = useWorkflowStore.getState();
 
-      // Add events for 101 workflows with increasing timestamps
       // Using ISO format that sorts correctly: 2026-01-01T00:00:00Z, etc.
       for (let i = 0; i <= MAX_WORKFLOWS; i++) {
-        // Generate unique, sortable timestamps
         const day = String(Math.floor(i / 24) + 1).padStart(2, '0');
         const hour = String(i % 24).padStart(2, '0');
         store.addEvent({
@@ -357,13 +347,11 @@ describe('workflowStore', () => {
       const state = useWorkflowStore.getState();
       const workflowIds = Object.keys(state.eventsByWorkflow);
 
-      // Should have evicted the oldest workflow (wf-0)
       expect(workflowIds).toHaveLength(MAX_WORKFLOWS);
       expect(workflowIds).not.toContain('wf-0');
       expect(workflowIds).toContain('wf-1');
       expect(workflowIds).toContain(`wf-${MAX_WORKFLOWS}`);
 
-      // Timestamp tracking should also be cleaned up
       expect(state.lastEventTimestampByWorkflow['wf-0']).toBeUndefined();
       expect(state.eventIdsByWorkflow['wf-0']).toBeUndefined();
     });
@@ -395,7 +383,6 @@ describe('workflowStore', () => {
       flushEvents();
 
       const state = useWorkflowStore.getState();
-      // Should have the latest timestamp
       expect(state.lastEventTimestampByWorkflow['wf-1']).toBe('2026-01-01T11:00:00Z');
     });
   });

--- a/dashboard/src/store/brainstormStore.ts
+++ b/dashboard/src/store/brainstormStore.ts
@@ -8,22 +8,18 @@ import type {
 } from "@/types/api";
 
 interface BrainstormState {
-  // Session management
   sessions: BrainstormingSession[];
   activeSessionId: string | null;
   activeProfile: ProfileInfo | null;
   sessionUsage: SessionUsageSummary | null;
 
-  // Current conversation
   messages: BrainstormMessage[];
   artifacts: BrainstormArtifact[];
 
-  // UI state
   isStreaming: boolean;
   streamingMessageId: string | null;
   drawerOpen: boolean;
 
-  // Session actions
   setSessions: (sessions: BrainstormingSession[]) => void;
   addSession: (session: BrainstormingSession) => void;
   updateSession: (
@@ -35,7 +31,6 @@ interface BrainstormState {
   setActiveProfile: (profile: ProfileInfo | null) => void;
   setSessionUsage: (usage: SessionUsageSummary | null) => void;
 
-  // Message actions
   setMessages: (messages: BrainstormMessage[]) => void;
   addMessage: (message: BrainstormMessage) => void;
   removeMessage: (messageId: string) => void;
@@ -49,20 +44,16 @@ interface BrainstormState {
   clearStaleStreaming: () => void;
   clearMessages: () => void;
 
-  // Artifact actions
   setArtifacts: (artifacts: BrainstormArtifact[]) => void;
   addArtifact: (artifact: BrainstormArtifact) => void;
 
-  // UI actions
   setStreaming: (streaming: boolean, messageId: string | null) => void;
   setDrawerOpen: (open: boolean) => void;
 
-  // WebSocket actions
   handleWebSocketDisconnect: () => void;
 }
 
 export const useBrainstormStore = create<BrainstormState>()((set) => ({
-  // Initial state
   sessions: [],
   activeSessionId: null,
   activeProfile: null,
@@ -73,7 +64,6 @@ export const useBrainstormStore = create<BrainstormState>()((set) => ({
   streamingMessageId: null,
   drawerOpen: false,
 
-  // Session actions
   setSessions: (sessions) => set({ sessions }),
 
   addSession: (session) =>
@@ -99,7 +89,6 @@ export const useBrainstormStore = create<BrainstormState>()((set) => ({
 
   setSessionUsage: (usage) => set({ sessionUsage: usage }),
 
-  // Message actions
   setMessages: (messages) => set({ messages }),
 
   addMessage: (message) =>
@@ -149,7 +138,6 @@ export const useBrainstormStore = create<BrainstormState>()((set) => ({
 
   clearMessages: () => set({ messages: [], artifacts: [] }),
 
-  // Artifact actions
   setArtifacts: (artifacts) => set({ artifacts }),
 
   addArtifact: (artifact) =>
@@ -159,13 +147,11 @@ export const useBrainstormStore = create<BrainstormState>()((set) => ({
         : [...state.artifacts, artifact],
     })),
 
-  // UI actions
   setStreaming: (streaming, messageId) =>
     set({ isStreaming: streaming, streamingMessageId: messageId }),
 
   setDrawerOpen: (open) => set({ drawerOpen: open }),
 
-  // WebSocket actions
   handleWebSocketDisconnect: () =>
     set((state) => {
       if (!state.streamingMessageId) {

--- a/dashboard/src/store/useModelsStore.ts
+++ b/dashboard/src/store/useModelsStore.ts
@@ -67,7 +67,6 @@ export const useModelsStore = create<ModelsState>((set, get) => ({
   timeoutId: undefined,
 
   fetchModels: async () => {
-    // Skip if already fetched this session
     if (get().models.length > 0 && get().lastFetched) {
       return;
     }
@@ -76,7 +75,6 @@ export const useModelsStore = create<ModelsState>((set, get) => ({
   },
 
   refreshModels: async () => {
-    // Cancel any pending request
     const currentController = get().abortController;
     const currentTimeoutId = get().timeoutId;
     if (currentController) {
@@ -86,10 +84,8 @@ export const useModelsStore = create<ModelsState>((set, get) => ({
       clearTimeout(currentTimeoutId);
     }
 
-    // Create new AbortController for this request
     const abortController = new AbortController();
 
-    // Set timeout to abort request after 30 seconds
     const timeoutId = setTimeout(() => {
       abortController.abort(new TimeoutError());
     }, 30000);

--- a/dashboard/src/store/workflowStore.ts
+++ b/dashboard/src/store/workflowStore.ts
@@ -179,13 +179,11 @@ function applyEventBatch(
     const existing = newEventsByWorkflow[workflowId] ?? [];
     const updated = [...existing, event];
 
-    // Trim oldest events if exceeding limit (keep most recent)
     const needsTrim = updated.length > MAX_EVENTS_PER_WORKFLOW;
     const trimmed = needsTrim
       ? updated.slice(-MAX_EVENTS_PER_WORKFLOW)
       : updated;
 
-    // Rebuild Set if trimmed (to remove old IDs), otherwise clone and add
     const newIds = needsTrim
       ? new Set(trimmed.map((e) => e.id))
       : new Set(existingIds).add(event.id);
@@ -196,17 +194,14 @@ function applyEventBatch(
     lastEventId = event.id;
   }
 
-  // Evict oldest workflows if exceeding MAX_WORKFLOWS
   const workflowIds = Object.keys(newEventsByWorkflow);
   if (workflowIds.length > MAX_WORKFLOWS) {
-    // Sort by last event timestamp (oldest first)
     const sortedByAge = workflowIds.sort((a, b) => {
       const tsA = newLastEventTimestamp[a] ?? '';
       const tsB = newLastEventTimestamp[b] ?? '';
       return tsA.localeCompare(tsB);
     });
 
-    // Evict oldest workflows until we're at the limit
     const toEvict = sortedByAge.slice(0, workflowIds.length - MAX_WORKFLOWS);
     for (const id of toEvict) {
       delete newEventsByWorkflow[id];
@@ -319,7 +314,6 @@ export const useWorkflowStore = create<WorkflowState>()(
       addEvent: (event) => {
         pendingEvents.push(event);
 
-        // Flush immediately if batch is full
         if (pendingEvents.length >= BATCH_SIZE_LIMIT) {
           flushPendingEvents();
         } else {
@@ -337,7 +331,6 @@ export const useWorkflowStore = create<WorkflowState>()(
 
       addPendingAction: (actionId) =>
         set((state) => {
-          // Don't add duplicates
           if (state.pendingActions.includes(actionId)) {
             return state;
           }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -4,14 +4,9 @@
  * Keep in sync with amelia/server/models/*.py
  */
 
-// Re-export all types from Plan 08 Task 8
 export * from './index';
 
 import type { WorkflowSummary, WorkflowDetail } from './index';
-
-// ============================================================================
-// React Router Loader Data Types
-// ============================================================================
 
 /**
  * Data returned by the workflows list route loader.
@@ -51,10 +46,6 @@ export interface WorkflowDetailLoaderData {
   workflow: WorkflowDetail;
 }
 
-// ============================================================================
-// React Router Action Result Types
-// ============================================================================
-
 /**
  * Result object returned by React Router actions (approve, reject, cancel).
  * Indicates whether the action succeeded and which action was performed.
@@ -89,10 +80,6 @@ export interface ActionResult {
   /** Error message if the action failed, otherwise undefined. */
   error?: string;
 }
-
-// ============================================================================
-// Brainstorming Types
-// ============================================================================
 
 /** Token usage for a single message. */
 export interface MessageUsage {

--- a/dashboard/src/utils/__tests__/workflow.test.ts
+++ b/dashboard/src/utils/__tests__/workflow.test.ts
@@ -75,7 +75,6 @@ describe('getActiveWorkflow', () => {
   });
 
   it('should work correctly regardless of array order', () => {
-    // Test with completed workflows listed first (like in the bug scenario)
     const workflows = [
       createMockWorkflowSummary({ id: 'completed-1', status: 'completed', started_at: '2025-01-01T10:00:00Z' }),
       createMockWorkflowSummary({ id: 'completed-2', status: 'completed', started_at: '2025-01-01T12:00:00Z' }),
@@ -83,14 +82,9 @@ describe('getActiveWorkflow', () => {
       createMockWorkflowSummary({ id: 'running-newest', status: 'in_progress', started_at: '2025-01-01T01:00:00Z' }),
       createMockWorkflowSummary({ id: 'blocked', status: 'blocked', started_at: '2025-01-01T02:00:00Z' }),
     ];
-    // Should select the most recent running workflow (running-oldest), not the first in array
     expect(getActiveWorkflow(workflows)?.id).toBe('running-oldest');
   });
 });
-
-// ============================================================================
-// Formatting Functions
-// ============================================================================
 
 describe('formatTokens', () => {
   it.each([

--- a/dashboard/src/utils/format.ts
+++ b/dashboard/src/utils/format.ts
@@ -10,7 +10,6 @@ const UUID_PATTERN = /^(.+?)-([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]
  * "brainstorm-12d73bed-8687-49b2-b761-099bb70eaa01" -> "brainstorm-12d73bed...a01".
  */
 export function truncateWorkflowId(id: string, maxPrefixLength = 20): string {
-  // Short IDs don't need truncation
   if (id.length <= 30) {
     return id;
   }
@@ -28,7 +27,6 @@ export function truncateWorkflowId(id: string, maxPrefixLength = 20): string {
       ? prefix.slice(0, safePrefixLength - 1) + '…'
       : prefix;
 
-    // Last 3 chars of the full UUID
     const lastChars = uuidLastSegment.slice(-3);
 
     return `${displayPrefix}-${uuidFirstSegment}...${lastChars}`;

--- a/dashboard/src/utils/workflow.ts
+++ b/dashboard/src/utils/workflow.ts
@@ -3,10 +3,6 @@
  */
 import type { WorkflowSummary, WorkflowDetail } from '@/types';
 
-// ============================================================================
-// Token & Cost Formatting
-// ============================================================================
-
 /**
  * Formats a token count in a compact format with K suffix for thousands.
  * Examples: 500 -> "500", 1500 -> "1.5K", 15200 -> "15.2K"
@@ -19,7 +15,6 @@ export function formatTokens(tokens: number): string {
     return tokens.toString();
   }
   const value = tokens / 1000;
-  // Use at most 1 decimal place, remove trailing zeros
   return `${parseFloat(value.toFixed(1))}K`;
 }
 
@@ -81,13 +76,11 @@ function sortByStartTimeDesc(a: WorkflowSummary, b: WorkflowSummary): number {
  * @returns The active workflow or null if none exist
  */
 export function getActiveWorkflow(workflows: WorkflowSummary[]): WorkflowSummary | null {
-  // Priority 1: Most recently started running workflow
   const running = workflows
     .filter(w => w.status === 'in_progress')
     .sort(sortByStartTimeDesc);
   if (running[0]) return running[0];
 
-  // Priority 2: Most recently started blocked workflow
   const blocked = workflows
     .filter(w => w.status === 'blocked')
     .sort(sortByStartTimeDesc);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,6 @@ def mock_profile_factory(tmp_path_factory: TempPathFactory) -> Callable[..., Pro
 
     Profiles now use agents dict for per-agent driver/model configuration.
     """
-    # Create a shared temp directory for all profiles in this test session
     base_tmp = tmp_path_factory.mktemp("workdir")
 
     def _create(
@@ -248,11 +247,9 @@ def mock_profile_factory(tmp_path_factory: TempPathFactory) -> Callable[..., Pro
         agents: dict[str, AgentConfig] | None = None,
         **kwargs: Any
     ) -> Profile:
-        # Use temp directory for repo_root unless explicitly overridden
         if "repo_root" not in kwargs:
             kwargs["repo_root"] = str(base_tmp)
 
-        # Default agents configuration if not provided
         if agents is None:
             if preset == "cli_single":
                 agents = {
@@ -269,7 +266,6 @@ def mock_profile_factory(tmp_path_factory: TempPathFactory) -> Callable[..., Pro
                 }
                 return Profile(name="test_api", tracker="noop", agents=agents, **kwargs)
             else:
-                # Default: all agents use claude
                 agents = {
                     "architect": AgentConfig(driver="claude", model="sonnet"),
                     "developer": AgentConfig(driver="claude", model="sonnet"),
@@ -319,10 +315,8 @@ def mock_execution_state_factory(
         if issue is None:
             issue = mock_issue_factory()
 
-        # Extract profile_id from profile
         profile_id = kwargs.pop("profile_id", profile.name)
 
-        # Provide defaults for required BasePipelineState fields
         workflow_id = kwargs.pop("workflow_id", uuid4())
         created_at = kwargs.pop("created_at", datetime.now(UTC))
         status = kwargs.pop("status", "pending")
@@ -521,7 +515,6 @@ def langgraph_mock_factory(
             astream_items
         )
 
-        # Mock checkpointer: passed directly to OrchestratorService(checkpointer=...)
         mock_saver = AsyncMock()
         mock_saver.adelete_thread = AsyncMock()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,18 +39,9 @@ from tests.conftest import AsyncIteratorMock
 rebuild_implementation_state()
 
 
-# =============================================================================
-# Constants
-# =============================================================================
-
 # Free model for OpenRouter integration tests (incurs no costs)
 # Must support tool use - see https://openrouter.ai/models?q=:free
 OPENROUTER_FREE_MODEL = "meta-llama/llama-3.3-70b-instruct:free"
-
-
-# =============================================================================
-# Git Repository Helpers
-# =============================================================================
 
 
 def _run_git(
@@ -104,7 +95,6 @@ def init_git_repo(
     _run_git(["git", "config", "user.name", "Test"], cwd=path, env=clean_env)
     _run_git(["git", "config", "commit.gpgsign", "false"], cwd=path, env=clean_env)
 
-    # Create initial files
     files_to_create = initial_files if initial_files is not None else {"README.md": "# Test"}
     for file_path, content in files_to_create.items():
         full_path = path / file_path
@@ -115,11 +105,6 @@ def init_git_repo(
     _run_git(["git", "commit", "-m", "Initial"], cwd=path, env=clean_env)
 
     return clean_env
-
-
-# =============================================================================
-# Factory Functions (module-level, not fixtures)
-# =============================================================================
 
 
 def make_issue(
@@ -209,7 +194,6 @@ def make_execution_state(
     if profile is None:
         profile = make_profile()
 
-    # Provide defaults for required BasePipelineState fields
     workflow_id = kwargs.pop("workflow_id", uuid4())
     created_at = kwargs.pop("created_at", datetime.now(UTC))
     status = kwargs.pop("status", "pending")
@@ -337,7 +321,6 @@ def make_reviewer_agentic_messages(
     if comments is None:
         comments = ["LGTM! Good work."] if approved else ["Issue found in code."]
 
-    # Map severity to beagle format section
     severity_map = {
         "low": "Minor",
         "medium": "Minor",
@@ -348,7 +331,6 @@ def make_reviewer_agentic_messages(
     }
     section = severity_map.get(severity, "Minor")
 
-    # Build issues section if not approved
     issues_section = ""
     if not approved:
         issues_section = f"\n### {section} (Should Fix)\n\n"
@@ -358,7 +340,6 @@ def make_reviewer_agentic_messages(
             issues_section += "   - Why: Quality concern\n"
             issues_section += "   - Fix: Address the issue\n\n"
 
-    # Build verdict
     verdict = "Yes" if approved else "No"
     rationale = "All changes look good." if approved else "Issues need to be addressed."
 
@@ -390,11 +371,6 @@ Review of the code changes.
             session_id="session-review",
         ),
     ]
-
-
-# =============================================================================
-# Fixtures
-# =============================================================================
 
 
 @pytest.fixture
@@ -525,11 +501,6 @@ def orchestrator_graph() -> CompiledStateGraph[Any]:
     )
 
 
-# ---------------------------------------------------------------------------
-# Shared LangGraph planning mocks
-# ---------------------------------------------------------------------------
-
-
 def create_planning_graph_mock(
     goal: str = "Test goal from architect",
     plan_markdown: str = "## Plan\n\n### Task 1: First task\n- Do something",
@@ -548,7 +519,6 @@ def create_planning_graph_mock(
     """
     mock_graph = MagicMock()
 
-    # Mock aget_state to return checkpoint with plan data
     checkpoint_values = {
         "goal": goal,
         "plan_markdown": plan_markdown,
@@ -559,7 +529,6 @@ def create_planning_graph_mock(
     mock_checkpoint.next = []
     mock_graph.aget_state = AsyncMock(return_value=mock_checkpoint)
 
-    # Mock astream to yield chunks including interrupt
     astream_items: list[tuple[str, dict[str, Any]]] = [
         ("updates", {"architect_node": {"goal": goal, "architect_raw_output": plan_markdown}}),
     ]
@@ -569,7 +538,6 @@ def create_planning_graph_mock(
 
     mock_graph.astream = lambda *args, **kwargs: AsyncIteratorMock(astream_items)
 
-    # Mock aupdate_state for approve_workflow
     mock_graph.aupdate_state = AsyncMock()
 
     return mock_graph
@@ -613,10 +581,6 @@ async def mock_langgraph_for_planning(
     ):
         yield mock_graph
 
-
-# ---------------------------------------------------------------------------
-# Shared database & service fixtures for orchestrator integration tests
-# ---------------------------------------------------------------------------
 
 DATABASE_URL = os.environ.get(
     "DATABASE_URL",
@@ -754,11 +718,6 @@ async def active_test_profile(
     return profile
 
 
-# ---------------------------------------------------------------------------
-# Shared orchestrator test client fixture
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 async def orchestrator_test_client(
     test_orchestrator: OrchestratorService,
@@ -786,11 +745,6 @@ async def orchestrator_test_client(
         base_url="http://testserver",
     ) as client:
         yield client
-
-
-# ---------------------------------------------------------------------------
-# Shared create_test_workflow helper
-# ---------------------------------------------------------------------------
 
 
 async def create_test_workflow(
@@ -827,11 +781,6 @@ async def create_test_workflow(
     )
     await repository.create(workflow)
     return workflow
-
-
-# ---------------------------------------------------------------------------
-# Shared mock_api_key fixture
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/tests/integration/server/conftest.py
+++ b/tests/integration/server/conftest.py
@@ -118,11 +118,6 @@ def _create_app_with_overrides(
     return app
 
 
-# =============================================================================
-# Shared brainstorm test helpers
-# =============================================================================
-
-
 def create_realistic_driver_messages(
     *,
     thinking_content: str = "Let me analyze this request...",

--- a/tests/integration/server/test_brainstorm_dependency_wiring.py
+++ b/tests/integration/server/test_brainstorm_dependency_wiring.py
@@ -43,11 +43,6 @@ DATABASE_URL = os.environ.get(
 )
 
 
-# =============================================================================
-# Static Wiring Tests
-# =============================================================================
-
-
 @pytest.mark.integration
 class TestBrainstormDependencyWiring:
     """Verify that create_app() wires all brainstorm dependencies."""
@@ -104,11 +99,6 @@ class TestBrainstormDependencyWiring:
             f"Missing brainstorm dependencies in create_app(): {missing}. "
             "Ensure all dependencies are wired in main.py."
         )
-
-
-# =============================================================================
-# Dynamic Wiring Tests
-# =============================================================================
 
 
 @pytest.mark.integration
@@ -403,11 +393,6 @@ class TestBrainstormDependencyResolution:
                 f"Expected 202 but got {msg_resp.status_code}. "
                 f"Response: {msg_resp.json()}"
             )
-
-
-# =============================================================================
-# Driver Cleanup Wiring Tests
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/server/test_brainstorm_integration.py
+++ b/tests/integration/server/test_brainstorm_integration.py
@@ -28,11 +28,6 @@ from amelia.server.services.brainstorm import BrainstormService
 from .conftest import AsyncClientFactory, noop_lifespan
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 async def test_client(
     test_brainstorm_service: BrainstormService,
@@ -59,11 +54,6 @@ async def test_client(
 
     async with async_client_factory(app) as client:
         yield client
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/server/test_brainstorm_message_flow.py
+++ b/tests/integration/server/test_brainstorm_message_flow.py
@@ -50,11 +50,6 @@ async def test_client(
         yield client
 
 
-# =============================================================================
-# Test Classes
-# =============================================================================
-
-
 @pytest.mark.integration
 class TestBrainstormMessageFlow:
     """Test full message flow from HTTP request to persistence."""

--- a/tests/integration/server/test_brainstorm_sequence.py
+++ b/tests/integration/server/test_brainstorm_sequence.py
@@ -30,11 +30,6 @@ from tests.conftest import create_mock_execute_agentic
 from .conftest import AsyncClientFactory, _create_app_with_overrides
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 def create_simple_driver_response(
     response_content: str,
     session_id: str = "driver-session",
@@ -85,11 +80,6 @@ async def test_client(
 
     async with async_client_factory(app) as client:
         yield client
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/server/test_brainstorm_usage.py
+++ b/tests/integration/server/test_brainstorm_usage.py
@@ -36,11 +36,6 @@ from tests.conftest import create_mock_execute_agentic
 from .conftest import _create_app_with_overrides
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 def create_mock_driver_with_usage(
     messages: list[AgenticMessage],
     usage: DriverUsage | None,
@@ -58,11 +53,6 @@ def create_mock_driver_with_usage(
     driver.execute_agentic = create_mock_execute_agentic(messages)
     driver.get_usage = MagicMock(return_value=usage)
     return driver
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/server/test_brainstorm_websocket.py
+++ b/tests/integration/server/test_brainstorm_websocket.py
@@ -41,11 +41,6 @@ from .conftest import (
 )
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def test_profile_repository(test_db: Database) -> ProfileRepository:
     """Create profile repository backed by test database."""
@@ -86,11 +81,6 @@ async def test_client(
         yield client
 
 
-# =============================================================================
-# Helper Functions
-# =============================================================================
-
-
 async def create_session_and_send_message(
     client: httpx.AsyncClient,
     message: str = "Test message",
@@ -122,11 +112,6 @@ async def create_session_and_send_message(
     )
 
     return session_id
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/server/test_condense_description.py
+++ b/tests/integration/server/test_condense_description.py
@@ -23,11 +23,6 @@ from tests.integration.server.conftest import noop_lifespan
 pytestmark = pytest.mark.integration
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def profile_repo(test_db: Database) -> ProfileRepository:
     """Real profile repository backed by test database."""
@@ -87,11 +82,6 @@ def _mock_driver(condensed_text: str) -> MagicMock:
     driver = MagicMock()
     driver.generate = AsyncMock(return_value=(condensed_text, "session-123"))
     return driver
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 class TestCondenseDescriptionIntegration:

--- a/tests/integration/test_external_plan_flow.py
+++ b/tests/integration/test_external_plan_flow.py
@@ -26,10 +26,6 @@ from amelia.server.database.repository import WorkflowRepository
 from tests.integration.conftest import init_git_repo
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
 # test_db, test_repository, test_profile_repository, and test_event_bus
 # fixtures are inherited from tests/integration/conftest.py
 
@@ -75,11 +71,6 @@ async def setup_test_profile(test_profile_repository: ProfileRepository) -> Prof
 def test_client(orchestrator_test_client: httpx.AsyncClient) -> httpx.AsyncClient:
     """Alias shared orchestrator_test_client fixture for local use."""
     return orchestrator_test_client
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/test_github_issue_workflow.py
+++ b/tests/integration/test_github_issue_workflow.py
@@ -32,11 +32,6 @@ from amelia.server.database.repository import WorkflowRepository
 from tests.integration.conftest import init_git_repo
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def github_worktree(tmp_path: Path) -> str:
     """Create a valid git worktree with a GitHub tracker profile.
@@ -135,11 +130,6 @@ def mock_graph(langgraph_mock_factory: Any):
     ) as mock_create_graph:
         mock_create_graph.return_value = mocks.graph
         yield mocks
-
-
-# =============================================================================
-# Tests
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/test_pr_autofix_flow.py
+++ b/tests/integration/test_pr_autofix_flow.py
@@ -42,10 +42,6 @@ from amelia.server.events.bus import EventBus
 from tests.conftest import create_mock_execute_agentic
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
 _NOW = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
 
 
@@ -140,11 +136,6 @@ def orchestrator(event_bus: EventBus) -> PRAutoFixOrchestrator:
     )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _mock_unified_driver(comment_ids: list[int]) -> MagicMock:
     """Create a mock driver for both classify (generate) and develop (execute_agentic)."""
     driver = MagicMock()
@@ -161,11 +152,6 @@ def _mock_unified_driver(comment_ids: list[int]) -> MagicMock:
     driver.get_usage = MagicMock(return_value=None)
     driver.get_tool_definitions = MagicMock(return_value=None)
     return driver
-
-
-# ---------------------------------------------------------------------------
-# Test: Full pipeline graph with real nodes
-# ---------------------------------------------------------------------------
 
 
 class TestPipelineEndToEnd:
@@ -370,11 +356,6 @@ class TestPipelineEndToEnd:
         mock_git_ops.stage_and_commit.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# Test: Orchestrator threads comments into pipeline
-# ---------------------------------------------------------------------------
-
-
 class TestOrchestratorThreadsComments:
     """Verify the orchestrator passes comments and config to the real pipeline."""
 
@@ -402,7 +383,6 @@ class TestOrchestratorThreadsComments:
         mock_github_service.reply_to_comment = AsyncMock()
         mock_github_service.resolve_thread = AsyncMock()
 
-        # Mock LocalWorktree as async context manager returning a fake path
         mock_worktree_instance = AsyncMock()
         mock_worktree_instance.__aenter__ = AsyncMock(return_value="/tmp/fake-worktree")
         mock_worktree_instance.__aexit__ = AsyncMock(return_value=None)
@@ -448,11 +428,6 @@ class TestOrchestratorThreadsComments:
         mock_git_ops.stage_and_commit.assert_called_once()
         # Replies were posted (reply_resolve ran)
         assert mock_github_service.reply_to_comment.call_count >= 1
-
-
-# ---------------------------------------------------------------------------
-# Test: Poller passes comments to orchestrator
-# ---------------------------------------------------------------------------
 
 
 class TestPollerPassesComments:
@@ -517,11 +492,6 @@ class TestPollerPassesComments:
         assert len(call_kwargs["comments"]) == 2
 
 
-# ---------------------------------------------------------------------------
-# Test: Concurrent trigger queueing + cooldown
-# ---------------------------------------------------------------------------
-
-
 class TestConcurrentTriggerQueueing:
     """Verify that concurrent trigger_fix_cycle calls queue properly."""
 
@@ -544,11 +514,9 @@ class TestConcurrentTriggerQueueing:
             github_pr_service=github_pr,
         )
 
-        # Collect emitted events
         emitted_events: list[Any] = []
         event_bus.subscribe(lambda e: emitted_events.append(e))
 
-        # Track _execute_pipeline calls
         execute_call_count = 0
         execute_started = asyncio.Event()
         execute_proceed = asyncio.Event()
@@ -561,7 +529,6 @@ class TestConcurrentTriggerQueueing:
                 await execute_proceed.wait()
             # Second call completes immediately
 
-        # Mock LocalWorktree as async context manager
         mock_worktree_instance = AsyncMock()
         mock_worktree_instance.__aenter__ = AsyncMock(return_value="/tmp/fake-worktree")
         mock_worktree_instance.__aexit__ = AsyncMock(return_value=None)
@@ -600,19 +567,12 @@ class TestConcurrentTriggerQueueing:
             execute_proceed.set()
             await task1
 
-        # PR_FIX_QUEUED should have been emitted
         queued_events = [e for e in emitted_events if e.event_type == EventType.PR_FIX_QUEUED]
         assert len(queued_events) >= 1, "PR_FIX_QUEUED event must be emitted for queued trigger"
 
-        # _execute_pipeline should have been called twice (initial + pending)
         assert execute_call_count == 2, (
             f"Expected 2 _execute_pipeline calls (initial + pending), got {execute_call_count}"
         )
-
-
-# ---------------------------------------------------------------------------
-# Test: Event emission sequence
-# ---------------------------------------------------------------------------
 
 
 class TestEventEmissionSequence:
@@ -691,7 +651,6 @@ class TestEventEmissionSequence:
                 comments=comments,
             )
 
-        # Filter lifecycle events
         started_events = [
             e for e in emitted_events if e.event_type == EventType.PR_AUTO_FIX_STARTED
         ]
@@ -702,12 +661,10 @@ class TestEventEmissionSequence:
         assert len(started_events) >= 1, "PR_AUTO_FIX_STARTED must be emitted"
         assert len(completed_events) >= 1, "PR_AUTO_FIX_COMPLETED must be emitted"
 
-        # Verify order: STARTED before COMPLETED
         started_idx = emitted_events.index(started_events[0])
         completed_idx = emitted_events.index(completed_events[0])
         assert started_idx < completed_idx, "STARTED must precede COMPLETED"
 
-        # Both must contain workflow_id in data
         assert "workflow_id" in (started_events[0].data or {}), (
             "PR_AUTO_FIX_STARTED must contain workflow_id in data"
         )
@@ -715,14 +672,8 @@ class TestEventEmissionSequence:
             "PR_AUTO_FIX_COMPLETED must contain workflow_id in data"
         )
 
-        # Both must have pr_number
         assert started_events[0].data["pr_number"] == 42
         assert completed_events[0].data["pr_number"] == 42
-
-
-# ---------------------------------------------------------------------------
-# Test: Divergence recovery -> retry -> success
-# ---------------------------------------------------------------------------
 
 
 class TestDivergenceRecovery:
@@ -786,13 +737,7 @@ class TestDivergenceRecovery:
         assert len(diverged_events) >= 1, "PR_FIX_DIVERGED must be emitted on divergence"
         assert diverged_events[0].data["attempt"] == 1
 
-        # _execute_pipeline should have been called 2 times (initial + retry)
         assert call_count == 2, f"Expected 2 calls (initial + retry), got {call_count}"
-
-
-# ---------------------------------------------------------------------------
-# Test: Multi-file-group partial failure
-# ---------------------------------------------------------------------------
 
 
 class TestMultiFileGroupPartialFailure:
@@ -837,7 +782,6 @@ class TestMultiFileGroupPartialFailure:
             ),
         ]
 
-        # Mock driver to classify both as actionable
         classification_output = ClassificationOutput(
             classifications=[
                 CommentClassification(
@@ -927,7 +871,6 @@ class TestMultiFileGroupPartialFailure:
         ):
             final_state = await graph.ainvoke(initial_state, config=config)
 
-        # Should have 2 group results
         group_results = final_state["group_results"]
         assert len(group_results) == 2, f"Expected 2 group results, got {len(group_results)}"
 
@@ -937,11 +880,6 @@ class TestMultiFileGroupPartialFailure:
 
         # Commit should still have happened for the fixed group
         mock_git_ops.stage_and_commit.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# Test: Confidence threshold filtering
-# ---------------------------------------------------------------------------
 
 
 class TestConfidenceThresholdFiltering:
@@ -1093,11 +1031,6 @@ class TestConfidenceThresholdFiltering:
         assert 301 not in all_comment_ids, "Low-confidence comment must NOT be in file_groups"
 
 
-# ---------------------------------------------------------------------------
-# Test: Aggressiveness filtering
-# ---------------------------------------------------------------------------
-
-
 class TestAggressivenessFiltering:
     """Verify aggressiveness=CRITICAL filters STYLE comments."""
 
@@ -1226,11 +1159,6 @@ class TestAggressivenessFiltering:
         mock_git_ops.stage_and_commit.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# Test: Commit message content
-# ---------------------------------------------------------------------------
-
-
 class TestCommitMessageContent:
     """Verify commit message contains prefix and addressed comments."""
 
@@ -1298,27 +1226,19 @@ class TestCommitMessageContent:
         ):
             await graph.ainvoke(initial_state, config=config)
 
-        # Capture the commit message
         mock_git_ops.stage_and_commit.assert_called_once()
         commit_msg = mock_git_ops.stage_and_commit.call_args[0][0]
 
-        # Must start with the configured prefix
         assert commit_msg.startswith("fix(review):"), (
             f"Commit message must start with 'fix(review):', got: {commit_msg[:50]}"
         )
 
-        # Must reference addressed comment content
         assert "Variable name" in commit_msg or "count" in commit_msg or "src/app.py" in commit_msg, (
             f"Commit message must reference addressed comments, got: {commit_msg}"
         )
         assert "null check" in commit_msg or "name" in commit_msg or "src/app.py" in commit_msg, (
             f"Commit message must reference addressed comments, got: {commit_msg}"
         )
-
-
-# ---------------------------------------------------------------------------
-# Test: Workflow status lifecycle
-# ---------------------------------------------------------------------------
 
 
 class TestWorkflowStatusLifecycle:
@@ -1394,24 +1314,16 @@ class TestWorkflowStatusLifecycle:
                 comments=comments,
             )
 
-        # workflow_repo.create() called once with IN_PROGRESS
         mock_workflow_repo.create.assert_called_once()
         created_state = mock_workflow_repo.create.call_args[0][0]
         assert created_state.workflow_status == WorkflowStatus.IN_PROGRESS
 
-        # workflow_repo.update() called once with COMPLETED
         mock_workflow_repo.update.assert_called_once()
         updated_state = mock_workflow_repo.update.call_args[0][0]
         assert updated_state.workflow_status == WorkflowStatus.COMPLETED
 
-        # issue_cache should contain pr_number and pr_comments
         assert updated_state.issue_cache["pr_number"] == 42
         assert "pr_comments" in updated_state.issue_cache
-
-
-# ---------------------------------------------------------------------------
-# Test: Metrics persistence
-# ---------------------------------------------------------------------------
 
 
 class TestMetricsPersistence:
@@ -1486,21 +1398,14 @@ class TestMetricsPersistence:
                 comments=comments,
             )
 
-        # save_classifications should be called with classification data
         mock_metrics_repo.save_classifications.assert_called_once()
 
-        # save_run_metrics should be called with fix counts
         mock_metrics_repo.save_run_metrics.assert_called_once()
         call_kwargs = mock_metrics_repo.save_run_metrics.call_args.kwargs
         assert call_kwargs["fixes_applied"] >= 1, (
             f"Expected fixes_applied >= 1, got {call_kwargs['fixes_applied']}"
         )
         assert call_kwargs["pr_number"] == 42
-
-
-# ---------------------------------------------------------------------------
-# Test: Poller deduplication
-# ---------------------------------------------------------------------------
 
 
 class TestPollerDeduplication:
@@ -1620,11 +1525,6 @@ class TestPollerDeduplication:
         assert mock_orchestrator.trigger_fix_cycle.call_count == 2, (
             f"Expected 2 triggers (first + third poll), got {mock_orchestrator.trigger_fix_cycle.call_count}"
         )
-
-
-# ---------------------------------------------------------------------------
-# Test: ATIF trajectory recording for fix cycles (requires PostgreSQL)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/integration/test_queue_workflow_flow.py
+++ b/tests/integration/test_queue_workflow_flow.py
@@ -36,11 +36,6 @@ from amelia.server.database.repository import WorkflowRepository
 from amelia.server.models.state import ServerExecutionState
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def test_client(orchestrator_test_client: httpx.AsyncClient) -> httpx.AsyncClient:
     """Alias shared orchestrator_test_client fixture for local use."""
@@ -92,11 +87,6 @@ async def create_pending_workflow(
     )
     await repository.create(workflow)
     return workflow
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/test_review_workflow.py
+++ b/tests/integration/test_review_workflow.py
@@ -46,10 +46,6 @@ from amelia.server.models.state import (
 from amelia.server.orchestrator.service import OrchestratorService
 
 
-# =============================================================================
-# Helpers
-# =============================================================================
-
 def _make_blocking_astream(event: asyncio.Event) -> Any:
     async def blocking_astream(*args: Any, **kwargs: Any) -> Any:
         await event.wait()
@@ -114,20 +110,10 @@ async def _create_completed_workflow(
     return state
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def test_client(orchestrator_test_client: httpx.AsyncClient) -> httpx.AsyncClient:
     """Alias shared orchestrator_test_client fixture for local use."""
     return orchestrator_test_client
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_branch.py
+++ b/tests/integration/test_workflow_branch.py
@@ -22,11 +22,6 @@ from amelia.server.orchestrator.runner import GraphRunner
 from amelia.server.orchestrator.service import OrchestratorService
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def git_mocks():
     """Patch git functions to simulate git state without touching the real tree.
@@ -81,11 +76,6 @@ def mock_graph():
         GraphRunner, "create_server_graph", return_value=mock
     ):
         yield mock
-
-
-# =============================================================================
-# Orchestrator-level tests
-# =============================================================================
 
 
 @pytest.mark.integration
@@ -329,11 +319,6 @@ class TestSandboxSkipsBranch:
         state = await test_orchestrator._repository.get(workflow_id)
         assert state is not None
         assert state.branch is None
-
-
-# =============================================================================
-# API endpoint test
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_endpoints.py
+++ b/tests/integration/test_workflow_endpoints.py
@@ -35,20 +35,10 @@ from amelia.trajectory import WorkflowTrajectoryRecorder
 from tests.integration.conftest import create_test_workflow
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def test_client(orchestrator_test_client: httpx.AsyncClient) -> httpx.AsyncClient:
     """Alias shared orchestrator_test_client fixture for local use."""
     return orchestrator_test_client
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 @pytest.mark.integration

--- a/tests/unit/agents/schemas/test_classifier_schema.py
+++ b/tests/unit/agents/schemas/test_classifier_schema.py
@@ -13,11 +13,6 @@ from amelia.agents.schemas.classifier import (
 from amelia.core.types import AggressivenessLevel, PRAutoFixConfig
 
 
-# ---------------------------------------------------------------------------
-# CommentCategory enum
-# ---------------------------------------------------------------------------
-
-
 class TestCommentCategory:
     """CommentCategory is a StrEnum with 6 values."""
 
@@ -34,12 +29,6 @@ class TestCommentCategory:
 
     def test_is_str_subclass(self) -> None:
         assert isinstance(CommentCategory.BUG, str)
-
-
-
-# ---------------------------------------------------------------------------
-# CommentClassification model
-# ---------------------------------------------------------------------------
 
 
 class TestCommentClassification:
@@ -93,11 +82,6 @@ class TestCommentClassification:
         assert c.confidence == value
 
 
-# ---------------------------------------------------------------------------
-# ClassificationOutput
-# ---------------------------------------------------------------------------
-
-
 class TestClassificationOutput:
     """ClassificationOutput wraps a list of CommentClassification."""
 
@@ -118,11 +102,6 @@ class TestClassificationOutput:
         ]
         out = ClassificationOutput(classifications=items)
         assert len(out.classifications) == 3
-
-
-# ---------------------------------------------------------------------------
-# CATEGORY_THRESHOLD mapping
-# ---------------------------------------------------------------------------
 
 
 class TestCategoryThreshold:
@@ -149,11 +128,6 @@ class TestCategoryThreshold:
     def test_all_categories_mapped(self) -> None:
         for cat in CommentCategory:
             assert cat in CATEGORY_THRESHOLD
-
-
-# ---------------------------------------------------------------------------
-# is_actionable helper
-# ---------------------------------------------------------------------------
 
 
 class TestIsActionable:
@@ -227,11 +201,6 @@ class TestIsActionable:
             CommentCategory.SUGGESTION,
             CommentCategory.QUESTION,
         }
-
-
-# ---------------------------------------------------------------------------
-# PRAutoFixConfig.confidence_threshold
-# ---------------------------------------------------------------------------
 
 
 class TestPRAutoFixConfigConfidenceThreshold:

--- a/tests/unit/agents/test_reviewer.py
+++ b/tests/unit/agents/test_reviewer.py
@@ -79,8 +79,6 @@ class TestAgenticReview:
         """
         source = inspect.getsource(Reviewer.agentic_review)
 
-        # Driver types that should NOT be checked via isinstance
-        # Check for common isinstance patterns with these driver types
         forbidden_patterns = [
             "isinstance(self.driver, ClaudeCliDriver)",
             "isinstance(self.driver, ApiDriver)",
@@ -105,7 +103,6 @@ class TestAgenticReview:
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage stream with beagle markdown format
         beagle_review_output = """## Review Summary
 
 Code looks good overall.
@@ -159,11 +156,10 @@ Rationale: No issues found, code is ready to merge.
         )
 
         assert result.approved is True
-        assert len(result.comments) == 0  # No issues found
+        assert len(result.comments) == 0
         assert result.severity == Severity.NONE
         assert session_id == "session-789"
 
-        # Verify execute_agentic was called
         mock_driver.execute_agentic.assert_called_once()
 
     async def test_agentic_review_emits_workflow_events(
@@ -178,7 +174,6 @@ Rationale: No issues found, code is ready to merge.
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage stream with various message types
         messages = [
             AgenticMessage(
                 type=AgenticMessageType.THINKING,
@@ -214,7 +209,6 @@ Rationale: No issues found, code is ready to merge.
         # At minimum 3 events during stream + 1 final output event
         assert mock_event_bus.emit.call_count >= 3
 
-        # Verify event types were properly mapped
         event_types = [call.args[0].event_type for call in mock_event_bus.emit.call_args_list]
         assert EventType.CLAUDE_THINKING in event_types
         assert EventType.CLAUDE_TOOL_CALL in event_types
@@ -230,7 +224,6 @@ Rationale: No issues found, code is ready to merge.
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage stream with error result
         messages = [
             AgenticMessage(
                 type=AgenticMessageType.THINKING,
@@ -253,7 +246,6 @@ Rationale: No issues found, code is ready to merge.
             workflow_id=uuid4(),
         )
 
-        # Should still return a result, but not approved
         assert result.approved is False
         assert session_id == "session-error"
 
@@ -269,7 +261,6 @@ Rationale: No issues found, code is ready to merge.
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage stream
         messages = [
             AgenticMessage(
                 type=AgenticMessageType.THINKING,
@@ -291,11 +282,10 @@ Rationale: No issues found, code is ready to merge.
             workflow_id=uuid4(),
         )
 
-        # Verify workflow events have correct agent and workflow_id (set by to_workflow_event)
         for call in mock_event_bus.emit.call_args_list:
             event = call.args[0]
             assert event.agent == "reviewer"
-            assert event.workflow_id is not None  # UUID propagated
+            assert event.workflow_id is not None
 
     async def test_agentic_review_parses_beagle_markdown_result(
         self,
@@ -308,7 +298,6 @@ Rationale: No issues found, code is ready to merge.
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage stream with beagle markdown format
         beagle_review_output = """## Review Summary
 
 Found 2 issues that should be addressed.
@@ -377,7 +366,6 @@ Rationale: Two major issues need to be fixed first.
             goal="Implement feature",
         )
 
-        # Create mock AgenticMessage with critical issue
         beagle_review_output = """## Review Summary
 
 Found a critical security issue.
@@ -564,7 +552,6 @@ class TestParseReviewResult:
         1. Regex r"Ready:\\s*(Yes|No|With fixes[^\\n]*)" doesn't match **Ready:** Yes
         2. Fallback finds "needs fixes" in rationale and incorrectly sets approved=False
         """
-        # Beagle markdown with bold formatting and "needs fixes" in rationale
         beagle_output = """## Review Summary
 
 Code looks good overall with no issues found.
@@ -589,7 +576,6 @@ Rationale: Code needs fixes for edge cases but they are out of scope.
         reviewer = create_reviewer()
         result = reviewer._parse_review_result(beagle_output, workflow_id=uuid4())
 
-        # Should be approved because verdict says "Ready: Yes"
         assert result.approved is True, (
             "Review should be approved when **Ready:** Yes is present, "
             "even if 'needs fixes' appears elsewhere in the output"
@@ -1000,7 +986,6 @@ class TestAgenticReviewDiffPath:
             diff_path="/tmp/test/diff.patch",
         )
 
-        # Verify the prompt passed to execute_agentic contains the diff path reference
         mock_driver.execute_agentic.assert_called_once()
         call_kwargs = mock_driver.execute_agentic.call_args
         prompt = call_kwargs[1].get("prompt") or call_kwargs[0][0]
@@ -1261,7 +1246,6 @@ Rationale: Major issue found.
             workflow_id=uuid4(),
         )
 
-        # Fallback markdown parsing should pick up the major issue
         assert result.approved is False
         assert result.severity == Severity.MAJOR
         assert len(result.comments) >= 1

--- a/tests/unit/core/test_developer_node.py
+++ b/tests/unit/core/test_developer_node.py
@@ -71,18 +71,14 @@ class TestDeveloperNodeProfileFromConfig:
         # Mock Developer to avoid actual execution
         with patch("amelia.pipelines.nodes.Developer") as mock_dev:
             mock_dev_instance = MagicMock()
-            # Developer.run is now an async generator
             async def mock_run(*args: Any, **kwargs: Any) -> Any:
                 yield state, MagicMock(type="thinking", content="test")
             mock_dev_instance.run = mock_run
             mock_dev.return_value = mock_dev_instance
 
-            # Should not raise, should use profile from config
             await call_developer_node(state, config)
 
-            # Verify Developer was created with AgentConfig from profile
             mock_dev.assert_called_once()
-            # The AgentConfig should come from profile.get_agent_config("developer")
             call_args = mock_dev.call_args
             assert call_args is not None
             agent_config = call_args[0][0]
@@ -121,7 +117,6 @@ class TestDeveloperUnifiedExecution:
             plan_markdown="# Test Plan\n\nImplement the feature.",
         )
 
-        # Create a mock driver that yields AgenticMessage
         mock_driver = MagicMock(spec=DriverInterface)
         mock_driver.execute_agentic = create_mock_execute_agentic([
             AgenticMessage(
@@ -149,12 +144,10 @@ class TestDeveloperUnifiedExecution:
 
         developer = create_developer_with_mock_driver(mock_driver)
 
-        # Collect all yielded results
         results = []
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Should have yielded events for each AgenticMessage
         assert len(results) >= 3  # At least thinking, tool_call, result
 
         # Verify it didn't try to import driver types
@@ -198,12 +191,11 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Find the thinking event
         thinking_events = [r for r in results if r[1].event_type == EventType.CLAUDE_THINKING]
         assert len(thinking_events) >= 1
         assert thinking_events[0][1].message == "Thinking about the problem..."
         assert thinking_events[0][1].agent == "developer"
-        assert thinking_events[0][1].workflow_id is not None  # UUID propagated
+        assert thinking_events[0][1].workflow_id is not None
 
     async def test_developer_processes_tool_call_message(
         self,
@@ -245,7 +237,6 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Find the tool call event
         tool_call_events = [r for r in results if r[1].event_type == EventType.CLAUDE_TOOL_CALL]
         assert len(tool_call_events) >= 1
         assert tool_call_events[0][1].tool_name == ToolName.WRITE_FILE
@@ -292,7 +283,6 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Find the tool result event
         tool_result_events = [r for r in results if r[1].event_type == EventType.CLAUDE_TOOL_RESULT]
         assert len(tool_result_events) >= 1
         assert tool_result_events[0][1].message == f"Tool {ToolName.READ_FILE} completed"
@@ -332,12 +322,10 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Find the agent output event
         output_events = [r for r in results if r[1].event_type == EventType.AGENT_OUTPUT]
         assert len(output_events) >= 1
         assert output_events[0][1].message == "Task completed successfully"
 
-        # Check final state
         final_state = results[-1][0]
         assert final_state.agentic_status == "completed"
         assert final_state.final_response == "Task completed successfully"
@@ -378,7 +366,6 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Check final state reflects error
         final_state = results[-1][0]
         assert final_state.agentic_status == "failed"
         assert final_state.error == "Error: Something went wrong"
@@ -429,7 +416,6 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Check final state has tool calls
         final_state = results[-1][0]
         assert len(final_state.tool_calls) >= 2
         tool_names = [tc.tool_name for tc in final_state.tool_calls]
@@ -484,7 +470,6 @@ class TestDeveloperUnifiedExecution:
         async for state_update, event in developer.run(state, profile, uuid4()):
             results.append((state_update, event))
 
-        # Check final state has tool results
         final_state = results[-1][0]
         assert len(final_state.tool_results) >= 2
 
@@ -535,7 +520,7 @@ class TestDeveloperUnifiedExecution:
         # All events should have agent and workflow_id set (from to_stream_event)
         for _state_update, event in results:
             assert event.agent == "developer"
-            assert event.workflow_id is not None  # UUID propagated
+            assert event.workflow_id is not None
             assert event.timestamp is not None
 
     async def test_developer_raises_without_goal(
@@ -624,7 +609,6 @@ Step 1: Build the thing
             }
         }
 
-        # Track what session_id is passed to the driver
         captured_session_id: str | None = "NOT_SET"
 
         async def mock_run(
@@ -632,7 +616,6 @@ Step 1: Build the thing
         ) -> Any:
             nonlocal captured_session_id
             captured_session_id = state.driver_session_id
-            # Return minimal valid state updates
             yield (state.model_copy(update={"agentic_status": "completed"}), MagicMock())
 
         with patch("amelia.pipelines.nodes.Developer") as mock_developer_class:
@@ -678,11 +661,9 @@ Step 1: Build the thing
 
             await call_developer_node(multi_task_state, config)
 
-        # Should preserve full plan with ALL tasks
         assert captured_plan is not None
         assert "### Task 1:" in captured_plan
-        assert "### Task 2:" in captured_plan  # Full plan preserved
-        # Should preserve header context
+        assert "### Task 2:" in captured_plan
         assert "**Goal:**" in captured_plan
         assert "## Phase 1:" in captured_plan
 
@@ -724,5 +705,4 @@ Step 1: Build the thing
 
             await call_developer_node(state, config)
 
-        # Session should be cleared for task execution
         assert captured_session_id is None

--- a/tests/unit/drivers/test_codex_driver.py
+++ b/tests/unit/drivers/test_codex_driver.py
@@ -544,11 +544,6 @@ async def test_execute_agentic_extracts_reasoning_from_item_completed() -> None:
     assert msgs[0].content == "Let me think about this"
 
 
-# ---------------------------------------------------------------------------
-# CodexApprovalMode tests
-# ---------------------------------------------------------------------------
-
-
 def test_init_default_approval_mode_is_full_auto() -> None:
     driver = CodexCliDriver()
     assert driver.approval_mode == CodexApprovalMode.FULL_AUTO
@@ -710,11 +705,6 @@ async def test_validate_schema_raises_schema_error() -> None:
         driver._validate_schema({"wrong": "data"}, _Schema, "source")
 
 
-# ---------------------------------------------------------------------------
-# Usage tracking tests
-# ---------------------------------------------------------------------------
-
-
 def _make_turn_completed_event(
     input_tokens: int, output_tokens: int, cached_input_tokens: int = 0
 ) -> CodexStreamEvent:
@@ -860,11 +850,6 @@ class TestCodexDriverUsageAccumulation:
             _ = [m async for m in driver.execute_agentic("task", cwd="/tmp")]
 
         assert driver.get_usage() is None
-
-
-# ---------------------------------------------------------------------------
-# Exception / early-exit usage tracking tests (Issue 4)
-# ---------------------------------------------------------------------------
 
 
 class TestCodexDriverUsageOnException:

--- a/tests/unit/drivers/test_model_provider_error.py
+++ b/tests/unit/drivers/test_model_provider_error.py
@@ -11,11 +11,6 @@ from amelia.core.exceptions import ModelProviderError
 from amelia.drivers.api.deepagents import _extract_provider_info, _is_model_provider_error
 
 
-# ---------------------------------------------------------------------------
-# Pure helper function tests
-# ---------------------------------------------------------------------------
-
-
 class TestModelProviderErrorRepr:
     """Tests for ModelProviderError __repr__ method."""
 
@@ -103,11 +98,6 @@ class TestExtractProviderInfo:
         assert message == str(exc)
 
 
-# ---------------------------------------------------------------------------
-# ApiDriver integration tests (mocked at external boundary)
-# ---------------------------------------------------------------------------
-
-
 class TestExecuteAgenticProviderErrorWrapping:
     """Tests that execute_agentic wraps model provider ValueErrors."""
 
@@ -183,11 +173,6 @@ class TestGenerateProviderErrorWrapping:
             await driver.generate(prompt="test")
 
         assert "minimax" in str(exc_info.value)
-
-
-# ---------------------------------------------------------------------------
-# CLI driver ProcessError wrapping tests
-# ---------------------------------------------------------------------------
 
 
 class TestCliDriverProcessErrorWrapping:

--- a/tests/unit/knowledge/test_ingestion.py
+++ b/tests/unit/knowledge/test_ingestion.py
@@ -15,11 +15,6 @@ from amelia.knowledge.models import Document, DocumentStatus
 from amelia.knowledge.repository import ChunkData, KnowledgeRepository
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 # A long, realistic chunk body that comfortably exceeds the 64-token floor
 # enforced by `MIN_CHUNK_TOKENS`. Tests use this so chunks are not silently
 # dropped by the new tiny-chunk filter.
@@ -120,11 +115,6 @@ def pipeline(mock_repo: AsyncMock, mock_embedding: AsyncMock) -> IngestionPipeli
         tag_derivation_model=None,
         tag_derivation_driver="api",
     )
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -502,11 +492,6 @@ async def test_concurrency_semaphore(
     assert snapshot <= 2, f"Expected at most 2 concurrent, got {snapshot}"
 
 
-# ---------------------------------------------------------------------------
-# New chunker contract: contextualize + min-token filter
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_drops_chunks_below_min_tokens(
     pipeline: IngestionPipeline,
@@ -709,11 +694,6 @@ async def test_embeds_contextualized_text(
     assert inserted[0]["token_count"] == 120
 
 
-# ---------------------------------------------------------------------------
-# Tag Extraction Helper Tests
-# ---------------------------------------------------------------------------
-
-
 def test_prepare_tag_extraction_input_truncates_long_text(
     pipeline: IngestionPipeline,
 ) -> None:
@@ -838,11 +818,6 @@ def test_build_tag_extraction_prompt(
     assert "lowercase" in prompt
 
 
-# ---------------------------------------------------------------------------
-# Tag Derivation Method Tests
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_derive_tags_success(
     pipeline: IngestionPipeline,
@@ -922,11 +897,6 @@ async def test_derive_tags_handles_llm_failure(
 
     assert result == []
     mock_extract.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# Tag Derivation Integration Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/unit/knowledge/test_service.py
+++ b/tests/unit/knowledge/test_service.py
@@ -16,11 +16,6 @@ from amelia.server.events.bus import EventBus
 from amelia.server.models.events import EventDomain, EventType, WorkflowEvent
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def mock_event_bus() -> MagicMock:
     """Provide a mocked EventBus."""
@@ -106,11 +101,6 @@ def service(
     )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _find_events(
     bus: MagicMock, event_type: EventType,
 ) -> list[WorkflowEvent]:
@@ -121,11 +111,6 @@ def _find_events(
         if isinstance(call_args.args[0], WorkflowEvent)
         and call_args.args[0].event_type == event_type
     ]
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipelines/pr_auto_fix/conftest.py
+++ b/tests/unit/pipelines/pr_auto_fix/conftest.py
@@ -28,11 +28,6 @@ from amelia.server.models.events import WorkflowEvent
 from amelia.services.github_pr import GitHubPRService
 
 
-# ---------------------------------------------------------------------------
-# Factory helpers
-# ---------------------------------------------------------------------------
-
-
 def make_comment(
     *,
     id: int = 1,
@@ -180,11 +175,6 @@ def make_orchestrator(
     )
 
 
-# ---------------------------------------------------------------------------
-# Mock pipeline context manager (reduces ~15 lines per usage)
-# ---------------------------------------------------------------------------
-
-
 @asynccontextmanager
 async def mock_pipeline_context(
     *,
@@ -213,11 +203,6 @@ async def mock_pipeline_context(
         return_value=mock_pipeline,
     ):
         yield mock_pipeline, mock_graph
-
-
-# ---------------------------------------------------------------------------
-# Shared orchestrator fixtures (used by test_orchestrator.py)
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()

--- a/tests/unit/pipelines/pr_auto_fix/test_nodes.py
+++ b/tests/unit/pipelines/pr_auto_fix/test_nodes.py
@@ -31,11 +31,6 @@ from .conftest import (
 )
 
 
-# ---------------------------------------------------------------------------
-# classify_node tests
-# ---------------------------------------------------------------------------
-
-
 class TestClassifyNode:
     """Tests for classify_node."""
 
@@ -76,11 +71,6 @@ class TestClassifyNode:
         assert result["file_groups"] == {}
 
 
-# ---------------------------------------------------------------------------
-# develop_node helpers
-# ---------------------------------------------------------------------------
-
-
 def _fake_dev_run_success(impl_state: Any, profile: Any, workflow_id: Any) -> Any:
     """Async generator that yields a completed state."""
     async def gen() -> Any:
@@ -95,11 +85,6 @@ def _fake_dev_run_failure(impl_state: Any, profile: Any, workflow_id: Any) -> An
         raise RuntimeError("Developer failed")
         yield  # noqa: RET503
     return gen()
-
-
-# ---------------------------------------------------------------------------
-# _build_developer_goal tests
-# ---------------------------------------------------------------------------
 
 
 class TestBuildDeveloperGoal:
@@ -166,11 +151,6 @@ class TestBuildDeveloperGoal:
         c = make_comment(id=1, path="src/app.py")
         goal = _build_developer_goal("src/app.py", [c], {}, pr_number=1, head_branch="main")
         assert "Working Directory" not in goal
-
-
-# ---------------------------------------------------------------------------
-# develop_node tests
-# ---------------------------------------------------------------------------
 
 
 class TestDevelopNode:
@@ -365,11 +345,6 @@ class TestDevelopNode:
         assert result["group_results"][0].status == expected_status
 
 
-# ---------------------------------------------------------------------------
-# commit_push_node tests
-# ---------------------------------------------------------------------------
-
-
 class TestCommitPushNode:
     """Tests for commit_push_node."""
 
@@ -464,11 +439,6 @@ class TestCommitPushNode:
         commit_msg = mock_git.stage_and_commit.call_args[0][0]
         for expected in ["chore(review):", "address PR review comments", "src/app.py:10", "Fix null check", "src/utils.py:20", "Add validation"]:
             assert expected in commit_msg
-
-
-# ---------------------------------------------------------------------------
-# reply_resolve_node tests
-# ---------------------------------------------------------------------------
 
 
 def _make_reply_resolve_state(

--- a/tests/unit/pipelines/pr_auto_fix/test_orchestrator.py
+++ b/tests/unit/pipelines/pr_auto_fix/test_orchestrator.py
@@ -16,11 +16,6 @@ from amelia.server.models.state import WorkflowStatus, WorkflowType
 from .conftest import mock_pipeline_context
 
 
-# ---------------------------------------------------------------------------
-# Phase 06-01 tests (config + event types)
-# ---------------------------------------------------------------------------
-
-
 class TestPRAutoFixConfigCooldown:
     """Tests for cooldown configuration fields on PRAutoFixConfig."""
 
@@ -76,11 +71,6 @@ class TestPRFixEventTypes:
         assert isinstance(event, EventType)
 
 
-# ---------------------------------------------------------------------------
-# Autouse: patch LocalWorktree + GitOperations for all tests in this module
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(autouse=True)
 def _patch_worktree_and_git(
     mock_local_worktree: MagicMock,
@@ -98,11 +88,6 @@ def _patch_worktree_and_git(
         ),
     ):
         yield
-
-
-# ---------------------------------------------------------------------------
-# ORCH-01: Per-PR Concurrency Control
-# ---------------------------------------------------------------------------
 
 
 class TestConcurrencyControl:
@@ -222,11 +207,6 @@ class TestConcurrencyControl:
         pipeline_continue.set()
         await task1
         assert call_count == 2
-
-
-# ---------------------------------------------------------------------------
-# ORCH-02: Cooldown with Reset
-# ---------------------------------------------------------------------------
 
 
 def _make_cooldown_orchestrator(
@@ -391,11 +371,6 @@ class TestCooldown:
 
         await asyncio.wait_for(task, timeout=timeout)
         assert call_count == 2
-
-
-# ---------------------------------------------------------------------------
-# ORCH-03: Worktree-based Branch Safety & Divergence Recovery
-# ---------------------------------------------------------------------------
 
 
 class TestWorktreeIntegration:
@@ -583,11 +558,6 @@ class TestDivergenceRecovery:
         assert orchestrator._execute_pipeline.await_count == 1
 
 
-# ---------------------------------------------------------------------------
-# Event Emission
-# ---------------------------------------------------------------------------
-
-
 class TestEventEmission:
     async def test_queued_event_has_pr_number(
         self,
@@ -618,11 +588,6 @@ class TestEventEmission:
         assert queued[0].data["pr_number"] == 42
 
 
-# ---------------------------------------------------------------------------
-# Pipeline Wiring
-# ---------------------------------------------------------------------------
-
-
 class TestExecutePipelineWiring:
     async def test_execute_pipeline_creates_and_invokes_graph(
         self,
@@ -651,11 +616,6 @@ class TestExecutePipelineWiring:
         assert "thread_id" in configurable
         assert configurable["profile"].name == "test"
         assert configurable["event_bus"] is not None
-
-
-# ---------------------------------------------------------------------------
-# Workflow Record Creation (Phase 09-01 Task 2)
-# ---------------------------------------------------------------------------
 
 
 class TestWorkflowRecordCreation:
@@ -1079,11 +1039,6 @@ class TestBuildPrCommentsStatusReason:
         assert by_id[2]["status_reason"] == "Timeout"
         assert by_id[3]["status_reason"] == "No code changes needed"
         assert by_id[4]["status_reason"] == "Not actionable or filtered"
-
-
-# ---------------------------------------------------------------------------
-# Phase 13-01: Workflow ID threading
-# ---------------------------------------------------------------------------
 
 
 class TestWorkflowIdThreading:

--- a/tests/unit/server/lifecycle/test_pr_poller.py
+++ b/tests/unit/server/lifecycle/test_pr_poller.py
@@ -22,11 +22,6 @@ from amelia.server.lifecycle.pr_poller import PRCommentPoller
 from amelia.server.models.events import _WARNING_TYPES, EventType
 
 
-# ---------------------------------------------------------------------------
-# Shared fixtures (reused by Task 2 tests)
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture()
 def mock_settings_repo() -> AsyncMock:
     """Mock SettingsRepository with get_server_settings."""
@@ -67,11 +62,6 @@ def sample_profile_no_autofix() -> Profile:
         name="no-autofix",
         repo_root="/tmp/test-repo",
     )
-
-
-# ---------------------------------------------------------------------------
-# Task 1: Config extensions
-# ---------------------------------------------------------------------------
 
 
 class TestPRAutoFixConfigPollLabel:
@@ -162,11 +152,6 @@ class TestListLabeledPRs:
             result = await service.list_labeled_prs("amelia")
 
         assert result == []
-
-
-# ---------------------------------------------------------------------------
-# Task 2: PRCommentPoller service
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -610,11 +595,6 @@ class TestNoOverlap:
 
             poll_continue.set()
             await task
-
-
-# ---------------------------------------------------------------------------
-# Processed comment tracking (skip-when-all-processed)
-# ---------------------------------------------------------------------------
 
 
 class TestProcessedCommentTracking:

--- a/tests/unit/server/orchestrator/test_runner.py
+++ b/tests/unit/server/orchestrator/test_runner.py
@@ -93,11 +93,6 @@ def runner(
     )
 
 
-# =============================================================================
-# Checkpoint Resume Tests (Bug #199: Infinite Loop) — relocated from test_service
-# =============================================================================
-
-
 class TestRunWorkflowCheckpointResume:
     """run_workflow must resume from an existing checkpoint instead of restarting.
 
@@ -203,11 +198,6 @@ class TestRunWorkflowCheckpointResume:
         assert first_arg is not None, "Expected astream called with initial_state"
         assert isinstance(first_arg, dict), "Expected initial_state to be a dict"
         assert first_arg.get("profile_id") == "test"
-
-
-# =============================================================================
-# Exponential Backoff / Retry Tests — relocated from test_service
-# =============================================================================
 
 
 class TestRunWorkflowWithRetry:
@@ -437,11 +427,6 @@ class TestRunWorkflowWithRetry:
             if len(c[0]) >= 2 and c[0][1] == WorkflowStatus.FAILED
         ]
         assert len(failed_calls) == 1
-
-
-# =============================================================================
-# Plan Sync Tests — relocated from test_service (driver-owned helper)
-# =============================================================================
 
 
 class TestSyncPlanFromCheckpoint:

--- a/tests/unit/server/orchestrator/test_service.py
+++ b/tests/unit/server/orchestrator/test_service.py
@@ -153,11 +153,6 @@ def capture_emit(
     return emitted_events, install
 
 
-# =============================================================================
-# Worktree Validation Tests
-# =============================================================================
-
-
 async def test_start_workflow_rejects_nonexistent_path(
     orchestrator: OrchestratorService,
 ) -> None:
@@ -218,18 +213,16 @@ async def test_start_workflow_success(
             worktree_path=valid_worktree,
         )
 
-        assert workflow_id  # Should return a UUID
+        assert workflow_id
         assert valid_worktree in orchestrator._active_tasks
         mock_repository.create.assert_called_once()
 
-        # Verify state creation
         call_args = mock_repository.create.call_args
         state = call_args[0][0]
         assert state.id == workflow_id
         assert state.issue_id == "ISSUE-123"
         assert state.worktree_path == valid_worktree
         assert state.workflow_status == WorkflowStatus.PENDING
-        # Verify profile_id is stored on ServerExecutionState
         assert state.profile_id == "test"
 
 
@@ -252,7 +245,6 @@ async def test_start_workflow_conflict(
 
     assert valid_worktree in str(exc_info.value)
 
-    # Cleanup
     _, task = orchestrator._active_tasks[valid_worktree]
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -272,7 +264,6 @@ async def test_start_workflow_concurrency_limit(
         orchestrator._active_tasks[f"/fake/worktree{i}"] = (uuid4(), task)
         tasks.append(task)
 
-    # Now try to start a workflow with a valid worktree path
     with pytest.raises(ConcurrencyLimitError) as exc_info:
         await orchestrator.start_workflow(
             issue_id="ISSUE-123",
@@ -281,7 +272,6 @@ async def test_start_workflow_concurrency_limit(
 
     assert exc_info.value.max_concurrent == 5
 
-    # Cleanup
     for task in tasks:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -319,7 +309,6 @@ async def test_cancel_workflow(
     mock_repository: AsyncMock,
 ) -> None:
     """Should cancel running workflow task and persist status."""
-    # Create mock workflow state
     cancel_wf_id = uuid4()
     mock_state = ServerExecutionState(
         id=cancel_wf_id,
@@ -330,20 +319,16 @@ async def test_cancel_workflow(
     )
     mock_repository.get.return_value = mock_state
 
-    # Create a fake running task
     task = asyncio.create_task(asyncio.sleep(100))
     orchestrator._active_tasks["/path/to/worktree"] = (cancel_wf_id, task)
 
     await orchestrator.cancel_workflow(cancel_wf_id)
 
-    # Wait for the cancellation to complete
     with contextlib.suppress(asyncio.CancelledError):
         await task
 
-    # Task should be cancelled
     assert task.cancelled()
 
-    # Status should be persisted to database
     mock_repository.set_status.assert_called_once_with(cancel_wf_id, WorkflowStatus.CANCELLED)
 
 
@@ -462,11 +447,6 @@ def test_get_active_workflows(orchestrator: OrchestratorService) -> None:
     assert set(active) == {"/path/1", "/path/2"}
 
 
-# =============================================================================
-# Approval Flow Tests
-# =============================================================================
-
-
 @patch("amelia.server.orchestrator.runner.create_implementation_graph")
 async def test_approve_workflow_success(
     mock_create_graph: MagicMock,
@@ -479,7 +459,6 @@ async def test_approve_workflow_success(
     received_events = []
     mock_event_bus.subscribe(lambda e: received_events.append(e))
 
-    # Create mock blocked workflow
     mock_state = ServerExecutionState(
         id=uuid4(),
         issue_id="ISSUE-123",
@@ -490,7 +469,6 @@ async def test_approve_workflow_success(
     )
     mock_repository.get.return_value = mock_state
 
-    # Setup LangGraph mocks using factory
     mocks = langgraph_mock_factory(
         aget_state_return=MagicMock(values={"human_approved": True}, next=[])
     )
@@ -500,14 +478,11 @@ async def test_approve_workflow_success(
     # New API returns None, raises on error
     await orchestrator.approve_workflow(mock_state.id)
 
-    # Should update status - now called twice: once for in_progress, once for completed
     assert mock_repository.set_status.call_count == 2
-    # First call is in_progress, second is completed
     calls = mock_repository.set_status.call_args_list
     assert calls[0][0] == (mock_state.id, WorkflowStatus.IN_PROGRESS)
     assert calls[1][0] == (mock_state.id, WorkflowStatus.COMPLETED)
 
-    # Should emit APPROVAL_GRANTED
     approval_granted = [e for e in received_events if e.event_type == EventType.APPROVAL_GRANTED]
     assert len(approval_granted) == 1
 
@@ -524,7 +499,6 @@ async def test_reject_workflow_success(
     received_events = []
     mock_event_bus.subscribe(lambda e: received_events.append(e))
 
-    # Create mock workflow and task
     mock_state = ServerExecutionState(
         id=uuid4(),
         issue_id="ISSUE-123",
@@ -535,29 +509,24 @@ async def test_reject_workflow_success(
     )
     mock_repository.get.return_value = mock_state
 
-    # Setup LangGraph mocks using factory
     mocks = langgraph_mock_factory()
     mock_create_graph.return_value = mocks.graph
 
     # Profile is already mocked via mock_profile_repo fixture
-    # Create fake task
     task = asyncio.create_task(asyncio.sleep(100))
     orchestrator._active_tasks["/path/to/worktree"] = (mock_state.id, task)
 
     # New API returns None, raises on error
     await orchestrator.reject_workflow(mock_state.id, feedback="Plan too complex")
 
-    # Should update status to failed
     mock_repository.set_status.assert_called_once_with(
         mock_state.id, WorkflowStatus.FAILED, failure_reason="Plan too complex"
     )
 
-    # Should cancel task - wait for cancellation to complete
     with contextlib.suppress(asyncio.CancelledError):
         await task
     assert task.cancelled()
 
-    # Should emit APPROVAL_REJECTED
     approval_rejected = [e for e in received_events if e.event_type == EventType.APPROVAL_REJECTED]
     assert len(approval_rejected) == 1
     assert "rejected" in approval_rejected[0].message.lower()
@@ -584,7 +553,6 @@ class TestRejectWorkflowGraphState:
         )
         mock_repository.get.return_value = workflow
 
-        # Setup LangGraph mocks using factory
         mocks = langgraph_mock_factory()
         mock_create_graph.return_value = mocks.graph
 
@@ -608,7 +576,6 @@ class TestApproveWorkflowResume:
         langgraph_mock_factory: Callable[..., MagicMock],
     ) -> None:
         """approve_workflow updates graph state and resumes execution."""
-        # Setup blocked workflow
         workflow = ServerExecutionState(
             id=uuid4(),
             issue_id="ISSUE-456",
@@ -619,7 +586,6 @@ class TestApproveWorkflowResume:
         mock_repository.get.return_value = workflow
         orchestrator._active_tasks["/tmp/test"] = (workflow.id, AsyncMock())
 
-        # Setup LangGraph mocks using factory
         mocks = langgraph_mock_factory(
             aget_state_return=MagicMock(values={"human_approved": True}, next=[])
         )
@@ -628,7 +594,6 @@ class TestApproveWorkflowResume:
         # Profile is already mocked via mock_profile_repo fixture
         await orchestrator.approve_workflow(workflow.id)
 
-        # Verify state was updated with approval
         mocks.graph.aupdate_state.assert_called_once()
         call_args = mocks.graph.aupdate_state.call_args
         assert call_args[0][1] == {"human_approved": True}
@@ -705,11 +670,9 @@ class TestApproveWorkflowResume:
         # the un-jittered 1.0 the old loop produced.
         slept_delay = mock_sleep.call_args_list[0][0][0]
         assert slept_delay == pytest.approx(1.2)
-        # Observable completion emitted after the retry.
         assert any(
             e[1] == EventType.WORKFLOW_COMPLETED for e in emitted_events
         )
-        # And the repository recorded COMPLETED.
         completed_calls = [
             c
             for c in mock_repository.set_status.call_args_list
@@ -735,7 +698,6 @@ class TestStartWorkflowWithRetry:
             # Wait briefly for task to start
             await asyncio.sleep(0.01)
 
-            # The task should call _run_workflow_with_retry
             assert workflow_id is not None
             mock_retry.assert_called_once()
 
@@ -745,7 +707,6 @@ async def test_get_workflow_by_worktree_uses_cache(
     mock_repository: AsyncMock,
 ) -> None:
     """get_workflow_by_worktree should use cached workflow_id, not DB."""
-    # Create workflow state
     cached_wf_id = uuid4()
     mock_state = ServerExecutionState(
         id=cached_wf_id,
@@ -760,31 +721,21 @@ async def test_get_workflow_by_worktree_uses_cache(
     task = asyncio.create_task(asyncio.sleep(100))
     orchestrator._active_tasks["/cached/worktree"] = (cached_wf_id, task)
 
-    # Reset mock to track calls
     mock_repository.list_active.reset_mock()
 
-    # Get workflow by worktree
     result = await orchestrator.get_workflow_by_worktree("/cached/worktree")
 
     # Should NOT call list_active (O(n) query)
     mock_repository.list_active.assert_not_called()
 
-    # Should call get() with cached workflow_id
     mock_repository.get.assert_called_once_with(cached_wf_id)
 
-    # Should return the workflow
     assert result is not None
     assert result.id == cached_wf_id
 
-    # Cleanup
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
-
-
-# =============================================================================
-# Task Title/Description Tests
-# =============================================================================
 
 
 class TestTaskProgressEvents:
@@ -818,7 +769,6 @@ class TestTaskProgressEvents:
         }
         await orchestrator._events.handle_tasks_event(uuid4(), task_data)
 
-        # Verify TASK_STARTED event emitted
         task_events = [e for e in emitted_events if e[1] == EventType.TASK_STARTED]
         assert len(task_events) == 1
         _, event_type, message, data = task_events[0]
@@ -866,7 +816,6 @@ class TestTaskProgressEvents:
 
         await orchestrator._events.handle_stream_chunk(uuid4(), chunk)
 
-        # Verify TASK_COMPLETED event emitted
         task_events = [e for e in emitted_events if e[1] == EventType.TASK_COMPLETED]
         assert len(task_events) == 1
         _, event_type, message, data = task_events[0]
@@ -904,7 +853,6 @@ class TestStartWorkflowWithTaskFields:
 
             assert workflow_id is not None
 
-            # Verify the issue_cache contains our custom issue
             call_args = mock_repository.create.call_args
             state = call_args[0][0]
             assert state.issue_cache is not None
@@ -955,7 +903,6 @@ class TestStartWorkflowWithTaskFields:
         # Tracker should not be called when task_title is provided
         mock_create_tracker.assert_not_called()
 
-        # Verify the issue was constructed from the provided fields
         call_args = mock_repository.create.call_args
         state = call_args[0][0]
         issue = Issue.model_validate(state.issue_cache)
@@ -972,7 +919,6 @@ class TestStartWorkflowWithTaskFields:
         """task_description defaults to task_title when not provided."""
         from amelia.core.types import Issue
 
-        # Create valid worktree
         worktree = tmp_path / "worktree"
         worktree.mkdir()
         (worktree / ".git").touch()
@@ -988,15 +934,9 @@ class TestStartWorkflowWithTaskFields:
 
             call_args = mock_repository.create.call_args
             state = call_args[0][0]
-            # Description should default to title
             assert state.issue_cache is not None
             issue = Issue.model_validate(state.issue_cache)
             assert issue.description == "Fix typo in README"
-
-
-# =============================================================================
-# ModelProviderError Retry Tests
-# =============================================================================
 
 
 class ModelProviderErrorSetup:
@@ -1010,7 +950,6 @@ class ModelProviderErrorSetup:
 @pytest.fixture
 def model_provider_error_setup(mock_repository: AsyncMock) -> ModelProviderErrorSetup:
     """Shared setup for ModelProviderError retry tests."""
-    # Setup blocked workflow with real ServerExecutionState
     mock_workflow = ServerExecutionState(
         id=uuid4(),
         issue_id="ISSUE-TEST",
@@ -1098,7 +1037,6 @@ async def test_model_provider_error_friendly_failure_reason(
     ):
         await orchestrator.approve_workflow(uuid4())
 
-    # Verify set_status was called with FAILED and a friendly failure_reason
     failed_calls = [
         call
         for call in mock_repository.set_status.call_args_list
@@ -1161,11 +1099,6 @@ async def test_httpx_connect_error_retried(
     # max_retries=2 means attempts 0, 1, 2 → astream called 3 times
     assert mock_graph.astream.call_count == 3
     assert mock_sleep.call_count == 2
-
-
-# =============================================================================
-# Resume Workflow Tests
-# =============================================================================
 
 
 async def test_resume_workflow_corrupted_checkpoint_raises_invalid_state(

--- a/tests/unit/server/routes/test_workflow_routes.py
+++ b/tests/unit/server/routes/test_workflow_routes.py
@@ -23,11 +23,6 @@ from amelia.trajectory import WorkflowTrajectoryRecorder
 from .conftest import patch_lifespan
 
 
-# =============================================================================
-# Module-level fixtures and helpers
-# =============================================================================
-
-
 @pytest.fixture
 def mock_repository() -> MagicMock:
     """Create a mock WorkflowRepository with common methods stubbed."""
@@ -112,11 +107,6 @@ def make_recorder_with_invocation(
     ])
     inv.close(usage=DriverUsage(input_tokens=10, output_tokens=5), cost_usd=0.01)
     return recorder
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 class TestGetWorkflowDetail:

--- a/tests/unit/server/services/test_brainstorm_service.py
+++ b/tests/unit/server/services/test_brainstorm_service.py
@@ -241,7 +241,6 @@ class TestSendMessage(TestBrainstormService):
         mock_repository.get_session.return_value = mock_session
         mock_repository.get_max_sequence.return_value = 0
 
-        # Consume the async generator
         messages = []
         async for msg in service.send_message(
             session_id=sess_id,
@@ -251,7 +250,6 @@ class TestSendMessage(TestBrainstormService):
         ):
             messages.append(msg)
 
-        # Verify user message was saved
         save_calls = mock_repository.save_message.call_args_list
         user_msg_call = save_calls[0][0][0]
         assert user_msg_call.role == MessageRole.USER
@@ -318,10 +316,8 @@ class TestSendMessage(TestBrainstormService):
         ):
             messages.append(msg)
 
-        # Verify session was updated with driver session ID
         update_calls = mock_repository.update_session.call_args_list
         assert len(update_calls) > 0
-        # Find the call that updated driver_session_id
         updated_session = update_calls[-1][0][0]
         assert updated_session.driver_session_id == "claude-sess-789"
 
@@ -392,7 +388,6 @@ class TestArtifactDetection(TestBrainstormService):
         mock_repository.get_session.return_value = self._make_session(sess_id)
         mock_repository.get_max_sequence.return_value = 0
 
-        # Patch Path.is_file to return True for the plan path
         original_is_file = Path.is_file
 
         def fake_is_file(self: Path) -> bool:
@@ -652,7 +647,6 @@ class TestHandoff(TestBrainstormService):
         ]
 
         mock_orchestrator = MagicMock()
-        # Simulate ValueError from orchestrator when tracker is not none
         mock_orchestrator.queue_workflow = AsyncMock(
             side_effect=ValueError("task_title can only be used with none tracker")
         )
@@ -672,7 +666,6 @@ class TestHandoff(TestBrainstormService):
         mock_repository: MagicMock,
     ) -> None:
         """Should pass artifact_path when creating workflow request."""
-        # Setup session and artifact
         sess_id = uuid4()
         session = BrainstormingSession(
             id=sess_id,
@@ -694,11 +687,9 @@ class TestHandoff(TestBrainstormService):
         mock_repository.get_session.return_value = session
         mock_repository.get_artifacts.return_value = [artifact]
 
-        # Create mock orchestrator that captures the request
         mock_orchestrator = AsyncMock()
         mock_orchestrator.queue_workflow = AsyncMock(return_value="workflow-456")
 
-        # Execute handoff
         result = await service.handoff_to_implementation(
             session_id=sess_id,
             artifact_path="/path/to/design.md",
@@ -707,7 +698,6 @@ class TestHandoff(TestBrainstormService):
             worktree_path="/path/to/repo",
         )
 
-        # Verify workflow was created with artifact_path
         mock_orchestrator.queue_workflow.assert_called_once()
         request = mock_orchestrator.queue_workflow.call_args[0][0]
         assert request.artifact_path == "/path/to/design.md"
@@ -915,10 +905,8 @@ class TestDeleteSessionCleanup(TestBrainstormService):
         mock_cleanup: MagicMock,
     ) -> None:
         """Should still delete session even if cleanup callback fails."""
-        # Setup: make cleanup raise an exception
         mock_cleanup.side_effect = Exception("cleanup failed")
 
-        # Create a session with driver_type and driver_session_id
         now = datetime.now(UTC)
         sess_id = uuid4()
         mock_session = BrainstormingSession(
@@ -935,7 +923,6 @@ class TestDeleteSessionCleanup(TestBrainstormService):
         # Should not raise, should still delete the session
         await service_with_cleanup.delete_session(sess_id)
 
-        # Verify cleanup was attempted
         mock_cleanup.assert_called_once_with("claude", "driver-sess-123")
         # Verify session was still deleted despite cleanup failure
         mock_repository.delete_session.assert_called_once_with(sess_id)
@@ -1037,10 +1024,8 @@ class TestGetSessionWithHistory(TestBrainstormService):
 
         result = await service.get_session_with_history(sess_id)
 
-        # Verify get_messages was called
         mock_repository.get_messages.assert_called_once()
 
-        # Verify result contains messages
         assert result is not None
         assert len(result["messages"]) == 2
 
@@ -1109,7 +1094,6 @@ class TestSendMessageNewArchitecture:
         mock_repository.get_session.return_value = mock_session
         mock_repository.get_max_sequence.return_value = 0  # First message
 
-        # Create a mock driver that captures the prompt
         captured_prompts: list[str] = []
 
         async def mock_execute_agentic(
@@ -1136,7 +1120,6 @@ class TestSendMessageNewArchitecture:
         ):
             pass
 
-        # Verify prompt was formatted with template
         expected = BRAINSTORMER_USER_PROMPT_TEMPLATE.format(idea="a caching layer")
         assert len(captured_prompts) == 1
         assert captured_prompts[0] == expected
@@ -1160,7 +1143,6 @@ class TestSendMessageNewArchitecture:
         mock_repository.get_session.return_value = mock_session
         mock_repository.get_max_sequence.return_value = 2  # Not first message
 
-        # Create a mock driver that captures the prompt
         captured_prompts: list[str] = []
 
         async def mock_execute_agentic(
@@ -1210,7 +1192,6 @@ class TestSendMessageNewArchitecture:
         mock_repository.get_session.return_value = mock_session
         mock_repository.get_max_sequence.return_value = 0
 
-        # Create a mock driver that captures the instructions
         captured_instructions: list[str | None] = []
 
         async def mock_execute_agentic(
@@ -1237,7 +1218,6 @@ class TestSendMessageNewArchitecture:
         ):
             pass
 
-        # Verify instructions contain system prompt content (with resolved path)
         assert len(captured_instructions) == 1
         assert captured_instructions[0] is not None
         assert "design collaborator" in captured_instructions[0]
@@ -1285,7 +1265,6 @@ class TestSendMessageNewArchitecture:
         ):
             pass
 
-        # Verify user message stored original content
         save_calls = mock_repository.save_message.call_args_list
         user_msg = save_calls[0][0][0]
         assert user_msg.content == "a caching layer"
@@ -1333,7 +1312,6 @@ class TestSendMessageNewArchitecture:
         ):
             pass
 
-        # Verify user message does not have is_system=True
         save_calls = mock_repository.save_message.call_args_list
         user_msg = save_calls[0][0][0]
         # Either is_system field is absent or defaults to False
@@ -1457,7 +1435,6 @@ class TestSendMessagePlanPath:
         assert "caching-layer" in instructions
         assert "-design.md" in instructions
 
-        # Verify output_artifact_path was persisted on session
         update_calls = mock_repository.update_session.call_args_list
         # First update_session call stores the artifact path
         updated_session = update_calls[0][0][0]
@@ -1495,7 +1472,6 @@ class TestSendMessagePlanPath:
         assert instructions is not None
         assert "brainstorm-abcd1234" in instructions
 
-        # Verify output_artifact_path was persisted on session
         update_calls = mock_repository.update_session.call_args_list
         updated_session = update_calls[0][0][0]
         assert updated_session.output_artifact_path is not None
@@ -1529,7 +1505,6 @@ class TestSendMessagePlanPath:
         assert "docs/plans/" in instructions
         assert "auth-system" in instructions
 
-        # Verify output_artifact_path was persisted on session
         update_calls = mock_repository.update_session.call_args_list
         updated_session = update_calls[0][0][0]
         assert updated_session.output_artifact_path is not None

--- a/tests/unit/server/test_event_filtering.py
+++ b/tests/unit/server/test_event_filtering.py
@@ -14,11 +14,6 @@ from amelia.server.models.responses import WorkflowDetailResponse, WorkflowSumma
 from amelia.server.models.state import WorkflowStatus, WorkflowType
 
 
-# ---------------------------------------------------------------------------
-# PR auto-fix event types: existence and values
-# ---------------------------------------------------------------------------
-
-
 class TestPRAutoFixEventTypes:
     """Tests for new PR auto-fix lifecycle event types."""
 
@@ -40,11 +35,6 @@ class TestPRAutoFixEventTypes:
         assert isinstance(event, EventType)
 
 
-# ---------------------------------------------------------------------------
-# Event level classification
-# ---------------------------------------------------------------------------
-
-
 class TestPRAutoFixEventClassification:
     """Tests for correct INFO/ERROR classification of new event types."""
 
@@ -64,11 +54,6 @@ class TestPRAutoFixEventClassification:
         assert get_event_level(EventType.PR_POLL_ERROR) == EventLevel.ERROR
 
 
-# ---------------------------------------------------------------------------
-# WorkflowType.PR_AUTO_FIX
-# ---------------------------------------------------------------------------
-
-
 class TestWorkflowTypePRAutoFix:
     """Tests for the PR_AUTO_FIX workflow type."""
 
@@ -77,11 +62,6 @@ class TestWorkflowTypePRAutoFix:
 
     def test_pr_auto_fix_is_workflow_type(self) -> None:
         assert isinstance(WorkflowType.PR_AUTO_FIX, WorkflowType)
-
-
-# ---------------------------------------------------------------------------
-# WorkflowSummary new fields
-# ---------------------------------------------------------------------------
 
 
 def _make_summary(**kwargs: object) -> WorkflowSummary:
@@ -123,11 +103,6 @@ class TestWorkflowSummaryFields:
         assert summary.pr_number == 42
         assert summary.pr_title == "Fix: broken tests"
         assert summary.pr_comment_count == 5
-
-
-# ---------------------------------------------------------------------------
-# WorkflowDetailResponse new fields
-# ---------------------------------------------------------------------------
 
 
 class TestWorkflowDetailResponseFields:

--- a/tests/unit/services/test_classifier.py
+++ b/tests/unit/services/test_classifier.py
@@ -250,9 +250,6 @@ class TestFilterComments:
         assert len(result) == 1
 
 
-# --- Task 2: LLM classification, filtering, grouping ---
-
-
 def _make_classification(
     comment_id: int,
     category: CommentCategory = CommentCategory.BUG,

--- a/tests/unit/services/test_github_pr.py
+++ b/tests/unit/services/test_github_pr.py
@@ -12,11 +12,6 @@ from amelia.core.types import PRAutoFixConfig, PRReviewComment, PRSummary
 from amelia.services.github_pr import AMELIA_FOOTER, GitHubPRService
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _make_mock_process(
     stdout: str = "",
     stderr: str = "",
@@ -32,10 +27,6 @@ def _make_mock_process(
     proc.wait = AsyncMock()
     return proc
 
-
-# ---------------------------------------------------------------------------
-# Sample data
-# ---------------------------------------------------------------------------
 
 _NOW = datetime(2026, 3, 13, 12, 0, 0, tzinfo=UTC)
 
@@ -141,11 +132,6 @@ _GRAPHQL_THREADS = {
 }
 
 
-# ---------------------------------------------------------------------------
-# GHAPI-01: Fetch unresolved review comments
-# ---------------------------------------------------------------------------
-
-
 async def test_fetch_review_comments_returns_unresolved(
     service: GitHubPRService,
 ) -> None:
@@ -175,9 +161,7 @@ async def test_fetch_review_comments_returns_unresolved(
         assert c.thread_id is not None
 
 
-# ---------------------------------------------------------------------------
 # GHAPI-01b: New context fields (original_line, start_line, side, subject_type)
-# ---------------------------------------------------------------------------
 
 
 async def test_fetch_review_comments_captures_context_fields(
@@ -299,11 +283,6 @@ async def test_fetch_review_comments_outdated_line_preserved(
     assert c.original_line == 15  # preserved despite line being null
 
 
-# ---------------------------------------------------------------------------
-# GHAPI-05: Skip self-authored and ignored comments
-# ---------------------------------------------------------------------------
-
-
 async def test_fetch_review_comments_skips_self_and_ignored(
     service: GitHubPRService,
 ) -> None:
@@ -329,11 +308,6 @@ async def test_fetch_review_comments_skips_self_and_ignored(
     # Comments 100, 103 should remain (unresolved, not skipped)
     assert 100 in comment_ids
     assert 103 in comment_ids
-
-
-# ---------------------------------------------------------------------------
-# GHAPI-02: List open PRs
-# ---------------------------------------------------------------------------
 
 
 async def test_list_open_prs(service: GitHubPRService) -> None:
@@ -366,11 +340,6 @@ async def test_list_open_prs(service: GitHubPRService) -> None:
     assert prs[1].number == 2
 
 
-# ---------------------------------------------------------------------------
-# GHAPI-03: Resolve thread
-# ---------------------------------------------------------------------------
-
-
 async def test_resolve_thread(service: GitHubPRService) -> None:
     """resolve_thread sends correct GraphQL mutation."""
     proc = _make_mock_process(
@@ -390,11 +359,6 @@ async def test_resolve_thread(service: GitHubPRService) -> None:
     # threadId should be passed
     arg_str = " ".join(str(a) for a in args)
     assert "PRRT_thread1" in arg_str
-
-
-# ---------------------------------------------------------------------------
-# GHAPI-04: Reply to comment
-# ---------------------------------------------------------------------------
 
 
 async def test_reply_to_comment(service: GitHubPRService) -> None:
@@ -436,11 +400,6 @@ async def test_reply_to_comment_uses_parent_id(service: GitHubPRService) -> None
     assert "/comments/100/replies" in arg_str
 
 
-# ---------------------------------------------------------------------------
-# GHAPI-05: _should_skip_comment
-# ---------------------------------------------------------------------------
-
-
 def test_should_skip_comment_footer_match(service: GitHubPRService) -> None:
     """Comment with Amelia footer should be skipped."""
     assert service._should_skip_comment(
@@ -465,11 +424,6 @@ def test_should_skip_comment_ignore_list(service: GitHubPRService) -> None:
     ) is False
 
 
-# ---------------------------------------------------------------------------
-# Error handling
-# ---------------------------------------------------------------------------
-
-
 async def test_gh_command_failure_raises_valueerror(
     service: GitHubPRService,
 ) -> None:
@@ -485,11 +439,6 @@ async def test_gh_command_failure_raises_valueerror(
         pytest.raises(ValueError, match="HTTP 404"),
     ):
         await service.list_open_prs()
-
-
-# ---------------------------------------------------------------------------
-# PRAutoFixConfig ignore_authors tests
-# ---------------------------------------------------------------------------
 
 
 def test_prautofix_config_ignore_authors_default() -> None:

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -71,7 +71,6 @@ class TestGenerate:
         assert result == "Test response from model"
         assert session_id is None
 
-        # Verify create_deep_agent was called correctly
         mock_deepagents_filesystem.create_deep_agent.assert_called_once()
         call_kwargs = mock_deepagents_filesystem.create_deep_agent.call_args.kwargs
         assert call_kwargs["system_prompt"] == "You are a helpful assistant"
@@ -93,7 +92,6 @@ class TestGenerate:
         assert result.message == "parsed response"
         assert session_id is None
 
-        # Verify response_format was passed to create_deep_agent with correct schema
         call_kwargs = mock_deepagents_filesystem.create_deep_agent.call_args.kwargs
         assert "response_format" in call_kwargs
         response_format = call_kwargs["response_format"]
@@ -214,7 +212,6 @@ class TestExecuteAgentic:
         async for msg in driver.execute_agentic(prompt="test", cwd="/test/path"):
             collected.append(msg)
 
-        # List content yields THINKING, plain string only yields RESULT at end
         thinking_msgs = [m for m in collected if m.type == AgenticMessageType.THINKING]
         result_msgs = [m for m in collected if m.type == AgenticMessageType.RESULT]
 
@@ -367,7 +364,6 @@ class TestLocalSandbox:
         """
         sandbox = LocalSandbox(root_dir=str(tmp_path), virtual_mode=True)
 
-        # Test that write() puts file under cwd, not at filesystem root
         result = sandbox.write("/docs/plans/test.md", "# Test Plan")
         assert result.error is None
         assert result.path == "/docs/plans/test.md"
@@ -385,7 +381,6 @@ class TestLocalSandbox:
         """virtual_mode=True should read files relative to cwd."""
         sandbox = LocalSandbox(root_dir=str(tmp_path), virtual_mode=True)
 
-        # Create a file under cwd
         (tmp_path / "subdir").mkdir()
         (tmp_path / "subdir" / "file.txt").write_text("content here")
 
@@ -516,14 +511,12 @@ class TestExecuteAgenticYieldsAgenticMessage:
 
         results = [msg async for msg in api_driver.execute_agentic("test prompt", cwd="/test/path")]
 
-        # Should have all types
         types = [m.type for m in results]
         assert AgenticMessageType.THINKING in types
         assert AgenticMessageType.TOOL_CALL in types
         assert AgenticMessageType.TOOL_RESULT in types
         assert AgenticMessageType.RESULT in types
 
-        # All should be AgenticMessage instances
         assert all(isinstance(m, AgenticMessage) for m in results)
 
 
@@ -560,18 +553,14 @@ class TestIncompleteTaskDetection:
             {"messages": [final_msg]},
         ]
 
-        # Patch logger to capture warning calls
         with patch("amelia.drivers.api.deepagents.logger") as mock_logger:
             results = [msg async for msg in api_driver.execute_agentic("test prompt", cwd="/test/path")]
 
-        # Should have yielded the result
         result_msgs = [m for m in results if m.type == AgenticMessageType.RESULT]
         assert len(result_msgs) == 1
 
-        # Should have logged warning about incomplete tasks
         warning_calls = mock_logger.warning.call_args_list
         assert len(warning_calls) >= 1
-        # Check that at least one warning mentions premature termination
         # Access the actual message from the call args (first positional argument)
         warning_messages = [call.args[0] if call.args else "" for call in warning_calls]
         assert any("premature termination" in msg for msg in warning_messages)
@@ -600,15 +589,12 @@ class TestIncompleteTaskDetection:
             {"messages": [final_msg]},
         ]
 
-        # Patch logger to capture warning calls
         with patch("amelia.drivers.api.deepagents.logger") as mock_logger:
             results = [msg async for msg in api_driver.execute_agentic("test prompt", cwd="/test/path")]
 
-        # Should have yielded the result
         result_msgs = [m for m in results if m.type == AgenticMessageType.RESULT]
         assert len(result_msgs) == 1
 
-        # Should NOT have logged warning about incomplete tasks (no premature termination warning)
         warning_calls = mock_logger.warning.call_args_list
         # Access the actual message from the call args (first positional argument)
         warning_messages = [call.args[0] if call.args else "" for call in warning_calls]
@@ -640,15 +626,12 @@ class TestIncompleteTaskDetection:
             {"messages": [final_msg]},
         ]
 
-        # Patch logger to capture warning calls
         with patch("amelia.drivers.api.deepagents.logger") as mock_logger:
             results = [msg async for msg in api_driver.execute_agentic("test prompt", cwd="/test/path")]
 
-        # Should have yielded the result
         result_msgs = [m for m in results if m.type == AgenticMessageType.RESULT]
         assert len(result_msgs) == 1
 
-        # Should have logged warning about no write_file
         warning_calls = mock_logger.warning.call_args_list
         # Access the actual message from the call args (first positional argument)
         warning_messages = [call.args[0] if call.args else "" for call in warning_calls]

--- a/tests/unit/test_claude_driver.py
+++ b/tests/unit/test_claude_driver.py
@@ -24,11 +24,6 @@ from amelia.drivers.cli.claude import (
 from amelia.drivers.cli.utils import strip_markdown_fences
 
 
-# =============================================================================
-# Test Models
-# =============================================================================
-
-
 class _TestModel(BaseModel):
     reasoning: str
     answer: str
@@ -38,14 +33,10 @@ class _TestListModel(BaseModel):
     tasks: list[str]
 
 
-# =============================================================================
-# Mock SDK Types
-#
 # These classes mock claude-agent-sdk types for testing without requiring
 # the actual SDK. They mirror the structure of:
 # - TextBlock, ToolUseBlock, ToolResultBlock (content blocks)
 # - AssistantMessage, ResultMessage (message types)
-# =============================================================================
 
 
 class MockTextBlock:
@@ -133,11 +124,6 @@ def _patch_sdk_types() -> contextlib.AbstractContextManager[None]:
     )
 
 
-# =============================================================================
-# Test Fixtures and Helpers
-# =============================================================================
-
-
 @pytest.fixture
 def driver() -> ClaudeCliDriver:
     return ClaudeCliDriver()
@@ -188,11 +174,6 @@ def create_mock_sdk_client(messages: list[Any]) -> MagicMock:
     mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
     return mock_class
-
-
-# =============================================================================
-# Test Classes
-# =============================================================================
 
 
 class TestClaudeCliDriverGenerate:

--- a/tests/unit/trajectory/test_recorder.py
+++ b/tests/unit/trajectory/test_recorder.py
@@ -32,7 +32,7 @@ async def test_recorder_assembles_valid_trajectory(tmp_path):
     assert data["steps"][0]["observation"]["results"][0]  # parent step references the subagent
     assert data["extra"]["outcome"]["status"] == "completed"
     assert data["final_metrics"]["total_cost_usd"] == 0.01
-    assert validate_trajectory(data)  # harbor validator entry point from Task 0
+    assert validate_trajectory(data)
 
 
 async def test_finalize_is_atomic_and_drains_open_invocation(tmp_path):


### PR DESCRIPTION
## Summary

Codebase-wide sweep removing redundant, stale, and excessive code comments. **Comment deletions only** — zero changes to code, strings, docstrings/JSDoc, or formatting. The 25 insertions across the diff are all code lines whose trailing inline comment was stripped (e.g. `const MAX_RECONNECT_DELAY = 30000; // 30 seconds` → `const MAX_RECONNECT_DELAY = 30000;`).

**Net: 229 files changed, ~2327 comment lines removed.**

Base branch is `feat/atif-trajectory-logging` (not `main`) because PR #626 is still open — this keeps the cleanup over the new trajectory code conflict-free.

## Deletions by area

| Area | Commit | Files | ~Comment lines |
|------|--------|-------|----------------|
| `amelia/pipelines/`, `amelia/trajectory/` | `55652e47` | 11 | 109 |
| `amelia/server/` | `e7f1d207` | 32 | 352 |
| rest of backend (`agents/ core/ drivers/ services/ sandbox/ tools/ knowledge/ cli/ client/`) | `4a6570a4` | 39 | 256 |
| `tests/` | `b0d1fe94` | 38 | 797 |
| `dashboard/src/` | `7bcab9b8` | 109 | 813 |

Categories removed: narration (the bulk), section-divider/banner-box structure, change-log/reviewer-talk (`# Phase 09-01 Task 2`, `// Re-export all types from Plan 08 Task 8`), type narration, and a couple of duplicated-adjacent-literal comments.

## Kept by policy

- All docstrings and JSDoc on exported symbols (untouched).
- "Why"/constraint/invariant/ordering/workaround comments (path-traversal checks, `os.replace` atomicity, abort-race guards, reconnect-backoff math, CSV-injection note, StrictMode-dedup test intent, etc.).
- Tooling directives (`# noqa`, `# type: ignore`, `// eslint-disable`, `// @ts-expect-error`, triple-slash references), shebangs, license headers.
- All `TODO`/`FIXME`/`HACK` markers (none were found in any scope — see below).

## TODO/FIXME/HACK inventory

**None found** in any swept area (`amelia/`, `tests/`, `dashboard/src/`).

## Stale comments flagged (deleted, not rewritten)

Two stale comments removed; the constraints they tried to express still hold in the code below them:

- `amelia/pipelines/nodes.py` (~L226, `call_reviewer_node`): comment named `get_current_commit`, but the call there is `_resolve_commit`.
- `amelia/pipelines/pr_auto_fix/orchestrator.py` (`_run_fix_cycle` metrics loop): `# … -- Pitfall 3` reviewer-talk; the per-comment counting it described remains correctly implemented by the loop.

## Verification (all green)

- `uv run ruff check amelia tests` — passed
- `uv run mypy amelia` — Success, 181 files
- `uv run pytest` — 2448 passed, 388 deselected
- `uv run pytest -m integration tests/integration/` — 330 passed, 2 skipped
- `cd dashboard && pnpm build` — ✓ built; (`pnpm lint`/`type-check`/`test:run` 904 passed during Task 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
