### PR TITLE
docs(readme): trim architectural overview now hosted on project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 [Amelia](https://en.wikipedia.org/wiki/Amelia_Earhart) is multi-agent orchestration for software development with human-in-the-loop approval gates and end-to-end observability.
 
-- **Multiple LLM drivers** — OpenRouter API, Claude CLI, or Codex CLI with per-agent model configuration
-- **CLI + Real-time dashboard** — monitor workflows, review plans, track costs, and manage configuration
-- **Workflow queueing** — queue issues, batch-generate plans, and control execution
-- **Sandbox execution** — run agents locally, in Docker, or in cloud sandboxes (Daytona.io)
-- **(Next) Issue tracker integration** — work from GitHub or Jira issues directly
+This README covers installation and the CLI reference. For the architecture, design decisions, and full capability overview — drivers, dashboard, queueing, sandbox execution, and issue-tracker integration — see the **[project page](https://existentialbirds.com/projects/amelia)**.
 
 ## Prerequisites
 
@@ -58,7 +54,7 @@ In another terminal:
 
 ```bash
 cd my-app
-amelia start --task "Create a Python CLI that fetches weather for a city using wttr.in"
+amelia start --title "Create a Python CLI that fetches weather for a city using wttr.in"
 ```
 
 The Architect agent creates a plan. Open the dashboard at `localhost:8420` to review and approve it. Once approved, the Developer agent implements the code.
@@ -92,17 +88,11 @@ cd /path/to/your/project
 ```
 
 > [!NOTE]
-> Run commands from your project root—agents can't help with code they can't see. Configuration is stored in `~/.amelia/amelia.db` and shared across all projects.
+> Run commands from your project root—agents can't help with code they can't see. Configuration is stored in PostgreSQL and shared across all projects.
 
 ## How It Works
 
-Amelia orchestrates three specialized agents through a LangGraph state machine:
-
-- **Architect** — reads the issue and produces a step-by-step implementation plan
-- **Developer** — executes the plan, writing code and running commands
-- **Reviewer** — reviews the Developer's changes and requests fixes if needed
-
-See the [documentation](https://existentialbirds.com/projects/amelia) for architecture and concepts details.
+Amelia runs your task through specialized agents (Architect → Developer → Reviewer) on a LangGraph state machine, pausing at approval gates you control. See the **[project page](https://existentialbirds.com/projects/amelia)** for the full architecture and design decisions.
 
 ## CLI Commands
 
@@ -118,7 +108,7 @@ See the [documentation](https://existentialbirds.com/projects/amelia) for archit
 | Command | Description |
 |---------|-------------|
 | `amelia start 123` | Start workflow for issue #123 |
-| `amelia start --task "desc"` | Run ad-hoc task without issue tracker |
+| `amelia start --title "desc"` | Run ad-hoc task without issue tracker |
 | `amelia start 123 --queue` | Queue workflow for later execution |
 | `amelia run abc-123` | Start a queued workflow |
 | `amelia status` | Show active workflows |
@@ -136,9 +126,7 @@ See the **[documentation](https://existentialbirds.com/projects/amelia)** for th
 
 ## Configuration
 
-Configuration is stored in PostgreSQL and managed via CLI (`amelia config`) or the dashboard at `localhost:8420/settings`.
-
-See the [documentation](https://existentialbirds.com/projects/amelia) for profile setup, server settings, and Jira integration.
+Profiles and server settings are managed via the `amelia config` CLI or the dashboard at `localhost:8420/settings`. See the **[project page](https://existentialbirds.com/projects/amelia)** for profile setup, per-agent model routing, and Jira integration.
 
 ## License
 


### PR DESCRIPTION
## Summary

Trims the conceptual/architectural material from the README that is now duplicated on the project doc-home page at [existentialbirds.com/projects/amelia](https://existentialbirds.com/projects/amelia), keeping the README focused on installation and the CLI reference. Also fixes two factual errors uncovered while verifying the sections we kept.

## Changes

### Changed
- Condensed the intro feature bullets to a one-line summary + link to the project page
- Condensed **How It Works** (Architect → Developer → Reviewer / LangGraph state machine) to a one-line summary + link
- Condensed the **Configuration** prose, keeping the practical "managed via `amelia config` or dashboard" pointer and dropping infra detail covered on the site

### Fixed
- `amelia start --task` → `--title` — the actual Typer flag (`amelia/client/cli.py:103`); was wrong in both the quickstart and the CLI table
- "Run from Source" note claimed config lives in `~/.amelia/amelia.db` (SQLite); storage is PostgreSQL (`server/config.py:37`)

Net: README.md drops from 146 to 134 lines (6 insertions, 18 deletions).

## Motivation

The Existential Birds site now hosts the "what/why/how it works" narrative for Amelia. Keeping the same prose in the README means two places to maintain and drift between. This makes the README task-focused (install + CLI) and points to the canonical page for the conceptual material.

## Testing

Docs-only change (Markdown). Verified by fanning out two read-only exploration passes over the codebase before editing:

- Confirmed every command in the CLI tables exists with the documented behavior/flags
- Confirmed Python 3.12+, the `api`/`claude`/`codex` driver names, `OPENROUTER_API_KEY`, the `amelia` entry point, and port 8420
- Surfaced and fixed the `--title` and PostgreSQL discrepancies above
- Re-read the final README end-to-end and grepped for remaining `--task` / `amelia.db` references (none)

- [x] Manual review performed
- [ ] Unit/integration tests — n/a (docs-only)

## Related Issues

- Closes #615

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated