### PR TITLE
perf(drivers): cache ApiDriver chat model + HTTP client (#642)

### DIFF
--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -211,10 +211,12 @@ class ApiDriver(DriverInterface):
         # per (provider, model, base_url, api_key_env_var) so back-to-back calls
         # reuse the HTTP connection instead of doing a fresh TCP+TLS handshake.
         self._chat_model: BaseChatModel | None = None
-        # Memoized non-agentic generate() agents keyed by (system_prompt, schema).
+        # Memoized non-agentic generate() agents keyed by (system_prompt, schema, backend_root).
         # The generate() tool set is fixed, so the LangGraph graph is built once
-        # per distinct (system_prompt, schema) rather than rebuilt on every call.
-        self._generate_agents: dict[tuple[str, type[BaseModel] | None], Any] = {}
+        # per distinct generate backend config rather than rebuilt on every call.
+        self._generate_agents: dict[
+            tuple[str, type[BaseModel] | None, str], Any
+        ] = {}
 
     def _get_chat_model(self) -> BaseChatModel:
         """Return the cached chat model, building it once on first use.
@@ -292,16 +294,15 @@ class ApiDriver(DriverInterface):
             chat_model = self._get_chat_model()
 
             # The generate() tool set is fixed, so memoize the built agent per
-            # (system_prompt, schema) instead of rebuilding the LangGraph graph
+            # (system_prompt, schema, backend root) instead of rebuilding the LangGraph graph
             # (and rebinding tools) on every call.
             effective_system_prompt = system_prompt or ""
-            agent_key = (effective_system_prompt, schema)
+            backend_root = self.cwd or "."
+            agent_key = (effective_system_prompt, schema, backend_root)
             agent = self._generate_agents.get(agent_key)
             if agent is None:
                 # Use FilesystemBackend for non-agentic generation - no shell execution needed
-                backend = FilesystemBackend(
-                    root_dir=self.cwd or ".", virtual_mode=False
-                )
+                backend = FilesystemBackend(root_dir=backend_root, virtual_mode=False)
 
                 agent_kwargs: dict[str, Any] = {
                     "model": chat_model,

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -20,6 +20,7 @@ from deepagents.backends.protocol import (
 )
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ToolStrategy
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
 from loguru import logger
@@ -206,6 +207,33 @@ class ApiDriver(DriverInterface):
         self.api_key_env_var = api_key_env_var
         self.cwd = cwd
         self._usage: DriverUsage | None = None
+        # Cached chat model (and its underlying httpx/openai client) built once
+        # per (provider, model, base_url, api_key_env_var) so back-to-back calls
+        # reuse the HTTP connection instead of doing a fresh TCP+TLS handshake.
+        self._chat_model: BaseChatModel | None = None
+        # Memoized non-agentic generate() agents keyed by (system_prompt, schema).
+        # The generate() tool set is fixed, so the LangGraph graph is built once
+        # per distinct (system_prompt, schema) rather than rebuilt on every call.
+        self._generate_agents: dict[tuple[str, type[BaseModel] | None], Any] = {}
+
+    def _get_chat_model(self) -> BaseChatModel:
+        """Return the cached chat model, building it once on first use.
+
+        Reuses the underlying HTTP client across calls. The missing-API-key
+        error still surfaces on first construction; the key rarely changes
+        within a process, so caching the model afterward is safe.
+
+        Returns:
+            The cached :class:`BaseChatModel` for this driver's provider config.
+        """
+        if self._chat_model is None:
+            self._chat_model = _create_chat_model(
+                self.model,
+                provider=self.provider,
+                base_url=self.base_url,
+                api_key_env_var=self.api_key_env_var,
+            )
+        return self._chat_model
 
     @classmethod
     def _sessions_lock_for_loop(cls) -> asyncio.Lock:
@@ -261,24 +289,30 @@ class ApiDriver(DriverInterface):
             raise ValueError("Prompt cannot be empty")
 
         try:
-            chat_model = _create_chat_model(
-                self.model,
-                provider=self.provider,
-                base_url=self.base_url,
-                api_key_env_var=self.api_key_env_var,
-            )
-            # Use FilesystemBackend for non-agentic generation - no shell execution needed
-            backend = FilesystemBackend(root_dir=self.cwd or ".", virtual_mode=False)
+            chat_model = self._get_chat_model()
 
-            agent_kwargs: dict[str, Any] = {
-                "model": chat_model,
-                "system_prompt": system_prompt or "",
-                "backend": backend,
-            }
-            if schema:
-                agent_kwargs["response_format"] = ToolStrategy(schema=schema)
+            # The generate() tool set is fixed, so memoize the built agent per
+            # (system_prompt, schema) instead of rebuilding the LangGraph graph
+            # (and rebinding tools) on every call.
+            effective_system_prompt = system_prompt or ""
+            agent_key = (effective_system_prompt, schema)
+            agent = self._generate_agents.get(agent_key)
+            if agent is None:
+                # Use FilesystemBackend for non-agentic generation - no shell execution needed
+                backend = FilesystemBackend(
+                    root_dir=self.cwd or ".", virtual_mode=False
+                )
 
-            agent = create_deep_agent(**agent_kwargs)
+                agent_kwargs: dict[str, Any] = {
+                    "model": chat_model,
+                    "system_prompt": effective_system_prompt,
+                    "backend": backend,
+                }
+                if schema:
+                    agent_kwargs["response_format"] = ToolStrategy(schema=schema)
+
+                agent = create_deep_agent(**agent_kwargs)
+                self._generate_agents[agent_key] = agent
 
             result = await agent.ainvoke({"messages": [HumanMessage(content=prompt)]})
 
@@ -437,12 +471,7 @@ class ApiDriver(DriverInterface):
         seen_message_ids: set[int] = set()
 
         try:
-            chat_model = _create_chat_model(
-                self.model,
-                provider=self.provider,
-                base_url=self.base_url,
-                api_key_env_var=self.api_key_env_var,
-            )
+            chat_model = self._get_chat_model()
             # virtual_mode=True ensures paths like "docs/plans/..." resolve relative
             # to cwd (e.g., /project/docs/plans/...) rather than being treated as
             # absolute paths from filesystem root (e.g., /docs/plans/...)

--- a/tests/unit/drivers/test_chat_model_cache.py
+++ b/tests/unit/drivers/test_chat_model_cache.py
@@ -1,0 +1,134 @@
+"""Tests for ApiDriver chat-model / HTTP-client caching (issue #642).
+
+These exercise the observable consequence: the chat model (and its underlying
+HTTP client) is built once per (provider, model, base_url, api_key_env_var) and
+reused across back-to-back calls, rather than rebuilt on every request. The
+key-missing error path must still raise clearly.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from amelia.drivers.api.deepagents import ApiDriver
+
+
+class TestChatModelInstanceCache:
+    """Cached chat model is reused across same-config generate() calls."""
+
+    async def test_generate_builds_chat_model_once_for_repeated_calls(
+        self, mock_deepagents_filesystem: MagicMock
+    ) -> None:
+        """_create_chat_model is invoked once across N same-config generate calls."""
+        driver = ApiDriver(model="test/model", cwd="/test", provider="openrouter")
+        mock_deepagents_filesystem.agent_result["messages"] = [
+            AIMessage(content="response")
+        ]
+
+        with patch(
+            "amelia.drivers.api.deepagents._create_chat_model"
+        ) as mock_create:
+            sentinel_model = MagicMock(name="chat_model")
+            mock_create.return_value = sentinel_model
+
+            await driver.generate(prompt="one")
+            await driver.generate(prompt="two")
+            await driver.generate(prompt="three")
+
+            assert mock_create.call_count == 1
+
+    async def test_distinct_configs_build_agents_with_their_cached_models(
+        self, mock_deepagents_filesystem: MagicMock
+    ) -> None:
+        """Each distinct generate config receives the driver's cached chat model."""
+        driver = ApiDriver(model="test/model", cwd="/test", provider="openrouter")
+        mock_deepagents_filesystem.agent_result["messages"] = [
+            AIMessage(content="response")
+        ]
+
+        with patch(
+            "amelia.drivers.api.deepagents._create_chat_model"
+        ) as mock_create:
+            sentinel_model = MagicMock(name="chat_model")
+            mock_create.return_value = sentinel_model
+
+            # Two distinct system prompts -> two agent builds, one cached model.
+            await driver.generate(prompt="one", system_prompt="sys-a")
+            await driver.generate(prompt="two", system_prompt="sys-b")
+
+            models_passed = [
+                call.kwargs["model"]
+                for call in mock_deepagents_filesystem.create_deep_agent.call_args_list
+            ]
+            assert mock_create.call_count == 1
+            assert len(models_passed) == 2
+            assert models_passed[0] is sentinel_model
+            assert models_passed[1] is sentinel_model
+
+    async def test_generate_and_execute_agentic_share_cached_model(
+        self, mock_deepagents_both: MagicMock
+    ) -> None:
+        """generate() and execute_agentic() reuse the same cached chat model."""
+        driver = ApiDriver(model="test/model", cwd="/test", provider="openrouter")
+        mock_deepagents_both.agent_result["messages"] = [AIMessage(content="ok")]
+        mock_deepagents_both.stream_chunks = [
+            {"messages": [AIMessage(content="done")]},
+        ]
+
+        with patch(
+            "amelia.drivers.api.deepagents._create_chat_model"
+        ) as mock_create:
+            mock_create.return_value = MagicMock(name="chat_model")
+
+            await driver.generate(prompt="one")
+            async for _ in driver.execute_agentic(prompt="two", cwd="/test"):
+                pass
+
+            assert mock_create.call_count == 1
+
+
+class TestGenerateAgentMemoized:
+    """Non-agentic generate() agent (fixed tool set) is built once and reused."""
+
+    async def test_repeated_generate_builds_agent_once(
+        self, mock_deepagents_filesystem: MagicMock
+    ) -> None:
+        """create_deep_agent runs once across repeated same-config generate calls."""
+        driver = ApiDriver(model="test/model", cwd="/test", provider="openrouter")
+        mock_deepagents_filesystem.agent_result["messages"] = [
+            AIMessage(content="response")
+        ]
+
+        await driver.generate(prompt="one", system_prompt="sys")
+        await driver.generate(prompt="two", system_prompt="sys")
+        await driver.generate(prompt="three", system_prompt="sys")
+
+        assert mock_deepagents_filesystem.create_deep_agent.call_count == 1
+
+    async def test_generate_rebuilds_agent_when_system_prompt_changes(
+        self, mock_deepagents_filesystem: MagicMock
+    ) -> None:
+        """A different system prompt yields a distinct memoized agent."""
+        driver = ApiDriver(model="test/model", cwd="/test", provider="openrouter")
+        mock_deepagents_filesystem.agent_result["messages"] = [
+            AIMessage(content="response")
+        ]
+
+        await driver.generate(prompt="one", system_prompt="sys-a")
+        await driver.generate(prompt="two", system_prompt="sys-b")
+
+        assert mock_deepagents_filesystem.create_deep_agent.call_count == 2
+
+
+class TestKeyMissingStillRaises:
+    """The cached path must not swallow the missing-API-key error."""
+
+    async def test_generate_raises_when_key_missing(
+        self, mock_deepagents_filesystem: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """generate() surfaces a clear error when the API key env var is unset."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        driver = ApiDriver(model="deepseek-chat", cwd="/test", provider="deepseek")
+
+        with pytest.raises(ValueError, match="DEEPSEEK_API_KEY"):
+            await driver.generate(prompt="hi")

--- a/tests/unit/drivers/test_chat_model_cache.py
+++ b/tests/unit/drivers/test_chat_model_cache.py
@@ -119,6 +119,26 @@ class TestGenerateAgentMemoized:
 
         assert mock_deepagents_filesystem.create_deep_agent.call_count == 2
 
+    async def test_generate_rebuilds_agent_when_driver_cwd_changes(
+        self, mock_deepagents_filesystem: MagicMock
+    ) -> None:
+        """A different backend root yields a distinct memoized agent."""
+        driver = ApiDriver(model="test/model", cwd="/test-a", provider="openrouter")
+        mock_deepagents_filesystem.agent_result["messages"] = [
+            AIMessage(content="response")
+        ]
+
+        await driver.generate(prompt="one", system_prompt="sys")
+        driver.cwd = "/test-b"
+        await driver.generate(prompt="two", system_prompt="sys")
+
+        assert mock_deepagents_filesystem.create_deep_agent.call_count == 2
+        roots = [
+            call.kwargs["root_dir"]
+            for call in mock_deepagents_filesystem.backend_class.call_args_list
+        ]
+        assert roots == ["/test-a", "/test-b"]
+
 
 class TestKeyMissingStillRaises:
     """The cached path must not swallow the missing-API-key error."""


### PR DESCRIPTION
## Problem

Both `generate()` and `execute_agentic()` called `_create_chat_model(...)` on every invocation, building a brand-new LangChain `ChatOpenAI` (and a fresh httpx/openai client) per call. That meant no HTTP connection reuse — a fresh TCP+TLS handshake on every request to the OpenAI-compatible/OpenRouter endpoint (default `minimax/minimax-m2`). `generate()` also rebuilt the LangGraph graph and rebound tools every call.

## Change

- Cache the chat model on the `ApiDriver` instance via `_get_chat_model()`, built once per `(provider, model, base_url, api_key_env_var)`. The underlying HTTP client is now reused across `generate()` and `execute_agentic()` calls.
- Memoize the non-agentic `generate()` agent keyed by `(system_prompt, schema)` — its tool set is fixed, so the graph is built once per distinct config instead of on every call.
- Missing-API-key error still surfaces clearly on first construction (the key rarely changes within a process, so caching afterward is safe).

`execute_agentic()`'s per-call agent is intentionally not memoized (tools/middleware/checkpointer vary per call); only the chat model is shared.

## How verified

- `uv run ruff check --fix amelia tests` — clean
- `uv run mypy amelia` — clean (183 files)
- `uv run pytest tests/unit/` — 2447 passed
- Driver integration tests (instantiation, multi-driver) — 15 passed
- New `tests/unit/drivers/test_chat_model_cache.py` asserts observable consequences: `_create_chat_model` invoked once across N same-config `generate()` calls, the cached model shared between `generate()` and `execute_agentic()`, the generate agent built once for repeated same-config calls (and rebuilt when `system_prompt` changes), and the key-missing path still raises.

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH