### PR TITLE
fix(orchestrator): validate reject_workflow status inside approval lock

### DIFF
--- a/amelia/server/orchestrator/service.py
+++ b/amelia/server/orchestrator/service.py
@@ -1103,18 +1103,18 @@ class OrchestratorService:
             WorkflowNotFoundError: If workflow doesn't exist.
             InvalidStateError: If workflow is not in "blocked" state.
         """
-        workflow = await self._repository.get(workflow_id)
-        if not workflow:
-            raise WorkflowNotFoundError(workflow_id)
-
-        if workflow.workflow_status != WorkflowStatus.BLOCKED:
-            raise InvalidStateError(
-                f"Cannot reject workflow in '{workflow.workflow_status}' state",
-                workflow_id=workflow_id,
-                current_status=workflow.workflow_status,
-            )
-
         async with self._approval_lock:
+            workflow = await self._repository.get(workflow_id)
+            if not workflow:
+                raise WorkflowNotFoundError(workflow_id)
+
+            if workflow.workflow_status != WorkflowStatus.BLOCKED:
+                raise InvalidStateError(
+                    f"Cannot reject workflow in '{workflow.workflow_status}' state",
+                    workflow_id=workflow_id,
+                    current_status=workflow.workflow_status,
+                )
+
             await self._repository.set_status(
                 workflow_id, WorkflowStatus.FAILED, failure_reason=feedback
             )

--- a/tests/unit/server/orchestrator/test_service.py
+++ b/tests/unit/server/orchestrator/test_service.py
@@ -575,6 +575,52 @@ async def test_reject_finalizes_recorder_and_forgets_sequence(
     assert wf_id not in orchestrator._events._sequence_counters
 
 
+async def test_reject_workflow_revalidates_status_inside_lock(
+    orchestrator: OrchestratorService,
+    mock_repository: AsyncMock,
+) -> None:
+    """A status change during reject's lock-wait must abort the rejection.
+
+    Reproduces the approve/reject race: reject reads BLOCKED, then another
+    approval transitions the workflow to IN_PROGRESS before reject acquires
+    the approval lock. reject must re-validate inside the lock and refuse —
+    never overwrite a no-longer-blocked workflow to FAILED.
+    """
+    state = ServerExecutionState(
+        id=uuid4(),
+        issue_id="ISSUE-123",
+        worktree_path="/path/to/worktree",
+        workflow_status=WorkflowStatus.BLOCKED,
+        started_at=datetime.now(UTC),
+        profile_id="test",
+    )
+    mock_repository.get.return_value = state
+
+    # Hold the approval lock so reject is forced to wait after entering it.
+    await orchestrator._approval_lock.acquire()
+    reject_task = asyncio.create_task(
+        orchestrator.reject_workflow(state.id, feedback="too complex")
+    )
+    # Let reject run up to the lock acquisition and block there.
+    await asyncio.sleep(0)
+
+    # Simulate a concurrent approval that transitioned the workflow.
+    state.workflow_status = WorkflowStatus.IN_PROGRESS
+
+    # Release the lock so reject proceeds and re-validates.
+    orchestrator._approval_lock.release()
+
+    with pytest.raises(InvalidStateError):
+        await reject_task
+
+    # The decisive assertion: FAILED was never written.
+    assert not any(
+        call.args[1:2] == (WorkflowStatus.FAILED,)
+        or WorkflowStatus.FAILED in call.args
+        for call in mock_repository.set_status.call_args_list
+    )
+
+
 async def test_start_review_workflow_registers_recorder(
     orchestrator: OrchestratorService,
     valid_worktree: str,


### PR DESCRIPTION
## Summary

Closes a TOCTOU window in `OrchestratorService.reject_workflow` where a concurrent approval could transition a workflow out of `BLOCKED` before reject acquired the approval lock — causing reject to silently overwrite an approved, executing workflow to `FAILED`.

## Changes

### Fixed
- Moved the `repository.get()` call and both guard clauses (`WorkflowNotFoundError` and `InvalidStateError`) inside the `_approval_lock` block in `reject_workflow`, matching the pattern already used by `approve_workflow` and `replan_workflow`. The status is now re-validated after the lock is held.

### Added
- `test_reject_workflow_revalidates_status_inside_lock` — drives the race by pre-acquiring the approval lock, mutating the workflow status to `IN_PROGRESS` while reject waits, then asserting `InvalidStateError` is raised and that `FAILED` is never written.

## Motivation

`reject_workflow` previously read and validated the workflow status *before* acquiring `_approval_lock`. Between that read and the lock acquisition, a concurrent `approve_workflow` could move the workflow to `IN_PROGRESS`. Reject would then proceed under the lock and overwrite the now-executing workflow to `FAILED`, losing the approval.

## Testing

- [x] Unit tests added/updated
- [x] Tests pass locally (`uv run pytest tests/unit/server/orchestrator/test_service.py` — 41 passed; full pre-push suite: 2465 passed)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes