### PR TITLE
perf(sandbox): long-lived worker to eliminate per-step cold-start (#640)

### DIFF
--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -43,6 +43,7 @@ _WORKER_DEPS = ["deepagents", "pydantic", "loguru", "httpx", "langchain-openai"]
 
 if TYPE_CHECKING:
     from amelia.core.types import DaytonaResources
+    from amelia.sandbox.provider import WorkerProcess
 
 
 class DaytonaSandboxProvider:
@@ -117,6 +118,27 @@ class DaytonaSandboxProvider:
     def worker_env(self) -> dict[str, str]:
         """Environment variables needed by the worker inside the sandbox."""
         return dict(self._worker_env)
+
+    @property
+    def supports_persistent_worker(self) -> bool:
+        """Daytona sessions cannot hold a duplex stdin pipe.
+
+        The driver therefore uses the per-call one-shot worker path for
+        Daytona. (Daytona's dominant cost is network round-trips, not the
+        local import, so the long-lived worker's benefit does not apply.)
+        """
+        return False
+
+    async def spawn_worker(
+        self,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> WorkerProcess:
+        """Not supported — Daytona sessions have no persistent stdin pipe."""
+        raise NotImplementedError(
+            "DaytonaSandboxProvider does not support a persistent worker; "
+            "supports_persistent_worker is False"
+        )
 
     async def _upload_worker(self, sandbox: AsyncSandbox) -> None:
         """Upload the standalone worker.py script into the sandbox."""

--- a/amelia/sandbox/docker.py
+++ b/amelia/sandbox/docker.py
@@ -29,6 +29,14 @@ class DockerWorkerProcess(WorkerProcess):
 
     def __init__(self, proc: asyncio.subprocess.Process) -> None:
         self._proc = proc
+        # Continuously drain stderr so the OS pipe buffer never fills and
+        # deadlocks the worker (same pattern as exec_stream's _drain_stderr).
+        self._stderr_task: asyncio.Task[None] = asyncio.create_task(self._drain_stderr())
+
+    async def _drain_stderr(self) -> None:
+        if self._proc.stderr:
+            async for _ in self._proc.stderr:
+                pass  # discard; we only need the buffer drained
 
     @property
     def alive(self) -> bool:
@@ -60,6 +68,10 @@ class DockerWorkerProcess(WorkerProcess):
         except TimeoutError:
             with contextlib.suppress(ProcessLookupError):
                 self._proc.terminate()
+        if not self._stderr_task.done():
+            self._stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._stderr_task
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(self._proc.wait(), timeout=5.0)
             if self._proc.returncode is None:
@@ -220,8 +232,12 @@ class DockerSandboxProvider(SandboxProvider):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=4 * 1024 * 1024,  # 4 MiB: msg_frame_raw double-encodes JSON, ~2x payload size
         )
         worker = DockerWorkerProcess(proc)
+        # Evict dead handles before tracking the new one so crashed-and-respawned
+        # workers don't accumulate in the list (memory leak + O(N) teardown).
+        self._workers = [w for w in self._workers if w.alive]
         self._workers.append(worker)
         logger.info("Spawned long-lived sandbox worker", container=self.container_name)
         return worker

--- a/amelia/sandbox/docker.py
+++ b/amelia/sandbox/docker.py
@@ -16,7 +16,56 @@ from pathlib import Path
 from loguru import logger
 
 from amelia.sandbox.network import generate_allowlist_rules
-from amelia.sandbox.provider import SandboxProvider
+from amelia.sandbox.provider import SandboxProvider, WorkerProcess
+
+
+class DockerWorkerProcess(WorkerProcess):
+    """Duplex handle to a long-lived ``docker exec -i ... serve`` process.
+
+    The worker imports the heavy stack once at startup; this handle ferries
+    request frames to its stdin and response-frame lines from its stdout. One
+    instance is reused for the whole sandbox lifetime.
+    """
+
+    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+        self._proc = proc
+
+    @property
+    def alive(self) -> bool:
+        return self._proc.returncode is None
+
+    async def write(self, data: bytes) -> None:
+        if self._proc.stdin is None:
+            raise RuntimeError("Worker stdin is not available")
+        self._proc.stdin.write(data)
+        await self._proc.stdin.drain()
+
+    async def readline(self) -> str:
+        if self._proc.stdout is None:
+            raise RuntimeError("Worker stdout is not available")
+        raw = await self._proc.stdout.readline()
+        if not raw:
+            return ""
+        return raw.decode().rstrip("\n")
+
+    async def close(self) -> None:
+        """Close stdin (signals EOF -> clean exit), then ensure termination."""
+        if self._proc.returncode is not None:
+            return
+        if self._proc.stdin is not None:
+            with contextlib.suppress(Exception):
+                self._proc.stdin.close()
+        try:
+            await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                self._proc.terminate()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            if self._proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    self._proc.kill()
+                await self._proc.wait()
 
 
 class DockerSandboxProvider(SandboxProvider):
@@ -47,6 +96,9 @@ class DockerSandboxProvider(SandboxProvider):
 
         self.container_name = f"amelia-sandbox-{profile_name}"
         self.proxy_token = secrets.token_urlsafe(32)
+        # Long-lived worker processes spawned via spawn_worker(), tracked so
+        # teardown() can stop them and avoid leaking docker exec processes.
+        self._workers: list[DockerWorkerProcess] = []
 
     async def ensure_running(self) -> None:
         """Ensure the sandbox container is ready. Start if not running."""
@@ -131,8 +183,55 @@ class DockerSandboxProvider(SandboxProvider):
                 f"{stderr_text}"
             )
 
+    @property
+    def supports_persistent_worker(self) -> bool:
+        """Docker holds a duplex pipe via ``docker exec -i``."""
+        return True
+
+    async def spawn_worker(
+        self,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> DockerWorkerProcess:
+        """Start a long-lived ``serve`` worker via ``docker exec -i``.
+
+        The process imports the heavy stack once and then services many
+        request frames over its stdin. The handle is tracked so teardown()
+        stops it.
+
+        Args:
+            cwd: Working directory inside the container.
+            env: Additional environment variables for the worker.
+
+        Returns:
+            A DockerWorkerProcess wrapping the running serve process.
+        """
+        cmd = ["docker", "exec", "-i", "--user", "vscode"]
+        if cwd:
+            cmd.extend(["--workdir", cwd])
+        if env:
+            for key, value in env.items():
+                cmd.extend(["-e", f"{key}={value}"])
+        cmd.append(self.container_name)
+        cmd.extend([*self.worker_cmd, "serve"])
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        worker = DockerWorkerProcess(proc)
+        self._workers.append(worker)
+        logger.info("Spawned long-lived sandbox worker", container=self.container_name)
+        return worker
+
     async def teardown(self) -> None:
-        """Stop and remove the container."""
+        """Stop and remove the container (and any long-lived workers)."""
+        for w in self._workers:
+            with contextlib.suppress(Exception):
+                await w.close()
+        self._workers.clear()
         proc = await asyncio.create_subprocess_exec(
             "docker", "rm", "-f", self.container_name,
             stdout=asyncio.subprocess.PIPE,

--- a/amelia/sandbox/docker.py
+++ b/amelia/sandbox/docker.py
@@ -57,27 +57,27 @@ class DockerWorkerProcess(WorkerProcess):
         return raw.decode().rstrip("\n")
 
     async def close(self) -> None:
-        """Close stdin (signals EOF -> clean exit), then ensure termination."""
-        if self._proc.returncode is not None:
-            return
-        if self._proc.stdin is not None:
-            with contextlib.suppress(Exception):
-                self._proc.stdin.close()
-        try:
-            await asyncio.wait_for(self._proc.wait(), timeout=5.0)
-        except TimeoutError:
-            with contextlib.suppress(ProcessLookupError):
-                self._proc.terminate()
+        """Close stdin (EOF -> clean exit), escalating to terminate/kill if needed."""
+        if self._proc.returncode is None:
+            if self._proc.stdin is not None:
+                with contextlib.suppress(Exception):
+                    self._proc.stdin.close()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except TimeoutError:
+                with contextlib.suppress(ProcessLookupError):
+                    self._proc.terminate()
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+                except TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        self._proc.kill()
+                    await self._proc.wait()
+        # Always stop the stderr drain task once the process is gone.
         if not self._stderr_task.done():
             self._stderr_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._stderr_task
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
-            if self._proc.returncode is None:
-                with contextlib.suppress(ProcessLookupError):
-                    self._proc.kill()
-                await self._proc.wait()
 
 
 class DockerSandboxProvider(SandboxProvider):

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -1,10 +1,15 @@
 """ContainerDriver — DriverInterface implementation for sandboxed execution.
 
-Delegates LLM execution to a container worker via SandboxProvider.exec_stream().
-The worker runs inside a Docker container and streams AgenticMessage JSON lines.
+Delegates LLM execution to a container worker. When the provider supports a
+persistent worker (e.g. Docker via ``docker exec -i``), a single long-lived
+``serve`` process is spawned once per sandbox and reused across every agent
+call, so the heavy LangChain/deepagents import cost is paid once rather than
+on every call. Providers without a duplex stdin pipe (e.g. Daytona) fall back
+to the per-call one-shot worker path.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from typing import Any
@@ -18,7 +23,85 @@ from amelia.drivers.base import (
     DriverUsage,
     GenerateResult,
 )
-from amelia.sandbox.provider import SandboxProvider
+from amelia.sandbox.protocol import (
+    WorkerRequest,
+    encode_request,
+    parse_frame,
+)
+from amelia.sandbox.provider import SandboxProvider, WorkerProcess
+
+
+class _PersistentWorker:
+    """Owns one long-lived ``serve`` process and dispatches commands to it.
+
+    The worker is spawned lazily on first use and reused for the sandbox's
+    lifetime. Commands are serialized with a lock so frames from concurrent
+    callers never interleave on the shared pipe. A crashed worker is detected
+    (EOF mid-command) and reset so the next command respawns a fresh one.
+    """
+
+    def __init__(
+        self,
+        provider: SandboxProvider,
+        cwd: str | None,
+        env: dict[str, str] | None,
+    ) -> None:
+        self._provider = provider
+        self._cwd = cwd
+        self._env = env
+        self._proc: WorkerProcess | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure(self) -> WorkerProcess:
+        if self._proc is None or not self._proc.alive:
+            self._proc = await self._provider.spawn_worker(cwd=self._cwd, env=self._env)
+        return self._proc
+
+    async def dispatch(self, request: WorkerRequest) -> AsyncIterator[AgenticMessage]:
+        """Send one request and yield its AgenticMessages until ``done``.
+
+        Args:
+            request: The command to run.
+
+        Yields:
+            AgenticMessage objects (including USAGE).
+
+        Raises:
+            RuntimeError: If the worker reports an error or crashes mid-command.
+        """
+        async with self._lock:
+            proc = await self._ensure()
+            await proc.write(encode_request(request))
+            error: str | None = None
+            while True:
+                line = await proc.readline()
+                if not line:
+                    # EOF before ``done`` — the worker crashed. Drop the handle
+                    # so the next command respawns a fresh worker.
+                    self._proc = None
+                    raise RuntimeError("Sandbox worker exited unexpectedly mid-command")
+                frame = parse_frame(line)
+                if frame.frame == "done":
+                    # ``done`` always terminates a command (success OR error).
+                    # Surface a deferred error only after fully draining the
+                    # command's frames, so the pipe is left clean for the next
+                    # command (no stale trailing ``done``).
+                    if error is not None:
+                        raise RuntimeError(f"Sandbox worker error: {error}")
+                    return
+                if frame.frame == "error":
+                    # Record and keep reading until ``done`` (protocol guarantees
+                    # ``error`` is followed by ``done``).
+                    error = frame.error
+                    continue
+                # frame.frame == "msg"
+                if frame.msg is not None and error is None:
+                    yield AgenticMessage.model_validate_json(frame.msg)
+
+    async def close(self) -> None:
+        if self._proc is not None:
+            await self._proc.close()
+            self._proc = None
 
 
 class ContainerDriver:
@@ -34,6 +117,13 @@ class ContainerDriver:
         self._provider = provider
         self._env = env
         self._last_usage: DriverUsage | None = None
+        self._worker: _PersistentWorker | None = None
+
+    def _persistent_worker(self, cwd: str | None) -> _PersistentWorker:
+        """Return the shared persistent worker, creating it on first use."""
+        if self._worker is None:
+            self._worker = _PersistentWorker(self._provider, cwd=cwd, env=self._env)
+        return self._worker
 
     async def _write_prompt(self, prompt: str, workflow_id: str | None = None) -> str:
         """Write the prompt to a temp file inside the container.
@@ -114,13 +204,30 @@ class ContainerDriver:
             raise ValueError("Prompt cannot be empty")
 
         await self._provider.ensure_running()
-        workflow_id = kwargs.get("workflow_id")
-        prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
 
         # Translate host path to sandbox-internal path (no-op for Docker,
         # maps to /workspace/repo for Daytona).
         sandbox_cwd = self._provider.resolve_cwd(cwd)
 
+        if self._provider.supports_persistent_worker:
+            request = WorkerRequest(
+                mode="agentic",
+                prompt=prompt,
+                model=self.model,
+                cwd=sandbox_cwd,
+                instructions=instructions,
+            )
+            worker = self._persistent_worker(sandbox_cwd)
+            async for msg in worker.dispatch(request):
+                if msg.type == AgenticMessageType.USAGE:
+                    self._last_usage = msg.usage
+                else:
+                    yield msg
+            return
+
+        # One-shot fallback: fresh worker process per call.
+        workflow_id = kwargs.get("workflow_id")
+        prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
         try:
             cmd = [
                 *self._provider.worker_cmd, "agentic",
@@ -172,27 +279,44 @@ class ContainerDriver:
             raise ValueError("Prompt cannot be empty")
 
         await self._provider.ensure_running()
-        workflow_id = kwargs.get("workflow_id")
-        prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
 
-        try:
-            cmd = [
-                *self._provider.worker_cmd, "generate",
-                "--prompt-file", prompt_path,
-                "--model", self.model,
-            ]
-            if schema:
-                cmd.extend(["--schema", f"{schema.__module__}:{schema.__name__}"])
+        schema_path = f"{schema.__module__}:{schema.__name__}" if schema else None
+        result_content: str | None = None
 
-            result_content: str | None = None
-            async for line in self._provider.exec_stream(cmd, env=self._env):
-                msg = self._parse_line(line)
+        if self._provider.supports_persistent_worker:
+            request = WorkerRequest(
+                mode="generate",
+                prompt=prompt,
+                model=self.model,
+                schema_path=schema_path,
+            )
+            worker = self._persistent_worker(None)
+            async for msg in worker.dispatch(request):
                 if msg.type == AgenticMessageType.USAGE:
                     self._last_usage = msg.usage
                 elif msg.type == AgenticMessageType.RESULT:
                     result_content = msg.content
-        finally:
-            await self._cleanup_prompt(prompt_path)
+        else:
+            # One-shot fallback: fresh worker process per call.
+            workflow_id = kwargs.get("workflow_id")
+            prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
+            try:
+                cmd = [
+                    *self._provider.worker_cmd, "generate",
+                    "--prompt-file", prompt_path,
+                    "--model", self.model,
+                ]
+                if schema_path:
+                    cmd.extend(["--schema", schema_path])
+
+                async for line in self._provider.exec_stream(cmd, env=self._env):
+                    msg = self._parse_line(line)
+                    if msg.type == AgenticMessageType.USAGE:
+                        self._last_usage = msg.usage
+                    elif msg.type == AgenticMessageType.RESULT:
+                        result_content = msg.content
+            finally:
+                await self._cleanup_prompt(prompt_path)
 
         if result_content is None:
             raise RuntimeError("Worker did not emit a RESULT message")

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -97,7 +97,13 @@ class _PersistentWorker:
                         continue
                     # frame.frame == "msg"
                     if frame.msg is not None and error is None:
-                        yield AgenticMessage.model_validate_json(frame.msg)
+                        try:
+                            message = AgenticMessage.model_validate_json(frame.msg)
+                        except ValidationError as exc:
+                            raise RuntimeError(
+                                f"Failed to parse worker output: {frame.msg[:200]}"
+                            ) from exc
+                        yield message
             finally:
                 # Any exit before ``done`` (crash EOF, caller cancellation, or a
                 # parse failure) leaves unread frames on the shared pipe. Drop

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -119,10 +119,10 @@ class ContainerDriver:
         self._last_usage: DriverUsage | None = None
         self._worker: _PersistentWorker | None = None
 
-    def _persistent_worker(self, cwd: str | None) -> _PersistentWorker:
+    def _persistent_worker(self) -> _PersistentWorker:
         """Return the shared persistent worker, creating it on first use."""
         if self._worker is None:
-            self._worker = _PersistentWorker(self._provider, cwd=cwd, env=self._env)
+            self._worker = _PersistentWorker(self._provider, cwd=None, env=self._env)
         return self._worker
 
     async def _write_prompt(self, prompt: str, workflow_id: str | None = None) -> str:
@@ -217,7 +217,7 @@ class ContainerDriver:
                 cwd=sandbox_cwd,
                 instructions=instructions,
             )
-            worker = self._persistent_worker(sandbox_cwd)
+            worker = self._persistent_worker()
             async for msg in worker.dispatch(request):
                 if msg.type == AgenticMessageType.USAGE:
                     self._last_usage = msg.usage
@@ -290,7 +290,7 @@ class ContainerDriver:
                 model=self.model,
                 schema_path=schema_path,
             )
-            worker = self._persistent_worker(None)
+            worker = self._persistent_worker()
             async for msg in worker.dispatch(request):
                 if msg.type == AgenticMessageType.USAGE:
                     self._last_usage = msg.usage

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import aclosing
 from typing import Any
 from uuid import uuid4
 
@@ -57,7 +58,7 @@ class _PersistentWorker:
             self._proc = await self._provider.spawn_worker(cwd=self._cwd, env=self._env)
         return self._proc
 
-    async def dispatch(self, request: WorkerRequest) -> AsyncIterator[AgenticMessage]:
+    async def dispatch(self, request: WorkerRequest) -> AsyncGenerator[AgenticMessage]:
         """Send one request and yield its AgenticMessages until ``done``.
 
         Args:
@@ -71,32 +72,39 @@ class _PersistentWorker:
         """
         async with self._lock:
             proc = await self._ensure()
-            await proc.write(encode_request(request))
-            error: str | None = None
-            while True:
-                line = await proc.readline()
-                if not line:
-                    # EOF before ``done`` — the worker crashed. Drop the handle
-                    # so the next command respawns a fresh worker.
+            completed = False
+            try:
+                await proc.write(encode_request(request))
+                error: str | None = None
+                while True:
+                    line = await proc.readline()
+                    if not line:
+                        raise RuntimeError("Sandbox worker exited unexpectedly mid-command")
+                    frame = parse_frame(line)
+                    if frame.frame == "done":
+                        # ``done`` always terminates a command (success OR error).
+                        # Surface a deferred error only after fully draining the
+                        # command's frames, so the pipe is left clean for the next
+                        # command (no stale trailing ``done``).
+                        completed = True
+                        if error is not None:
+                            raise RuntimeError(f"Sandbox worker error: {error}")
+                        return
+                    if frame.frame == "error":
+                        # Record and keep reading until ``done`` (protocol guarantees
+                        # ``error`` is followed by ``done``).
+                        error = frame.error
+                        continue
+                    # frame.frame == "msg"
+                    if frame.msg is not None and error is None:
+                        yield AgenticMessage.model_validate_json(frame.msg)
+            finally:
+                # Any exit before ``done`` (crash EOF, caller cancellation, or a
+                # parse failure) leaves unread frames on the shared pipe. Drop
+                # and close the worker so the next command respawns a clean one.
+                if not completed and self._proc is proc:
                     self._proc = None
-                    raise RuntimeError("Sandbox worker exited unexpectedly mid-command")
-                frame = parse_frame(line)
-                if frame.frame == "done":
-                    # ``done`` always terminates a command (success OR error).
-                    # Surface a deferred error only after fully draining the
-                    # command's frames, so the pipe is left clean for the next
-                    # command (no stale trailing ``done``).
-                    if error is not None:
-                        raise RuntimeError(f"Sandbox worker error: {error}")
-                    return
-                if frame.frame == "error":
-                    # Record and keep reading until ``done`` (protocol guarantees
-                    # ``error`` is followed by ``done``).
-                    error = frame.error
-                    continue
-                # frame.frame == "msg"
-                if frame.msg is not None and error is None:
-                    yield AgenticMessage.model_validate_json(frame.msg)
+                    await asyncio.shield(proc.close())
 
     async def close(self) -> None:
         if self._proc is not None:
@@ -218,11 +226,12 @@ class ContainerDriver:
                 instructions=instructions,
             )
             worker = self._persistent_worker()
-            async for msg in worker.dispatch(request):
-                if msg.type == AgenticMessageType.USAGE:
-                    self._last_usage = msg.usage
-                else:
-                    yield msg
+            async with aclosing(worker.dispatch(request)) as stream:
+                async for msg in stream:
+                    if msg.type == AgenticMessageType.USAGE:
+                        self._last_usage = msg.usage
+                    else:
+                        yield msg
             return
 
         # One-shot fallback: fresh worker process per call.
@@ -291,11 +300,12 @@ class ContainerDriver:
                 schema_path=schema_path,
             )
             worker = self._persistent_worker()
-            async for msg in worker.dispatch(request):
-                if msg.type == AgenticMessageType.USAGE:
-                    self._last_usage = msg.usage
-                elif msg.type == AgenticMessageType.RESULT:
-                    result_content = msg.content
+            async with aclosing(worker.dispatch(request)) as stream:
+                async for msg in stream:
+                    if msg.type == AgenticMessageType.USAGE:
+                        self._last_usage = msg.usage
+                    elif msg.type == AgenticMessageType.RESULT:
+                        result_content = msg.content
         else:
             # One-shot fallback: fresh worker process per call.
             workflow_id = kwargs.get("workflow_id")

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -32,6 +32,24 @@ from amelia.sandbox.protocol import (
 from amelia.sandbox.provider import SandboxProvider, WorkerProcess
 
 
+def _parse_worker_message(raw: str) -> AgenticMessage:
+    """Validate a worker AgenticMessage JSON payload, normalizing failures.
+
+    Args:
+        raw: A JSON-encoded AgenticMessage emitted by the worker.
+
+    Returns:
+        The parsed AgenticMessage.
+
+    Raises:
+        RuntimeError: If the payload is not a valid AgenticMessage.
+    """
+    try:
+        return AgenticMessage.model_validate_json(raw)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        raise RuntimeError(f"Failed to parse worker output: {raw[:200]}") from exc
+
+
 class _PersistentWorker:
     """Owns one long-lived ``serve`` process and dispatches commands to it.
 
@@ -97,13 +115,7 @@ class _PersistentWorker:
                         continue
                     # frame.frame == "msg"
                     if frame.msg is not None and error is None:
-                        try:
-                            message = AgenticMessage.model_validate_json(frame.msg)
-                        except ValidationError as exc:
-                            raise RuntimeError(
-                                f"Failed to parse worker output: {frame.msg[:200]}"
-                            ) from exc
-                        yield message
+                        yield _parse_worker_message(frame.msg)
             finally:
                 # Any exit before ``done`` (crash EOF, caller cancellation, or a
                 # parse failure) leaves unread frames on the shared pipe. Drop
@@ -162,25 +174,6 @@ class ContainerDriver:
         """
         async for _ in self._provider.exec_stream(["rm", "-f", prompt_path]):
             pass
-
-    def _parse_line(self, line: str) -> AgenticMessage:
-        """Parse a JSON line from the worker into an AgenticMessage.
-
-        Args:
-            line: JSON-encoded line from the worker process.
-
-        Returns:
-            Parsed AgenticMessage.
-
-        Raises:
-            RuntimeError: If the line cannot be parsed.
-        """
-        try:
-            return AgenticMessage.model_validate_json(line)
-        except (json.JSONDecodeError, ValidationError) as exc:
-            raise RuntimeError(
-                f"Failed to parse worker output: {line[:200]}"
-            ) from exc
 
     async def execute_agentic(
         self,
@@ -254,7 +247,7 @@ class ContainerDriver:
                 cmd.extend(["--instructions", instructions])
 
             async for line in self._provider.exec_stream(cmd, cwd=sandbox_cwd, env=self._env):
-                msg = self._parse_line(line)
+                msg = _parse_worker_message(line)
                 if msg.type == AgenticMessageType.USAGE:
                     self._last_usage = msg.usage
                 else:
@@ -326,7 +319,7 @@ class ContainerDriver:
                     cmd.extend(["--schema", schema_path])
 
                 async for line in self._provider.exec_stream(cmd, env=self._env):
-                    msg = self._parse_line(line)
+                    msg = _parse_worker_message(line)
                     if msg.type == AgenticMessageType.USAGE:
                         self._last_usage = msg.usage
                     elif msg.type == AgenticMessageType.RESULT:

--- a/amelia/sandbox/protocol.py
+++ b/amelia/sandbox/protocol.py
@@ -83,8 +83,17 @@ def encode_request(request: WorkerRequest) -> bytes:
     Returns:
         ``[4-byte big-endian length][JSON]`` ready to write to the worker's
         stdin.
+
+    Raises:
+        ValueError: If the serialized payload exceeds ``MAX_REQUEST_BYTES``.
+            Rejecting here fails locally instead of killing the worker when it
+            rejects the oversized frame on the read side.
     """
     payload = request.model_dump_json().encode("utf-8")
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise ValueError(
+            f"Request is too large: {len(payload)} bytes (max {MAX_REQUEST_BYTES})"
+        )
     return _LENGTH_STRUCT.pack(len(payload)) + payload
 
 

--- a/amelia/sandbox/protocol.py
+++ b/amelia/sandbox/protocol.py
@@ -96,13 +96,22 @@ def _read_exactly(stream: IO[bytes], count: int) -> bytes | None:
         count: Number of bytes required.
 
     Returns:
-        The bytes, or ``None`` if EOF is reached before any/all bytes arrive.
+        The bytes, or ``None`` if EOF is reached before the first byte arrives
+        (clean EOF — no message started).
+
+    Raises:
+        EOFError: If EOF arrives after at least one byte has been read
+            (truncated frame — a protocol error).
     """
     chunks: list[bytes] = []
     remaining = count
     while remaining > 0:
         chunk = stream.read(remaining)
         if not chunk:
+            if chunks:
+                raise EOFError(
+                    f"Truncated read: expected {count} bytes, got {count - remaining}"
+                )
             return None
         chunks.append(chunk)
         remaining -= len(chunk)
@@ -121,7 +130,9 @@ def read_request(stream: IO[bytes]) -> WorkerRequest | None:
         The parsed request, or ``None`` on clean EOF (no more commands).
 
     Raises:
-        ValueError: If the length prefix is corrupt or implausibly large.
+        EOFError: If EOF arrives mid-header (truncated length prefix).
+        ValueError: If the length prefix is corrupt or implausibly large,
+            or if EOF arrives mid-payload.
     """
     header = _read_exactly(stream, LENGTH_PREFIX_BYTES)
     if header is None:
@@ -129,7 +140,10 @@ def read_request(stream: IO[bytes]) -> WorkerRequest | None:
     (length,) = _LENGTH_STRUCT.unpack(header)
     if length == 0 or length > MAX_REQUEST_BYTES:
         raise ValueError(f"Invalid request length: {length}")
-    payload = _read_exactly(stream, length)
+    try:
+        payload = _read_exactly(stream, length)
+    except EOFError as exc:
+        raise ValueError("Truncated request") from exc
     if payload is None:
         raise ValueError("Truncated request: EOF before payload complete")
     return WorkerRequest.model_validate_json(payload)

--- a/amelia/sandbox/protocol.py
+++ b/amelia/sandbox/protocol.py
@@ -1,0 +1,194 @@
+"""Wire protocol for the long-lived sandbox worker.
+
+The driver runs a single long-lived worker process inside the sandbox that
+imports the heavy LangChain/deepagents stack ONCE at startup, then services
+many commands over its stdin/stdout. This module defines the framing for
+that channel so the cost of importing the stack is paid once per sandbox
+lifetime instead of once per agent call.
+
+Request framing (host -> worker, binary stdin):
+    A request is a single length-prefixed JSON object:
+        [4-byte big-endian unsigned length][UTF-8 JSON payload]
+    The length prefix makes the boundary unambiguous and lets the worker
+    tolerate partial reads on the pipe.
+
+Response framing (worker -> host, line-oriented stdout):
+    The worker streams newline-delimited JSON objects. Each line is a
+    ``ResponseFrame``:
+      - ``{"frame": "msg", "msg": <AgenticMessage JSON>}`` — one streamed
+        message (thinking / tool_call / tool_result / result / usage).
+      - ``{"frame": "done"}`` — terminates the current command. The driver
+        stops reading for this command when it sees this frame.
+      - ``{"frame": "error", "error": "<message>"}`` — the command failed.
+        The worker survives and stays ready for the next command; the driver
+        raises. ``error`` is always followed by ``done``.
+
+Line orientation (rather than length-prefixing responses too) is deliberate:
+the existing parser is line-based, and the worker may emit an unbounded number
+of streamed messages per command, so a streaming line protocol is the natural
+fit.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import IO, Literal
+
+from pydantic import BaseModel
+
+
+# Number of bytes in the big-endian unsigned request length prefix.
+LENGTH_PREFIX_BYTES = 4
+_LENGTH_STRUCT = struct.Struct(">I")
+
+# Guard against a corrupt/garbage length prefix asking us to allocate GBs.
+MAX_REQUEST_BYTES = 64 * 1024 * 1024
+
+
+class WorkerRequest(BaseModel):
+    """A single command sent to the long-lived worker.
+
+    ``mode`` selects the operation; the remaining fields mirror the CLI
+    arguments the per-call worker used to take.
+    """
+
+    mode: Literal["agentic", "generate"]
+    prompt: str
+    model: str
+    cwd: str | None = None
+    instructions: str | None = None
+    schema_path: str | None = None
+
+
+class ResponseFrame(BaseModel):
+    """One line of worker output.
+
+    Exactly one of the optional payloads is set depending on ``frame``.
+    """
+
+    frame: Literal["msg", "done", "error"]
+    # Raw AgenticMessage JSON string for frame == "msg". Kept as a string so
+    # this module does not need to import the (worker-local) AgenticMessage
+    # type; the driver re-parses it with its own model.
+    msg: str | None = None
+    error: str | None = None
+
+
+def encode_request(request: WorkerRequest) -> bytes:
+    """Serialize a request to a length-prefixed frame.
+
+    Args:
+        request: The command to send.
+
+    Returns:
+        ``[4-byte big-endian length][JSON]`` ready to write to the worker's
+        stdin.
+    """
+    payload = request.model_dump_json().encode("utf-8")
+    return _LENGTH_STRUCT.pack(len(payload)) + payload
+
+
+def _read_exactly(stream: IO[bytes], count: int) -> bytes | None:
+    """Read exactly ``count`` bytes, tolerating partial reads.
+
+    Args:
+        stream: Binary input stream.
+        count: Number of bytes required.
+
+    Returns:
+        The bytes, or ``None`` if EOF is reached before any/all bytes arrive.
+    """
+    chunks: list[bytes] = []
+    remaining = count
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def read_request(stream: IO[bytes]) -> WorkerRequest | None:
+    """Read one length-prefixed request from a binary stream.
+
+    Handles partial reads by looping until the full frame is available.
+
+    Args:
+        stream: Binary input stream (the worker's stdin buffer).
+
+    Returns:
+        The parsed request, or ``None`` on clean EOF (no more commands).
+
+    Raises:
+        ValueError: If the length prefix is corrupt or implausibly large.
+    """
+    header = _read_exactly(stream, LENGTH_PREFIX_BYTES)
+    if header is None:
+        return None
+    (length,) = _LENGTH_STRUCT.unpack(header)
+    if length == 0 or length > MAX_REQUEST_BYTES:
+        raise ValueError(f"Invalid request length: {length}")
+    payload = _read_exactly(stream, length)
+    if payload is None:
+        raise ValueError("Truncated request: EOF before payload complete")
+    return WorkerRequest.model_validate_json(payload)
+
+
+def msg_frame(msg: BaseModel) -> str:
+    """Build a ``msg`` response line for a streamed message.
+
+    Args:
+        msg: An AgenticMessage (or compatible model) to forward.
+
+    Returns:
+        A newline-terminated JSON ``ResponseFrame`` line.
+    """
+    return msg_frame_raw(msg.model_dump_json())
+
+
+def msg_frame_raw(msg_json: str) -> str:
+    """Build a ``msg`` response line from a pre-serialized AgenticMessage.
+
+    Args:
+        msg_json: An already-JSON-encoded AgenticMessage.
+
+    Returns:
+        A newline-terminated JSON ``ResponseFrame`` line.
+    """
+    return ResponseFrame(frame="msg", msg=msg_json).model_dump_json() + "\n"
+
+
+def done_frame() -> str:
+    """Build the terminating ``done`` response line for a command."""
+    return ResponseFrame(frame="done").model_dump_json() + "\n"
+
+
+def error_frame(error: str) -> str:
+    """Build an ``error`` response line.
+
+    Args:
+        error: Human-readable failure description.
+
+    Returns:
+        A newline-terminated JSON ``ResponseFrame`` line.
+    """
+    return ResponseFrame(frame="error", error=error).model_dump_json() + "\n"
+
+
+def parse_frame(line: str) -> ResponseFrame:
+    """Parse one worker output line into a ResponseFrame.
+
+    Args:
+        line: A single JSON line emitted by the worker.
+
+    Returns:
+        The parsed frame.
+
+    Raises:
+        ValueError: If the line is not a valid ResponseFrame.
+    """
+    try:
+        return ResponseFrame.model_validate_json(line)
+    except Exception as exc:  # noqa: BLE001 - normalize to ValueError for callers
+        raise ValueError(f"Malformed worker frame: {line[:200]}") from exc

--- a/amelia/sandbox/provider.py
+++ b/amelia/sandbox/provider.py
@@ -7,6 +7,37 @@ from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
+class WorkerProcess(Protocol):
+    """A long-lived worker process inside the sandbox.
+
+    Wraps a duplex channel to a single ``python -m amelia.sandbox.worker serve``
+    process: the driver writes length-prefixed request frames and reads
+    newline-delimited response frames. One process is reused across many agent
+    calls so the heavy import cost is paid once.
+    """
+
+    async def write(self, data: bytes) -> None:
+        """Write a request frame to the worker's stdin."""
+        ...
+
+    async def readline(self) -> str:
+        """Read one response-frame line (without trailing newline).
+
+        Returns an empty string on EOF (the worker exited).
+        """
+        ...
+
+    async def close(self) -> None:
+        """Stop the worker process and release its resources."""
+        ...
+
+    @property
+    def alive(self) -> bool:
+        """Whether the worker process is still running."""
+        ...
+
+
+@runtime_checkable
 class SandboxProvider(Protocol):
     """Manages sandbox lifecycle and command execution.
 
@@ -56,6 +87,37 @@ class SandboxProvider(Protocol):
         for remote sandboxes). Default is empty.
         """
         return {}
+
+    @property
+    def supports_persistent_worker(self) -> bool:
+        """Whether this provider can host a long-lived ``serve`` worker.
+
+        Transports that can hold a duplex stdin/stdout pipe to a single
+        process (e.g. Docker via ``docker exec -i``) return True. Transports
+        without persistent stdin (e.g. Daytona sessions) return False, and the
+        driver falls back to the per-call one-shot worker path.
+        """
+        return False
+
+    async def spawn_worker(
+        self,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> WorkerProcess:
+        """Start the long-lived ``serve`` worker and return a handle to it.
+
+        Only called when ``supports_persistent_worker`` is True.
+
+        Args:
+            cwd: Working directory inside the sandbox.
+            env: Additional environment variables for the worker.
+
+        Returns:
+            A WorkerProcess wrapping the running serve process.
+        """
+        raise NotImplementedError(
+            "This provider does not support a persistent worker"
+        )
 
     async def write_file(self, path: str, content: bytes) -> None:
         """Write content to a file inside the sandbox.

--- a/amelia/sandbox/worker.py
+++ b/amelia/sandbox/worker.py
@@ -3,9 +3,20 @@
 Receives a prompt, runs a DeepAgents agent or single-turn LLM call,
 and streams AgenticMessage objects as JSON lines to stdout.
 
-Usage:
+Two run modes:
+
+``serve`` (long-lived, preferred):
+    python -m amelia.sandbox.worker serve
+    Imports the heavy LangChain/deepagents stack ONCE at startup, then reads
+    length-prefixed JSON requests from stdin and services many commands over
+    its lifetime. The driver keeps one ``serve`` process per sandbox so the
+    import cost is paid once per sandbox, not once per agent call.
+
+``agentic`` / ``generate`` (one-shot, legacy/fallback):
     python -m amelia.sandbox.worker agentic --prompt-file /tmp/p.txt --cwd /workspace --model m
     python -m amelia.sandbox.worker generate --prompt-file /tmp/p.txt --model m [--schema mod:Cls]
+    Spawns a fresh process per call and pays the import cost each time. Kept
+    for transports (e.g. Daytona) that cannot hold a long-lived stdin pipe.
 """
 
 from __future__ import annotations
@@ -18,10 +29,22 @@ import sys
 import tempfile
 import time
 from enum import StrEnum
-from typing import Any, TextIO, cast
+from typing import Any, Protocol, cast
 
 from loguru import logger
 from pydantic import BaseModel, ValidationError
+
+
+class _LineSink(Protocol):
+    """Minimal write target for emitted JSON lines.
+
+    Satisfied by ``sys.stdout``, ``io.StringIO``, and the serve-mode framing
+    writer, so the run functions can emit to any of them.
+    """
+
+    def write(self, data: str, /) -> int: ...
+
+    def flush(self) -> None: ...
 
 
 # --- Inlined types (standalone: no amelia imports in the container) --------
@@ -105,7 +128,7 @@ def normalize_tool_name(raw_name: str) -> str:
     return TOOL_NAME_ALIASES.get(raw_name, raw_name)
 
 
-def _emit_line(msg: AgenticMessage, file: TextIO = sys.stdout) -> None:
+def _emit_line(msg: AgenticMessage, file: _LineSink = sys.stdout) -> None:
     """Write a single AgenticMessage as a JSON line to the given stream.
 
     Args:
@@ -116,7 +139,7 @@ def _emit_line(msg: AgenticMessage, file: TextIO = sys.stdout) -> None:
     file.flush()
 
 
-def _emit_usage(usage: DriverUsage, file: TextIO = sys.stdout) -> None:
+def _emit_usage(usage: DriverUsage, file: _LineSink = sys.stdout) -> None:
     """Emit the final USAGE message.
 
     Args:
@@ -163,6 +186,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Amelia sandbox worker",
     )
     sub = parser.add_subparsers(dest="mode", required=True)
+
+    # Long-lived mode: import once, read length-prefixed requests from stdin.
+    sub.add_parser("serve")
 
     shared = argparse.ArgumentParser(add_help=False)
     shared.add_argument("--prompt-file", required=True, help="Path to prompt file")
@@ -235,25 +261,51 @@ def _create_worker_chat_model(model: str, base_url: str | None = None) -> Any:
     return init_chat_model(model)
 
 
-async def _run_agentic(args: argparse.Namespace) -> None:
+def _import_stack() -> None:
+    """Import the heavy LangChain/deepagents stack.
+
+    In ``serve`` mode this is called ONCE at startup so subsequent commands
+    pay no import cost. In one-shot mode it is called per process (the cost
+    the long-lived worker exists to eliminate). Imports are deferred here
+    rather than at module top so the lightweight protocol path (and the
+    standalone Daytona upload) does not drag in the stack unnecessarily.
+    """
+    import deepagents  # noqa: F401, PLC0415
+    import deepagents.backends  # noqa: F401, PLC0415
+    import langchain.agents.structured_output  # noqa: F401, PLC0415
+    import langchain.chat_models  # noqa: F401, PLC0415
+    import langchain_core.messages  # noqa: F401, PLC0415
+
+
+async def _run_agentic(
+    *,
+    prompt: str,
+    model: str,
+    cwd: str,
+    instructions: str | None,
+    file: _LineSink = sys.stdout,
+) -> None:
     """Run agentic mode — full tool-using agent execution.
 
     Args:
-        args: Parsed CLI arguments.
+        prompt: The task prompt.
+        model: LLM model identifier.
+        cwd: Working directory for the filesystem backend.
+        instructions: Optional system instructions.
+        file: Output stream for emitted JSON-line messages.
     """
     from deepagents import create_deep_agent  # noqa: PLC0415
     from deepagents.backends import FilesystemBackend  # noqa: PLC0415
     from langchain_core.messages import AIMessage, HumanMessage, ToolMessage  # noqa: PLC0415
 
-    prompt = _read_prompt(args.prompt_file)
     base_url = os.environ.get("LLM_PROXY_URL")
 
-    chat_model = _create_worker_chat_model(args.model, base_url=base_url)
-    backend = FilesystemBackend(root_dir=args.cwd, virtual_mode=True)
+    chat_model = _create_worker_chat_model(model, base_url=base_url)
+    backend = FilesystemBackend(root_dir=cwd, virtual_mode=True)
 
     agent = create_deep_agent(
         model=chat_model,
-        system_prompt=args.instructions or "",
+        system_prompt=instructions or "",
         backend=backend,
     )
 
@@ -285,14 +337,14 @@ async def _run_agentic(args: argparse.Namespace) -> None:
                         _emit_line(AgenticMessage(
                             type=AgenticMessageType.THINKING,
                             content=block["text"],
-                            model=args.model,
-                        ))
+                            model=model,
+                        ), file=file)
             elif isinstance(content, str) and content:
                 _emit_line(AgenticMessage(
                     type=AgenticMessageType.THINKING,
                     content=content,
-                    model=args.model,
-                ))
+                    model=model,
+                ), file=file)
 
             for tc in message.tool_calls:
                 _emit_line(AgenticMessage(
@@ -300,8 +352,8 @@ async def _run_agentic(args: argparse.Namespace) -> None:
                     tool_name=normalize_tool_name(tc["name"]),
                     tool_input=tc.get("args", {}),
                     tool_call_id=tc.get("id"),
-                    model=args.model,
-                ))
+                    model=model,
+                ), file=file)
 
         elif isinstance(message, ToolMessage):
             _emit_line(AgenticMessage(
@@ -310,8 +362,8 @@ async def _run_agentic(args: argparse.Namespace) -> None:
                 tool_output=str(message.content)[:10000],
                 tool_call_id=message.tool_call_id,
                 is_error=getattr(message, "status", None) == "error",
-                model=args.model,
-            ))
+                model=model,
+            ), file=file)
 
     if num_turns == 0:
         raise RuntimeError("Agent stream yielded no messages")
@@ -331,8 +383,8 @@ async def _run_agentic(args: argparse.Namespace) -> None:
     _emit_line(AgenticMessage(
         type=AgenticMessageType.RESULT,
         content=final_content,
-        model=args.model,
-    ))
+        model=model,
+    ), file=file)
 
     duration_ms = int((time.monotonic() - start_time) * 1000)
     _emit_usage(DriverUsage(
@@ -340,27 +392,35 @@ async def _run_agentic(args: argparse.Namespace) -> None:
         output_tokens=total_output or None,
         duration_ms=duration_ms,
         num_turns=num_turns,
-        model=args.model,
-    ))
+        model=model,
+    ), file=file)
 
 
-async def _run_generate(args: argparse.Namespace) -> None:
+async def _run_generate(
+    *,
+    prompt: str,
+    model: str,
+    schema_path: str | None,
+    file: _LineSink = sys.stdout,
+) -> None:
     """Run generate mode — single-turn structured output.
 
     Args:
-        args: Parsed CLI arguments.
+        prompt: The generation prompt.
+        model: LLM model identifier.
+        schema_path: Optional ``module:ClassName`` schema path.
+        file: Output stream for emitted JSON-line messages.
     """
     from deepagents import create_deep_agent  # noqa: PLC0415
     from deepagents.backends import FilesystemBackend  # noqa: PLC0415
     from langchain.agents.structured_output import ToolStrategy  # noqa: PLC0415
     from langchain_core.messages import HumanMessage  # noqa: PLC0415
 
-    prompt = _read_prompt(args.prompt_file)
     base_url = os.environ.get("LLM_PROXY_URL")
 
-    chat_model = _create_worker_chat_model(args.model, base_url=base_url)
+    chat_model = _create_worker_chat_model(model, base_url=base_url)
 
-    schema = _import_schema(args.schema) if args.schema else None
+    schema = _import_schema(schema_path) if schema_path else None
 
     start_time = time.monotonic()
 
@@ -401,16 +461,126 @@ async def _run_generate(args: argparse.Namespace) -> None:
     _emit_line(AgenticMessage(
         type=AgenticMessageType.RESULT,
         content=content,
-        model=args.model,
-    ))
+        model=model,
+    ), file=file)
 
     duration_ms = int((time.monotonic() - start_time) * 1000)
     _emit_usage(DriverUsage(
         input_tokens=total_input or None,
         output_tokens=total_output or None,
         duration_ms=duration_ms,
-        model=args.model,
-    ))
+        model=model,
+    ), file=file)
+
+
+async def _dispatch_request(request: Any, file: _LineSink) -> None:
+    """Run a single decoded request, writing JSON-line messages to ``file``.
+
+    Args:
+        request: A WorkerRequest with mode/prompt/model and mode-specific fields.
+        file: Output stream for the command's messages.
+    """
+    if request.mode == "agentic":
+        await _run_agentic(
+            prompt=request.prompt,
+            model=request.model,
+            cwd=request.cwd or os.getcwd(),
+            instructions=request.instructions,
+            file=file,
+        )
+    elif request.mode == "generate":
+        await _run_generate(
+            prompt=request.prompt,
+            model=request.model,
+            schema_path=request.schema_path,
+            file=file,
+        )
+    else:  # pragma: no cover - guarded by WorkerRequest validation
+        raise ValueError(f"Unknown request mode: {request.mode!r}")
+
+
+async def _serve(stdin: Any = None, stdout: _LineSink = sys.stdout) -> None:
+    """Long-lived serve loop — import once, dispatch many commands.
+
+    Reads length-prefixed JSON requests from ``stdin`` (binary) and writes
+    newline-delimited response frames to ``stdout``. Each command is
+    terminated with a ``done`` frame; a failing command emits an ``error``
+    frame (followed by ``done``) but does NOT kill the worker, so the next
+    command is still served. A clean EOF on stdin ends the loop.
+
+    Commands are serviced strictly sequentially: the loop awaits each
+    dispatch fully (including its ``done`` frame) before reading the next
+    request, so concurrent commands from the driver are serialized on the
+    wire by construction.
+
+    Args:
+        stdin: Binary input stream (defaults to ``sys.stdin.buffer``).
+        stdout: Text output stream for response frames.
+    """
+    from amelia.sandbox.protocol import (  # noqa: PLC0415
+        done_frame,
+        error_frame,
+        msg_frame_raw,
+        read_request,
+    )
+
+    if stdin is None:
+        stdin = sys.stdin.buffer
+
+    # Pay the heavy import cost ONCE, before serving any command.
+    _import_stack()
+    logger.info("Sandbox worker ready (stack imported once)")
+
+    while True:
+        request = read_request(stdin)
+        if request is None:
+            logger.info("Worker stdin closed, shutting down")
+            return
+
+        # The run functions emit plain AgenticMessage JSON lines; this adapter
+        # re-wraps each complete line as a ``msg`` response frame so serve-mode
+        # output is framed without changing the run functions.
+        framed = _FramingWriter(stdout, msg_frame_raw)
+        try:
+            await _dispatch_request(request, framed)
+            framed.flush()
+            stdout.write(done_frame())
+            stdout.flush()
+        except Exception as exc:  # noqa: BLE001 - report, survive, keep serving
+            logger.exception("Command failed")
+            framed.flush()
+            stdout.write(error_frame(str(exc)))
+            stdout.write(done_frame())
+            stdout.flush()
+
+
+class _FramingWriter:
+    """File-like adapter that re-frames each written AgenticMessage line.
+
+    The run functions call ``_emit_line`` which does ``file.write(json + "\\n")``
+    then ``file.flush()``. This adapter intercepts those writes, wraps each
+    complete JSON line in a ``msg`` response frame via ``frame_fn``, and
+    forwards it to the real stdout.
+    """
+
+    def __init__(self, out: _LineSink, frame_fn: Any) -> None:
+        self._out = out
+        self._frame_fn = frame_fn
+        self._partial = ""
+
+    def write(self, data: str) -> int:
+        self._partial += data
+        while "\n" in self._partial:
+            line, self._partial = self._partial.split("\n", 1)
+            if line:
+                self._out.write(self._frame_fn(line))
+        return len(data)
+
+    def flush(self) -> None:
+        if self._partial.strip():
+            self._out.write(self._frame_fn(self._partial))
+            self._partial = ""
+        self._out.flush()
 
 
 async def _main() -> None:
@@ -420,10 +590,21 @@ async def _main() -> None:
     logger.add(sys.stderr, level="DEBUG")
 
     args = _parse_args()
-    if args.mode == "agentic":
-        await _run_agentic(args)
+    if args.mode == "serve":
+        await _serve()
+    elif args.mode == "agentic":
+        await _run_agentic(
+            prompt=_read_prompt(args.prompt_file),
+            model=args.model,
+            cwd=args.cwd,
+            instructions=args.instructions,
+        )
     elif args.mode == "generate":
-        await _run_generate(args)
+        await _run_generate(
+            prompt=_read_prompt(args.prompt_file),
+            model=args.model,
+            schema_path=args.schema,
+        )
 
 
 if __name__ == "__main__":

--- a/amelia/sandbox/worker.py
+++ b/amelia/sandbox/worker.py
@@ -555,31 +555,26 @@ async def _serve(stdin: Any = None, stdout: _LineSink = sys.stdout) -> None:
 
 
 class _FramingWriter:
-    """File-like adapter that re-frames each written AgenticMessage line.
+    """File-like sink that wraps each emitted AgenticMessage line in a frame.
 
-    The run functions call ``_emit_line`` which does ``file.write(json + "\\n")``
-    then ``file.flush()``. This adapter intercepts those writes, wraps each
-    complete JSON line in a ``msg`` response frame via ``frame_fn``, and
-    forwards it to the real stdout.
+    The only writers are ``_emit_line``/``_emit_usage``, which each write
+    exactly one ``json + "\\n"`` line (compact JSON never contains a literal
+    newline) then flush. This sink wraps that line in a ``msg`` response frame
+    via ``frame_fn`` and forwards it to the real stdout, so serve-mode output
+    is framed without changing the run functions.
     """
 
     def __init__(self, out: _LineSink, frame_fn: Any) -> None:
         self._out = out
         self._frame_fn = frame_fn
-        self._partial = ""
 
     def write(self, data: str) -> int:
-        self._partial += data
-        while "\n" in self._partial:
-            line, self._partial = self._partial.split("\n", 1)
-            if line:
-                self._out.write(self._frame_fn(line))
+        line = data.rstrip("\n")
+        if line:
+            self._out.write(self._frame_fn(line))
         return len(data)
 
     def flush(self) -> None:
-        if self._partial.strip():
-            self._out.write(self._frame_fn(self._partial))
-        self._partial = ""
         self._out.flush()
 
 

--- a/amelia/sandbox/worker.py
+++ b/amelia/sandbox/worker.py
@@ -579,7 +579,7 @@ class _FramingWriter:
     def flush(self) -> None:
         if self._partial.strip():
             self._out.write(self._frame_fn(self._partial))
-            self._partial = ""
+        self._partial = ""
         self._out.flush()
 
 

--- a/tests/integration/test_docker_persistent_worker.py
+++ b/tests/integration/test_docker_persistent_worker.py
@@ -1,0 +1,153 @@
+"""Integration test: ONE long-lived Docker worker serves MULTIPLE commands.
+
+Exercises the real Docker sandbox path for issue #640:
+  - DockerSandboxProvider starts a real container,
+  - spawn_worker() launches a real ``python -m amelia.sandbox.worker serve``
+    process via ``docker exec -i``,
+  - the protocol framing carries multiple sequential requests to that ONE
+    process,
+  - the worker imports the heavy stack exactly once (asserted via its startup
+    log line), survives a per-command error, and is cleanly stopped on
+    teardown.
+
+No LLM is required: the requests deliberately fail fast *inside* the worker
+(an unimportable schema), which makes the worker emit an ``error`` frame and
+keep serving — directly proving a single process handles multiple commands.
+
+Skipped automatically unless Docker is running and the ``amelia-sandbox``
+image is present locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+from amelia.sandbox.protocol import WorkerRequest, encode_request, parse_frame
+
+
+pytestmark = pytest.mark.integration
+
+
+def _docker_ready() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        if subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10,
+        ).returncode != 0:
+            return False
+        return subprocess.run(
+            ["docker", "image", "inspect", "amelia-sandbox:latest"],
+            capture_output=True, timeout=10,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_ready(),
+    reason="Docker not running or amelia-sandbox:latest image not built",
+)
+
+
+async def _read_until_done(worker) -> list:
+    """Read response frames from the worker until a ``done`` frame."""
+    frames = []
+    while True:
+        line = await worker.readline()
+        if not line:
+            raise AssertionError("worker exited before emitting 'done'")
+        frame = parse_frame(line)
+        frames.append(frame)
+        if frame.frame == "done":
+            return frames
+
+
+@requires_docker
+async def test_single_worker_handles_multiple_sequential_commands() -> None:
+    from amelia.sandbox.docker import DockerSandboxProvider
+
+    provider = DockerSandboxProvider(
+        profile_name=f"640test-{uuid.uuid4().hex[:8]}",
+        network_allowlist_enabled=False,
+    )
+    try:
+        await provider.ensure_running()
+
+        # ONE long-lived worker.
+        worker = await provider.spawn_worker(cwd="/workspace")
+        assert worker.alive
+        assert provider.supports_persistent_worker is True
+
+        # Two sequential commands over the SAME process. Each uses an
+        # unimportable schema so the command fails fast inside the worker
+        # (no LLM call) and the worker stays alive for the next command.
+        for i in range(2):
+            req = WorkerRequest(
+                mode="generate",
+                prompt=f"cmd-{i}",
+                model="test-model",
+                schema_path="nonexistent.module:Schema",
+            )
+            await worker.write(encode_request(req))
+            frames = await _read_until_done(worker)
+            kinds = [f.frame for f in frames]
+            # The command surfaced an error but the loop terminated it
+            # cleanly with 'done' — and the worker is still alive.
+            assert "error" in kinds
+            assert kinds[-1] == "done"
+            assert worker.alive, "worker must survive a per-command error"
+
+        # The heavy stack was imported exactly ONCE for the whole lifetime:
+        # the serve worker logs a single readiness line to its stderr.
+        # (returncode is still None — same process serviced both commands.)
+        assert worker.alive
+
+        await worker.close()
+        assert not worker.alive
+    finally:
+        await provider.teardown()
+        # No leaked workers tracked after teardown.
+        assert provider._workers == []
+
+
+@requires_docker
+async def test_worker_startup_imports_stack_once() -> None:
+    """The 'ready' log line appears exactly once across many commands."""
+    from amelia.sandbox.docker import DockerSandboxProvider
+
+    provider = DockerSandboxProvider(
+        profile_name=f"640log-{uuid.uuid4().hex[:8]}",
+        network_allowlist_enabled=False,
+    )
+    try:
+        await provider.ensure_running()
+        worker = await provider.spawn_worker(cwd="/workspace")
+
+        for i in range(3):
+            req = WorkerRequest(
+                mode="generate",
+                prompt=f"x-{i}",
+                model="test-model",
+                schema_path="nonexistent.module:Schema",
+            )
+            await worker.write(encode_request(req))
+            await _read_until_done(worker)
+
+        # Drain stderr by closing; then assert the readiness line count.
+        proc = worker._proc  # noqa: SLF001 - integration check on the real handle
+        await worker.close()
+        stderr = b""
+        if proc.stderr is not None:
+            with __import__("contextlib").suppress(Exception):
+                stderr = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+        ready_lines = stderr.decode(errors="replace").count("worker ready")
+        # Exactly one import/readiness across all three commands.
+        assert ready_lines == 1, stderr.decode(errors="replace")
+    finally:
+        await provider.teardown()

--- a/tests/unit/sandbox/test_container_driver.py
+++ b/tests/unit/sandbox/test_container_driver.py
@@ -22,10 +22,15 @@ class SampleSchema(BaseModel):
 
 
 def _make_provider_mock(lines: list[str]) -> AsyncMock:
-    """Create a mock SandboxProvider whose exec_stream returns the given lines."""
+    """Create a one-shot mock provider whose exec_stream returns the given lines.
+
+    ``supports_persistent_worker`` is False so the driver uses the per-call
+    fallback path these tests exercise (the path Daytona uses in production).
+    """
     provider = AsyncMock(spec=SandboxProvider)
     provider.ensure_running = AsyncMock()
     provider.write_file = AsyncMock()
+    provider.supports_persistent_worker = False
 
     call_count = 0
 
@@ -128,6 +133,7 @@ class TestExecuteAgentic:
         provider = AsyncMock(spec=SandboxProvider)
         provider.ensure_running = AsyncMock()
         provider.write_file = AsyncMock()
+        provider.supports_persistent_worker = False
 
         call_count = 0
 
@@ -159,6 +165,7 @@ class TestExecuteAgentic:
         provider = AsyncMock(spec=SandboxProvider)
         provider.ensure_running = AsyncMock()
         provider.write_file = AsyncMock()
+        provider.supports_persistent_worker = False
 
         call_count = 0
 

--- a/tests/unit/sandbox/test_container_driver_persistent.py
+++ b/tests/unit/sandbox/test_container_driver_persistent.py
@@ -1,0 +1,233 @@
+"""Tests for ContainerDriver's long-lived persistent-worker path.
+
+These assert the lifecycle the long-lived worker guarantees, with the
+transport faked at the WorkerProcess boundary:
+  - the worker is spawned ONCE even across many agent calls (no per-call
+    cold-start);
+  - each call gets its own framed result stream, terminated by ``done``;
+  - a worker error frame surfaces as a RuntimeError;
+  - a worker that exits mid-command is detected and reset (next call respawns);
+  - concurrent calls are serialized on the shared pipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from amelia.drivers.base import AgenticMessage, AgenticMessageType, DriverUsage
+from amelia.sandbox.driver import ContainerDriver
+from amelia.sandbox.protocol import (
+    WorkerRequest,
+    done_frame,
+    error_frame,
+    msg_frame,
+    read_request,
+)
+
+
+class FakeWorkerProcess:
+    """In-memory duplex worker that replies per request from a script.
+
+    ``responder`` maps a received WorkerRequest to the list of response-frame
+    lines to emit (the test supplies msg/done/error frames). Tracks how many
+    requests it served so tests can assert single-spawn reuse.
+    """
+
+    def __init__(self, responder, *, on_request=None) -> None:
+        self._responder = responder
+        self._on_request = on_request
+        self._outbox: list[str] = []
+        self.requests: list[WorkerRequest] = []
+        self.alive = True
+        self.closed = False
+
+    async def write(self, data: bytes) -> None:
+        import io
+
+        request = read_request(io.BytesIO(data))
+        assert request is not None
+        self.requests.append(request)
+        if self._on_request is not None:
+            await self._on_request(self, request)
+        if self.alive:
+            self._outbox.extend(self._responder(request))
+
+    async def readline(self) -> str:
+        if self._outbox:
+            return self._outbox.pop(0).rstrip("\n")
+        # No buffered output: simulate EOF (worker exited).
+        return ""
+
+    async def close(self) -> None:
+        self.closed = True
+        self.alive = False
+
+
+class FakeProvider:
+    """Provider that hands out a single FakeWorkerProcess and counts spawns."""
+
+    def __init__(self, worker: FakeWorkerProcess) -> None:
+        self._worker = worker
+        self.spawn_count = 0
+        self.supports_persistent_worker = True
+
+    async def ensure_running(self) -> None:
+        return None
+
+    def resolve_cwd(self, cwd: str) -> str:
+        return cwd
+
+    async def spawn_worker(self, cwd=None, env=None) -> FakeWorkerProcess:
+        self.spawn_count += 1
+        return self._worker
+
+
+def _result_then_usage(content: str) -> list[str]:
+    return [
+        msg_frame(AgenticMessage(type=AgenticMessageType.RESULT, content=content)),
+        msg_frame(
+            AgenticMessage(
+                type=AgenticMessageType.USAGE,
+                usage=DriverUsage(input_tokens=1, output_tokens=2),
+            )
+        ),
+        done_frame(),
+    ]
+
+
+class TestSpawnOnce:
+    async def test_worker_spawned_once_across_many_calls(self) -> None:
+        worker = FakeWorkerProcess(lambda req: _result_then_usage(f"r:{req.prompt}"))
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        for prompt in ("a", "b", "c"):
+            out, _ = await driver.generate(prompt=prompt)
+            assert out == f"r:{prompt}"
+
+        # One agentic call too — still the same worker.
+        msgs: list[AgenticMessage] = []
+        async for msg in driver.execute_agentic(prompt="d", cwd="/w"):
+            msgs.append(msg)
+        assert [m.content for m in msgs] == ["r:d"]
+
+        # The expensive spawn (and its one-time import) happened exactly once.
+        assert provider.spawn_count == 1
+        assert worker.requests[0].mode == "generate"
+        assert worker.requests[-1].mode == "agentic"
+        assert worker.requests[-1].cwd == "/w"
+
+    async def test_usage_captured_from_persistent_worker(self) -> None:
+        worker = FakeWorkerProcess(lambda req: _result_then_usage("x"))
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        await driver.generate(prompt="hello")
+        usage = driver.get_usage()
+        assert usage is not None
+        assert usage.input_tokens == 1
+        assert usage.output_tokens == 2
+
+    async def test_agentic_excludes_usage_from_stream(self) -> None:
+        worker = FakeWorkerProcess(lambda req: _result_then_usage("done"))
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        types = [m.type async for m in driver.execute_agentic(prompt="go", cwd="/w")]
+        assert AgenticMessageType.USAGE not in types
+        assert AgenticMessageType.RESULT in types
+
+
+class TestErrorPropagation:
+    async def test_error_frame_raises(self) -> None:
+        worker = FakeWorkerProcess(
+            lambda req: [error_frame("worker blew up"), done_frame()]
+        )
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        with pytest.raises(RuntimeError, match="worker blew up"):
+            await driver.generate(prompt="x")
+
+    async def test_error_then_success_on_same_worker_not_corrupted(self) -> None:
+        """After an error command, the trailing ``done`` must not corrupt the next.
+
+        Regression: the protocol emits ``error`` then ``done``. If the driver
+        raised on ``error`` without consuming the ``done``, the next command
+        would read that stale ``done`` first and return an empty stream.
+        """
+
+        def responder(req: WorkerRequest) -> list[str]:
+            if req.prompt == "bad":
+                return [error_frame("boom"), done_frame()]
+            return _result_then_usage(f"ok:{req.prompt}")
+
+        worker = FakeWorkerProcess(responder)
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await driver.generate(prompt="bad")
+
+        # Same worker (no respawn), next command returns its real result.
+        out, _ = await driver.generate(prompt="good")
+        assert out == "ok:good"
+        assert provider.spawn_count == 1
+
+    async def test_worker_crash_midcommand_detected_and_resets(self) -> None:
+        """A worker that exits before ``done`` raises, then the next call respawns."""
+        # First request: responder yields NOTHING (no done) -> readline EOF.
+        # Second request: a fresh worker that responds normally.
+        crashing = FakeWorkerProcess(lambda req: [])  # no frames -> EOF
+        healthy = FakeWorkerProcess(lambda req: _result_then_usage("recovered"))
+
+        class TwoWorkerProvider(FakeProvider):
+            def __init__(self) -> None:
+                super().__init__(crashing)
+                self._workers = [crashing, healthy]
+
+            async def spawn_worker(self, cwd=None, env=None):
+                self.spawn_count += 1
+                return self._workers.pop(0)
+
+        provider = TwoWorkerProvider()
+        driver = ContainerDriver(model="m", provider=provider)
+
+        with pytest.raises(RuntimeError, match="exited unexpectedly"):
+            await driver.generate(prompt="first")
+
+        # Next call respawns a fresh worker and succeeds.
+        out, _ = await driver.generate(prompt="second")
+        assert out == "recovered"
+        assert provider.spawn_count == 2
+
+
+class TestSerialization:
+    async def test_concurrent_calls_are_serialized(self) -> None:
+        """Two concurrent dispatches never interleave their request frames."""
+        active = {"n": 0, "max": 0}
+
+        async def gate(worker: FakeWorkerProcess, req: WorkerRequest) -> None:
+            active["n"] += 1
+            active["max"] = max(active["max"], active["n"])
+            await asyncio.sleep(0.01)  # hold the "command" open
+            active["n"] -= 1
+
+        worker = FakeWorkerProcess(
+            lambda req: _result_then_usage(req.prompt), on_request=gate,
+        )
+        provider = FakeProvider(worker)
+        driver = ContainerDriver(model="m", provider=provider)
+
+        results = await asyncio.gather(
+            driver.generate(prompt="one"),
+            driver.generate(prompt="two"),
+            driver.generate(prompt="three"),
+        )
+
+        assert {r[0] for r in results} == {"one", "two", "three"}
+        # The lock guarantees at most one command in flight at a time.
+        assert active["max"] == 1
+        assert provider.spawn_count == 1

--- a/tests/unit/sandbox/test_container_driver_persistent.py
+++ b/tests/unit/sandbox/test_container_driver_persistent.py
@@ -279,7 +279,7 @@ class TestEarlyExitResetsWorker:
         provider = TwoWorkerProvider()
         driver = ContainerDriver(model="m", provider=provider)
 
-        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError
+        with pytest.raises(RuntimeError, match="Failed to parse worker output"):
             await driver.generate(prompt="garbage")
 
         assert leaky.closed is True

--- a/tests/unit/sandbox/test_container_driver_persistent.py
+++ b/tests/unit/sandbox/test_container_driver_persistent.py
@@ -198,9 +198,93 @@ class TestErrorPropagation:
         with pytest.raises(RuntimeError, match="exited unexpectedly"):
             await driver.generate(prompt="first")
 
+        # The crashed worker is dropped and closed so it cannot serve stale frames.
+        assert crashing.closed is True
+
         # Next call respawns a fresh worker and succeeds.
         out, _ = await driver.generate(prompt="second")
         assert out == "recovered"
+        assert provider.spawn_count == 2
+
+
+class TestEarlyExitResetsWorker:
+    """A dispatch that unwinds before ``done`` must close the worker.
+
+    Otherwise unread frames from the abandoned command stay buffered on the
+    shared pipe and the next command reads them as its own output.
+    """
+
+    async def test_caller_cancellation_midstream_resets_worker(self) -> None:
+        # First command streams two messages then ``done``; the caller stops
+        # consuming after the first, leaving the second msg + done unread.
+        def responder(req: WorkerRequest) -> list[str]:
+            if req.prompt == "partial":
+                return [
+                    msg_frame(AgenticMessage(type=AgenticMessageType.RESULT, content="a")),
+                    msg_frame(AgenticMessage(type=AgenticMessageType.RESULT, content="b")),
+                    done_frame(),
+                ]
+            return _result_then_usage(f"r:{req.prompt}")
+
+        leaky = FakeWorkerProcess(responder)
+        healthy = FakeWorkerProcess(responder)
+
+        class TwoWorkerProvider(FakeProvider):
+            def __init__(self) -> None:
+                super().__init__(leaky)
+                self._workers = [leaky, healthy]
+
+            async def spawn_worker(self, cwd=None, env=None):
+                self.spawn_count += 1
+                return self._workers.pop(0)
+
+        provider = TwoWorkerProvider()
+        driver = ContainerDriver(model="m", provider=provider)
+
+        # Drive the production entrypoint and cancel mid-stream, exactly as a
+        # caller that stops consuming would. ``aclosing`` in execute_agentic must
+        # propagate the close down to dispatch so the worker is reset.
+        stream = driver.execute_agentic(prompt="partial", cwd="/w")
+        first = await stream.__anext__()
+        assert first.content == "a"
+        await stream.aclose()  # caller stops consuming mid-command
+
+        # The abandoned worker was closed; the next call respawns a clean one
+        # and gets its own result rather than the leaked "b"/done frames.
+        assert leaky.closed is True
+        out, _ = await driver.generate(prompt="next")
+        assert out == "r:next"
+        assert provider.spawn_count == 2
+
+    async def test_parse_failure_midcommand_resets_worker(self) -> None:
+        # First command emits a structurally valid frame whose payload is not a
+        # valid AgenticMessage, so model_validate_json raises before ``done``.
+        def responder(req: WorkerRequest) -> list[str]:
+            if req.prompt == "garbage":
+                return ['{"frame": "msg", "msg": "not-a-message"}', done_frame()]
+            return _result_then_usage(f"r:{req.prompt}")
+
+        leaky = FakeWorkerProcess(responder)
+        healthy = FakeWorkerProcess(responder)
+
+        class TwoWorkerProvider(FakeProvider):
+            def __init__(self) -> None:
+                super().__init__(leaky)
+                self._workers = [leaky, healthy]
+
+            async def spawn_worker(self, cwd=None, env=None):
+                self.spawn_count += 1
+                return self._workers.pop(0)
+
+        provider = TwoWorkerProvider()
+        driver = ContainerDriver(model="m", provider=provider)
+
+        with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError
+            await driver.generate(prompt="garbage")
+
+        assert leaky.closed is True
+        out, _ = await driver.generate(prompt="next")
+        assert out == "r:next"
         assert provider.spawn_count == 2
 
 

--- a/tests/unit/sandbox/test_docker_provider.py
+++ b/tests/unit/sandbox/test_docker_provider.py
@@ -168,7 +168,17 @@ def _mock_serve_proc() -> AsyncMock:
     proc.stdin = MagicMock()
     proc.stdin.drain = AsyncMock()
     proc.stdout = AsyncMock()
+    # stderr is a real StreamReader in production (async-iterable over bytes);
+    # the worker drains it in a background task. Yield nothing so the drain
+    # task completes cleanly instead of leaving an unawaited AsyncMock coroutine.
+    proc.stderr = AsyncMock()
+    proc.stderr.__aiter__ = lambda self: _async_iter([])
     proc.wait = AsyncMock(return_value=0)
+    # kill()/terminate() are synchronous on asyncio.subprocess.Process — model
+    # them as sync so close()'s force-kill path doesn't leak an unawaited
+    # coroutine (AsyncMock would make every call awaitable).
+    proc.kill = MagicMock()
+    proc.terminate = MagicMock()
     return proc
 
 

--- a/tests/unit/sandbox/test_docker_provider.py
+++ b/tests/unit/sandbox/test_docker_provider.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from amelia.sandbox.docker import DockerSandboxProvider
-from amelia.sandbox.provider import SandboxProvider
+from amelia.sandbox.docker import DockerSandboxProvider, DockerWorkerProcess
+from amelia.sandbox.provider import SandboxProvider, WorkerProcess
 
 
 async def _async_iter[T](items: list[T]) -> AsyncIterator[T]:
@@ -159,6 +159,85 @@ class TestTeardown:
         assert "rm" in args
         assert "-f" in args
         assert "amelia-sandbox-test" in args
+
+
+def _mock_serve_proc() -> AsyncMock:
+    """A mock asyncio subprocess that looks like a live ``serve`` worker."""
+    proc = AsyncMock()
+    proc.returncode = None  # alive
+    proc.stdin = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = AsyncMock()
+    proc.wait = AsyncMock(return_value=0)
+    return proc
+
+
+class TestPersistentWorker:
+    """Docker provider supports a long-lived serve worker (issue #640)."""
+
+    def test_supports_persistent_worker_is_true(self) -> None:
+        provider = DockerSandboxProvider(profile_name="test")
+        assert provider.supports_persistent_worker is True
+
+    async def test_spawn_worker_runs_serve_with_interactive_stdin(self) -> None:
+        provider = DockerSandboxProvider(profile_name="test")
+        proc = _mock_serve_proc()
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            worker = await provider.spawn_worker(cwd="/workspace/repo", env={"K": "V"})
+
+        assert isinstance(worker, DockerWorkerProcess)
+        assert isinstance(worker, WorkerProcess)
+        args = mock_exec.call_args[0]
+        # docker exec -i (interactive stdin) ... python -m amelia.sandbox.worker serve
+        assert args[:4] == ("docker", "exec", "-i", "--user")
+        assert "--workdir" in args
+        assert "/workspace/repo" in args
+        assert "-e" in args and "K=V" in args
+        assert "amelia-sandbox-test" in args
+        assert args[-4:] == ("python", "-m", "amelia.sandbox.worker", "serve")
+        # stdin must be a pipe so we can stream request frames.
+        assert mock_exec.call_args[1]["stdin"] is not None
+
+    async def test_teardown_closes_spawned_workers(self) -> None:
+        """teardown() must stop long-lived workers — no leaked processes."""
+        provider = DockerSandboxProvider(profile_name="test")
+        serve_proc = _mock_serve_proc()
+        rm_proc = AsyncMock()
+        rm_proc.communicate.return_value = (b"", b"")
+        rm_proc.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=[serve_proc, rm_proc],
+        ):
+            worker = await provider.spawn_worker()
+            await provider.teardown()
+
+        # Worker stdin was closed (EOF -> clean exit) and the process awaited.
+        serve_proc.stdin.close.assert_called_once()
+        serve_proc.wait.assert_awaited()
+        # The tracked-workers list is cleared so a second teardown is a no-op.
+        assert provider._workers == []
+        # The handle we got back is the one that was closed.
+        assert worker is not None
+
+    async def test_worker_write_and_readline_round_trip(self) -> None:
+        """DockerWorkerProcess forwards bytes to stdin and reads stdout lines."""
+        proc = _mock_serve_proc()
+        proc.stdout.readline = AsyncMock(return_value=b'{"frame":"done"}\n')
+
+        worker = DockerWorkerProcess(proc)
+        await worker.write(b"\x00\x00\x00\x02{}")
+        proc.stdin.write.assert_called_once_with(b"\x00\x00\x00\x02{}")
+        line = await worker.readline()
+        assert line == '{"frame":"done"}'
+
+    async def test_worker_readline_eof_returns_empty(self) -> None:
+        proc = _mock_serve_proc()
+        proc.stdout.readline = AsyncMock(return_value=b"")
+        worker = DockerWorkerProcess(proc)
+        assert await worker.readline() == ""
 
 
 class TestEnsureRunning:

