### PR TITLE
chore(release): 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-10
+
 ### Changed
 
-- **dashboard:** Migrate to Vite 8 / Rolldown — replace `rollupOptions.output.manualChunks` (function form) with `rolldownOptions.output.codeSplitting.groups` for vendor chunk splitting ([f7c794a](https://github.com/existential-birds/amelia/commit/f7c794a1))
+- **Breaking:** Replace the `workflow_log` / `token_usage` database stores with canonical ATIF-v1.7 trajectory files as the single persistent record of every implementation and PR auto-fix run — serving run history, fine-tuning export (via the harbor CLI), and configuration benchmarking. Trajectories are written to `{trajectory_dir}/{workflow_id}/trajectory.json`; new thin index columns (`trajectory_path`, `total_cost_usd`, `total_tokens`, `total_duration_ms`) are added to `workflows`. The persisted event stream is removed in favor of a bounded in-memory ring buffer (last 1000 events) for WebSocket reconnect backfill ([#626](https://github.com/existential-birds/amelia/pull/626))
+
+  **Migration:** Migration 016 drops the `workflow_log` and `token_usage` tables — historical run-history and token-usage rows are not carried forward. The dashboard wire format (`WorkflowEvent`) is unchanged, so no frontend changes are required. New runs are recorded as trajectory files going forward.
+
+- **dashboard:** Migrate chunk splitting to Vite 8 / Rolldown — replace `rollupOptions.output.manualChunks` (function form) with `rolldownOptions.output.codeSplitting.groups` for vendor chunk splitting ([#624](https://github.com/existential-birds/amelia/pull/624))
+
+### Fixed
+
+- **dashboard:** Resolve Vite 8 deprecation warnings ([#623](https://github.com/existential-birds/amelia/pull/623))
 
 ## [0.22.0] - 2026-06-07
 
@@ -588,7 +598,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FastAPI server with WebSocket support
 - React dashboard for workflow visualization
 
-[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/existential-birds/amelia/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/existential-birds/amelia/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/existential-birds/amelia/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/existential-birds/amelia/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/existential-birds/amelia/compare/v0.20.0...v0.20.1

--- a/amelia/__init__.py
+++ b/amelia/__init__.py
@@ -8,7 +8,7 @@ Exports:
     __version__: Package version string.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 __all__ = [
     "__version__",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amelia-dashboard",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amelia"
-version = "0.22.0"
+version = "0.23.0"
 description = "A local agentic coding system with configurable profiles."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "amelia"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- Bump version to 0.23.0
- Update CHANGELOG.md with changes since v0.22.0

### Highlights

- **Breaking:** Run-history storage replaced with ATIF-v1.7 trajectory logging — `workflow_log` / `token_usage` tables dropped (migration 016), event stream now an in-memory ring buffer ([#626](https://github.com/existential-birds/amelia/pull/626))
- **dashboard:** Vite 8 / Rolldown chunk-splitting migration ([#624](https://github.com/existential-birds/amelia/pull/624)) and deprecation-warning fixes ([#623](https://github.com/existential-birds/amelia/pull/623))

## Post-merge steps

After merging, run:
\`\`\`
/release-tag 0.23.0
\`\`\`

---

Generated with [Claude Code](https://claude.com/claude-code)