--- a/tests/unit/sandbox/test_provider.py
+++ b/tests/unit/sandbox/test_provider.py
@@ -37,6 +37,17 @@ class FakeSandboxProvider:
     def worker_env(self) -> dict[str, str]:
         return {}
 
+    @property
+    def supports_persistent_worker(self) -> bool:
+        return False
+
+    async def spawn_worker(
+        self,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> object:
+        raise NotImplementedError
+
     async def health_check(self) -> bool:
         return True
 

--- a/tests/unit/sandbox/test_worker_serve.py
+++ b/tests/unit/sandbox/test_worker_serve.py
@@ -1,0 +1,182 @@
+"""Tests for the long-lived ``serve`` mode of the sandbox worker.
+
+These assert the lifecycle the long-lived worker exists to guarantee:
+  - the heavy import happens exactly ONCE, before any command and not per
+    command;
+  - a single serve loop dispatches MULTIPLE sequential requests, returning a
+    framed result per command;
+  - a command that raises mid-flight emits an ``error`` frame but does NOT
+    kill the worker — the next command is still served;
+  - a clean EOF on stdin stops the loop.
+
+The LLM stack is faked at the dispatch boundary so no network/LLM is needed.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, TextIO
+
+import pytest
+
+from amelia.sandbox import worker as worker_mod
+from amelia.sandbox.protocol import (
+    WorkerRequest,
+    encode_request,
+    parse_frame,
+)
+from amelia.sandbox.worker import AgenticMessage, AgenticMessageType, _serve
+
+
+def _requests_stdin(*requests: WorkerRequest) -> io.BytesIO:
+    """Build a binary stdin containing the given framed requests, then EOF."""
+    return io.BytesIO(b"".join(encode_request(r) for r in requests))
+
+
+def _frames(stdout: io.StringIO) -> list[Any]:
+    """Parse all response frames written to stdout."""
+    return [parse_frame(line) for line in stdout.getvalue().splitlines() if line]
+
+
+@pytest.fixture
+def patched_stack(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch import + dispatch; record import count and dispatched requests.
+
+    Returns a dict with ``import_calls`` (int) and ``dispatched`` (list of
+    WorkerRequest) populated as the serve loop runs.
+    """
+    state: dict[str, Any] = {"import_calls": 0, "dispatched": []}
+
+    def fake_import() -> None:
+        state["import_calls"] += 1
+
+    async def fake_dispatch(request: WorkerRequest, file: TextIO) -> None:
+        state["dispatched"].append(request)
+        # Emit one RESULT line the way the real run functions do, so the
+        # framing writer wraps it into a ``msg`` frame.
+        worker_mod._emit_line(
+            AgenticMessage(
+                type=AgenticMessageType.RESULT, content=f"ok:{request.prompt}",
+            ),
+            file=file,
+        )
+
+    monkeypatch.setattr(worker_mod, "_import_stack", fake_import)
+    monkeypatch.setattr(worker_mod, "_dispatch_request", fake_dispatch)
+    return state
+
+
+class TestServeLifecycle:
+    async def test_import_happens_once_across_many_commands(
+        self, patched_stack: dict[str, Any],
+    ) -> None:
+        reqs = [
+            WorkerRequest(mode="generate", prompt="a", model="m"),
+            WorkerRequest(mode="generate", prompt="b", model="m"),
+            WorkerRequest(mode="agentic", prompt="c", model="m", cwd="/w"),
+        ]
+        stdout = io.StringIO()
+
+        await _serve(stdin=_requests_stdin(*reqs), stdout=stdout)
+
+        # The stack is imported exactly once, regardless of command count.
+        assert patched_stack["import_calls"] == 1
+        # All three commands were dispatched, in order.
+        assert [r.prompt for r in patched_stack["dispatched"]] == ["a", "b", "c"]
+
+    async def test_one_result_and_done_per_command(
+        self, patched_stack: dict[str, Any],
+    ) -> None:
+        reqs = [
+            WorkerRequest(mode="generate", prompt="a", model="m"),
+            WorkerRequest(mode="generate", prompt="b", model="m"),
+        ]
+        stdout = io.StringIO()
+
+        await _serve(stdin=_requests_stdin(*reqs), stdout=stdout)
+
+        frames = _frames(stdout)
+        # Expect: msg(a), done, msg(b), done
+        kinds = [f.frame for f in frames]
+        assert kinds == ["msg", "done", "msg", "done"]
+
+        first_result = AgenticMessage.model_validate_json(frames[0].msg)
+        second_result = AgenticMessage.model_validate_json(frames[2].msg)
+        assert first_result.content == "ok:a"
+        assert second_result.content == "ok:b"
+
+    async def test_eof_stops_loop(self, patched_stack: dict[str, Any]) -> None:
+        stdout = io.StringIO()
+        # Empty stdin → immediate clean EOF, no commands, no output.
+        await _serve(stdin=io.BytesIO(b""), stdout=stdout)
+        assert patched_stack["dispatched"] == []
+        assert stdout.getvalue() == ""
+
+
+class TestServeCrashRecovery:
+    async def test_command_crash_emits_error_but_worker_survives(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import_calls = {"n": 0}
+
+        def fake_import() -> None:
+            import_calls["n"] += 1
+
+        dispatched: list[str] = []
+
+        async def flaky_dispatch(request: WorkerRequest, file: TextIO) -> None:
+            dispatched.append(request.prompt)
+            if request.prompt == "boom":
+                raise RuntimeError("kaboom")
+            worker_mod._emit_line(
+                AgenticMessage(type=AgenticMessageType.RESULT, content="fine"),
+                file=file,
+            )
+
+        monkeypatch.setattr(worker_mod, "_import_stack", fake_import)
+        monkeypatch.setattr(worker_mod, "_dispatch_request", flaky_dispatch)
+
+        reqs = [
+            WorkerRequest(mode="generate", prompt="boom", model="m"),
+            WorkerRequest(mode="generate", prompt="after", model="m"),
+        ]
+        stdout = io.StringIO()
+
+        await _serve(stdin=_requests_stdin(*reqs), stdout=stdout)
+
+        # Worker imported once and served BOTH commands despite the first crash.
+        assert import_calls["n"] == 1
+        assert dispatched == ["boom", "after"]
+
+        frames = _frames(stdout)
+        kinds = [f.frame for f in frames]
+        # boom: error, done ; after: msg, done
+        assert kinds == ["error", "done", "msg", "done"]
+        assert "kaboom" in (frames[0].error or "")
+        assert AgenticMessage.model_validate_json(frames[2].msg).content == "fine"
+
+    async def test_partial_command_messages_still_framed_before_error(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Messages emitted before a mid-command crash are flushed, then error."""
+        monkeypatch.setattr(worker_mod, "_import_stack", lambda: None)
+
+        async def emit_then_crash(request: WorkerRequest, file: TextIO) -> None:
+            worker_mod._emit_line(
+                AgenticMessage(type=AgenticMessageType.THINKING, content="step"),
+                file=file,
+            )
+            raise RuntimeError("mid-stream failure")
+
+        monkeypatch.setattr(worker_mod, "_dispatch_request", emit_then_crash)
+
+        req = WorkerRequest(mode="agentic", prompt="x", model="m", cwd="/w")
+        stdout = io.StringIO()
+        await _serve(stdin=_requests_stdin(req), stdout=stdout)
+
+        frames = _frames(stdout)
+        kinds = [f.frame for f in frames]
+        assert kinds == ["msg", "error", "done"]
+        assert AgenticMessage.model_validate_json(frames[0].msg).type == (
+            AgenticMessageType.THINKING
+        )

--- a/tests/unit/sandbox/test_worker_wire_protocol.py
+++ b/tests/unit/sandbox/test_worker_wire_protocol.py
@@ -1,0 +1,136 @@
+"""Tests for the long-lived worker wire protocol framing.
+
+These assert observable consequences of the framing: a request round-trips
+through encode/read, partial reads on the pipe are tolerated, EOF is a clean
+end-of-stream, corrupt prefixes are rejected, and response frames serialize
+the way the driver expects to parse them.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+
+import pytest
+
+from amelia.sandbox.protocol import (
+    LENGTH_PREFIX_BYTES,
+    MAX_REQUEST_BYTES,
+    ResponseFrame,
+    WorkerRequest,
+    done_frame,
+    encode_request,
+    error_frame,
+    msg_frame,
+    parse_frame,
+    read_request,
+)
+from amelia.sandbox.worker import AgenticMessage, AgenticMessageType
+
+
+class _PartialStream(io.RawIOBase):
+    """Binary stream that yields at most ``chunk`` bytes per read().
+
+    Simulates a pipe that returns short reads, forcing the reader to loop.
+    """
+
+    def __init__(self, data: bytes, chunk: int) -> None:
+        self._data = data
+        self._pos = 0
+        self._chunk = chunk
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:  # type: ignore[override]
+        if self._pos >= len(self._data):
+            return b""
+        n = min(size if size > 0 else self._chunk, self._chunk)
+        out = self._data[self._pos : self._pos + n]
+        self._pos += len(out)
+        return out
+
+
+class TestRequestRoundTrip:
+    def test_encode_then_read_round_trips(self) -> None:
+        req = WorkerRequest(
+            mode="agentic", prompt="do x", model="m", cwd="/work", instructions="be terse",
+        )
+        stream = io.BytesIO(encode_request(req))
+        out = read_request(stream)
+        assert out == req
+
+    def test_encode_uses_4_byte_big_endian_prefix(self) -> None:
+        req = WorkerRequest(mode="generate", prompt="hi", model="m")
+        frame = encode_request(req)
+        (length,) = struct.unpack(">I", frame[:LENGTH_PREFIX_BYTES])
+        assert length == len(frame) - LENGTH_PREFIX_BYTES
+
+    def test_two_requests_read_sequentially_from_one_stream(self) -> None:
+        a = WorkerRequest(mode="generate", prompt="first", model="m")
+        b = WorkerRequest(mode="agentic", prompt="second", model="m", cwd="/w")
+        stream = io.BytesIO(encode_request(a) + encode_request(b))
+        assert read_request(stream) == a
+        assert read_request(stream) == b
+        assert read_request(stream) is None  # clean EOF after both
+
+
+class TestPartialReads:
+    @pytest.mark.parametrize("chunk", [1, 2, 3, 5, 7])
+    def test_request_survives_short_reads(self, chunk: int) -> None:
+        req = WorkerRequest(
+            mode="agentic", prompt="a longer prompt that spans many bytes", model="model-x", cwd="/w",
+        )
+        stream = _PartialStream(encode_request(req), chunk=chunk)
+        assert read_request(stream) == req
+
+
+class TestEofAndErrors:
+    def test_clean_eof_returns_none(self) -> None:
+        assert read_request(io.BytesIO(b"")) is None
+
+    def test_truncated_payload_raises(self) -> None:
+        req = WorkerRequest(mode="generate", prompt="hello", model="m")
+        frame = encode_request(req)
+        # Drop the last 3 bytes of the payload.
+        stream = io.BytesIO(frame[:-3])
+        with pytest.raises(ValueError, match="Truncated request"):
+            read_request(stream)
+
+    def test_zero_length_prefix_raises(self) -> None:
+        stream = io.BytesIO(struct.pack(">I", 0))
+        with pytest.raises(ValueError, match="Invalid request length"):
+            read_request(stream)
+
+    def test_implausibly_large_prefix_raises(self) -> None:
+        stream = io.BytesIO(struct.pack(">I", MAX_REQUEST_BYTES + 1))
+        with pytest.raises(ValueError, match="Invalid request length"):
+            read_request(stream)
+
+
+class TestResponseFrames:
+    def test_msg_frame_carries_agentic_message(self) -> None:
+        m = AgenticMessage(type=AgenticMessageType.RESULT, content="done")
+        line = msg_frame(m)
+        assert line.endswith("\n")
+        frame = parse_frame(line)
+        assert frame.frame == "msg"
+        assert frame.msg is not None
+        restored = AgenticMessage.model_validate_json(frame.msg)
+        assert restored.content == "done"
+
+    def test_done_frame_round_trips(self) -> None:
+        frame = parse_frame(done_frame())
+        assert frame.frame == "done"
+
+    def test_error_frame_carries_message(self) -> None:
+        frame = parse_frame(error_frame("boom"))
+        assert frame.frame == "error"
+        assert frame.error == "boom"
+
+    def test_parse_rejects_garbage(self) -> None:
+        with pytest.raises(ValueError, match="Malformed worker frame"):
+            parse_frame("not json at all")
+
+    def test_response_frame_is_pydantic(self) -> None:
+        assert issubclass(ResponseFrame, __import__("pydantic").BaseModel)

--- a/tests/unit/sandbox/test_worker_wire_protocol.py
+++ b/tests/unit/sandbox/test_worker_wire_protocol.py
@@ -107,6 +107,13 @@ class TestEofAndErrors:
         with pytest.raises(ValueError, match="Invalid request length"):
             read_request(stream)
 
+    def test_encode_rejects_oversized_request(self) -> None:
+        req = WorkerRequest(
+            mode="generate", prompt="x" * (MAX_REQUEST_BYTES + 1), model="m",
+        )
+        with pytest.raises(ValueError, match="Request is too large"):
+            encode_request(req)
+
 
 class TestResponseFrames:
     def test_msg_frame_carries_agentic_message(self) -> None:


### PR DESCRIPTION
## Problem

Every `execute_agentic` / `generate` call spawned a FRESH `python -m amelia.sandbox.worker` process inside the container via `exec_stream`. The worker imports the heavy stack (deepagents, langchain.chat_models, deepagents.backends, langchain_core.messages) at call time, so the LangChain/deepagents import cost (~1-3s) was paid on EVERY agent call, not once.

## Change

Run a LONG-LIVED worker per sandbox that imports the stack ONCE and reads commands over a pipe, reused across steps:

- **`amelia/sandbox/protocol.py`** (new): wire protocol. Requests are length-prefixed JSON (4-byte big-endian length + payload, tolerant of partial reads); responses are newline-delimited `msg` / `done` / `error` frames with explicit per-command termination and error propagation.
- **`worker.py`**: new `serve` mode imports the stack once, then loops reading requests from stdin, dispatching to the existing agentic/generate run functions, emitting `done` per command and `error` (without dying) on per-command failure. EOF on stdin → clean exit. The one-shot `agentic`/`generate` CLI modes are retained for transports without a duplex pipe.
- **`SandboxProvider`**: adds `supports_persistent_worker` + `spawn_worker`. `DockerSandboxProvider` runs `docker exec -i ... worker serve`, tracks the process, and stops it on `teardown()` (no leaked processes). Daytona reports `supports_persistent_worker=False` and keeps the per-call path (its bottleneck is network, and sessions have no persistent stdin).
- **`ContainerDriver`**: dispatches to one shared persistent worker when supported — spawned once, commands serialized with a lock, respawned on crash, with `error` frames fully drained through `done` so the pipe stays clean for the next command — and falls back to the per-call path otherwise.

## Verification (actual results)

- `uv run ruff check --fix amelia tests` → **All checks passed!**
- `uv run mypy amelia` → **Success: no issues found in 184 source files**
- `uv run pytest tests/unit/` → **2474 passed, 56 deselected**
- Pre-push gate (ruff + mypy + full pytest + `pnpm build`) → **2511 passed; dashboard built**. (`pnpm build` first failed on a fresh worktree missing `node_modules`; fixed with `pnpm install`, then the gate passed legitimately — no `--no-verify`.)
- **Docker integration test EXECUTED (not skipped)**: `tests/integration/test_docker_persistent_worker.py` ran against a real `amelia-sandbox:latest` container (rebuilt to include `serve` mode) → **2 passed in ~5s**. It confirms ONE worker process serves MULTIPLE sequential commands and imports the stack exactly once (asserted via a single readiness log line). Full integration suite: **333 passed, 2 skipped**.

Tests added: protocol framing + partial reads + EOF/corrupt-prefix; serve lifecycle (import-once, dispatch-many, crash-survives, EOF-stops); driver persistent path (spawn-once across N calls, usage capture, error propagation, error-then-success non-corruption, crash-reset, concurrency serialization); Docker provider spawn/teardown/transport.

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH