### PR TITLE
perf(git): collapse and async-wrap synchronous git subprocesses (#645)

### DIFF
--- a/amelia/client/git.py
+++ b/amelia/client/git.py
@@ -7,8 +7,9 @@ def get_worktree_context() -> tuple[str, str]:
     """Returns (worktree_path, worktree_name) for current directory.
 
     Detects the current git worktree root and derives a human-readable name
-    from the current branch or directory name. All worktree context is
-    resolved in a SINGLE git invocation to avoid serial subprocess overhead.
+    from the current branch or directory name. Worktree context is resolved in
+    a single git invocation for the common (non-detached) case; detached HEAD
+    requires a second targeted call to obtain the short commit sha.
 
     Handles edge cases:
     - Detached HEAD: Uses short commit hash as name (e.g., "detached-abc1234")
@@ -37,7 +38,12 @@ def get_worktree_context() -> tuple[str, str]:
     #   2. --is-bare-repository    -> "true" / "false"
     #   3. --show-toplevel         -> absolute worktree root path
     #   4. --abbrev-ref HEAD       -> branch name, or "HEAD" if detached
-    #   5. --short HEAD            -> short commit sha (used for detached HEAD)
+    #
+    # NOTE: --abbrev-ref is a sticky output-format mode in git rev-parse.
+    # Appending --short HEAD after --abbrev-ref HEAD does NOT produce a short
+    # sha; the sticky abbrev-ref mode causes git to emit the abbrev-ref value
+    # ("HEAD") again instead.  The short sha for detached HEAD is therefore
+    # fetched with a separate targeted call only when needed (see below).
     #
     # In a bare repo or non-repo, --show-toplevel makes rev-parse exit non-zero;
     # we re-probe --is-bare-repository in that path to distinguish the two cases.
@@ -50,8 +56,6 @@ def get_worktree_context() -> tuple[str, str]:
             "--show-toplevel",
             "--abbrev-ref",
             "HEAD",
-            "--short",
-            "HEAD",
         ],
         capture_output=True,
         text=True,
@@ -59,7 +63,7 @@ def get_worktree_context() -> tuple[str, str]:
 
     lines = result.stdout.splitlines()
 
-    if result.returncode != 0 or not lines or lines[0].strip() != "true":
+    if not lines or lines[0].strip() != "true":
         # rev-parse failed (or reported we're not in a work tree). Distinguish a
         # bare repository from "not a repo at all" with a single follow-up probe.
         bare_check = subprocess.run(
@@ -71,9 +75,9 @@ def get_worktree_context() -> tuple[str, str]:
             raise ValueError("Cannot run workflows in a bare repository")
         raise ValueError("Not inside a git repository")
 
-    # lines: [is_inside_work_tree, is_bare, toplevel, branch, short_sha]
-    # The branch line may legitimately be empty (unborn branch), and the short
-    # sha line may be empty too — but the toplevel/branch lines must be present.
+    # lines: [is_inside_work_tree, is_bare, toplevel, branch]
+    # The branch line may legitimately be empty (unborn branch), but the
+    # toplevel/branch lines must be present.
     if len(lines) < 4:
         raise RuntimeError(
             f"Failed to determine worktree root: unexpected git output {lines!r}"
@@ -81,11 +85,19 @@ def get_worktree_context() -> tuple[str, str]:
 
     worktree_path = lines[2].strip()
     branch = lines[3].strip()
-    short_hash = lines[4].strip() if len(lines) > 4 else ""
 
     # Handle detached HEAD state: --abbrev-ref reports "HEAD", so name from sha.
+    # Fetch the short sha with a separate call; combining --short with
+    # --abbrev-ref in one invocation produces the wrong output due to sticky
+    # output-format modes in git rev-parse (--abbrev-ref overrides --short).
     if branch == "HEAD":
-        branch = f"detached-{short_hash}" if short_hash else "detached"
+        sha_result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        short_hash = sha_result.stdout.strip() if sha_result.returncode == 0 else ""
+        branch = f"detached-{short_hash}" if short_hash else ""
 
     # Use directory name if branch is empty.
     return worktree_path, branch or Path(worktree_path).name

--- a/amelia/client/git.py
+++ b/amelia/client/git.py
@@ -7,7 +7,8 @@ def get_worktree_context() -> tuple[str, str]:
     """Returns (worktree_path, worktree_name) for current directory.
 
     Detects the current git worktree root and derives a human-readable name
-    from the current branch or directory name.
+    from the current branch or directory name. All worktree context is
+    resolved in a SINGLE git invocation to avoid serial subprocess overhead.
 
     Handles edge cases:
     - Detached HEAD: Uses short commit hash as name (e.g., "detached-abc1234")
@@ -30,13 +31,37 @@ def get_worktree_context() -> tuple[str, str]:
         >>> get_worktree_context()
         ('/home/user/myproject', 'detached-abc1234')
     """
+    # Single git invocation resolves all worktree context. Each flag emits one
+    # output line, in order:
+    #   1. --is-inside-work-tree   -> "true" / "false"
+    #   2. --is-bare-repository    -> "true" / "false"
+    #   3. --show-toplevel         -> absolute worktree root path
+    #   4. --abbrev-ref HEAD       -> branch name, or "HEAD" if detached
+    #   5. --short HEAD            -> short commit sha (used for detached HEAD)
+    #
+    # In a bare repo or non-repo, --show-toplevel makes rev-parse exit non-zero;
+    # we re-probe --is-bare-repository in that path to distinguish the two cases.
     result = subprocess.run(
-        ["git", "rev-parse", "--is-inside-work-tree"],
+        [
+            "git",
+            "rev-parse",
+            "--is-inside-work-tree",
+            "--is-bare-repository",
+            "--show-toplevel",
+            "--abbrev-ref",
+            "HEAD",
+            "--short",
+            "HEAD",
+        ],
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0 or result.stdout.strip() != "true":
-        # Could be bare repo or not a repo at all
+
+    lines = result.stdout.splitlines()
+
+    if result.returncode != 0 or not lines or lines[0].strip() != "true":
+        # rev-parse failed (or reported we're not in a work tree). Distinguish a
+        # bare repository from "not a repo at all" with a single follow-up probe.
         bare_check = subprocess.run(
             ["git", "rev-parse", "--is-bare-repository"],
             capture_output=True,
@@ -46,40 +71,21 @@ def get_worktree_context() -> tuple[str, str]:
             raise ValueError("Cannot run workflows in a bare repository")
         raise ValueError("Not inside a git repository")
 
-    # Get worktree root (works for main repo and worktrees)
-    try:
-        worktree_path = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to determine worktree root: {e.stderr}") from e
+    # lines: [is_inside_work_tree, is_bare, toplevel, branch, short_sha]
+    # The branch line may legitimately be empty (unborn branch), and the short
+    # sha line may be empty too — but the toplevel/branch lines must be present.
+    if len(lines) < 4:
+        raise RuntimeError(
+            f"Failed to determine worktree root: unexpected git output {lines!r}"
+        )
 
-    try:
-        branch = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        # Fallback to directory name if branch detection fails
-        return worktree_path, Path(worktree_path).name
+    worktree_path = lines[2].strip()
+    branch = lines[3].strip()
+    short_hash = lines[4].strip() if len(lines) > 4 else ""
 
-    # Handle detached HEAD state
+    # Handle detached HEAD state: --abbrev-ref reports "HEAD", so name from sha.
     if branch == "HEAD":
-        try:
-            short_hash = subprocess.run(
-                ["git", "rev-parse", "--short", "HEAD"],
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout.strip()
-            branch = f"detached-{short_hash}"
-        except subprocess.CalledProcessError:
-            branch = "detached"
+        branch = f"detached-{short_hash}" if short_hash else "detached"
 
-    # Use directory name if branch is empty
+    # Use directory name if branch is empty.
     return worktree_path, branch or Path(worktree_path).name

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -115,7 +115,14 @@ class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
             )
 
     async def aexecute(self, command: str) -> ExecuteResponse:
-        """Async wrapper for execute (runs in thread pool)."""
+        """Async entry point for shell execution.
+
+        The blocking ``subprocess.run(..., shell=True)`` in ``execute`` must
+        never run on the event loop, so it is offloaded to a worker thread via
+        ``asyncio.to_thread``. The deepagents tool layer awaits this method
+        (not the sync ``execute``), keeping the loop responsive during long or
+        slow commands.
+        """
         return await asyncio.to_thread(self.execute, command)
 
 

--- a/amelia/tools/file_bundler.py
+++ b/amelia/tools/file_bundler.py
@@ -85,45 +85,20 @@ def _is_binary(data: bytes) -> bool:
     return b"\x00" in data[:512]
 
 
-def _is_git_repo(working_dir: Path) -> bool:
-    """Check if working_dir is inside a git repository.
-
-    Args:
-        working_dir: Directory to check.
-
-    Returns:
-        True if inside a git repo.
-    """
-    try:
-        # Strip GIT_* env vars so the check reflects the actual directory,
-        # not inherited context from a parent process or hook.
-        clean_env = {
-            k: v for k, v in os.environ.items()
-            if not k.startswith("GIT_")
-        }
-        result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            cwd=working_dir,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            env=clean_env,
-        )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-
-
 def _get_git_tracked_files(working_dir: Path) -> set[str] | None:
     """Get all git-tracked files (respects .gitignore).
 
-    Uses ``git ls-files`` which excludes gitignored files.
+    Uses ``git ls-files`` which excludes gitignored files. This single probe
+    doubles as the git-repo check: outside a repository ``git ls-files`` exits
+    non-zero, which we report as ``None`` so the caller falls back to non-git
+    mode. No separate ``rev-parse --git-dir`` pre-check is needed.
 
     Args:
-        working_dir: Git repository root.
+        working_dir: Directory to inspect (a git repository root, or not).
 
     Returns:
-        Set of relative file paths tracked by git, or None on failure.
+        Set of relative file paths tracked by git, or None when the directory
+        is not a git repository or ``git ls-files`` otherwise fails.
     """
     try:
         clean_env = {
@@ -274,12 +249,11 @@ async def bundle_files(
         ValueError: If any resolved path escapes working_dir.
     """
     wd = Path(working_dir)
-    is_git = await asyncio.to_thread(_is_git_repo, wd)
-    tracked: set[str] | None = None
-    if is_git:
-        tracked = await asyncio.to_thread(_get_git_tracked_files, wd)
-        if tracked is None:
-            logger.warning("git ls-files failed, falling back to non-git mode")
+    # A single `git ls-files` both detects the repo and lists tracked files.
+    # Returns None outside a repo (or on failure) -> non-git fallback mode.
+    tracked: set[str] | None = await asyncio.to_thread(_get_git_tracked_files, wd)
+    if tracked is None:
+        logger.debug("git ls-files unavailable, using non-git mode", working_dir=working_dir)
 
     file_paths = await asyncio.to_thread(_resolve_globs, wd, patterns, tracked, exclude_patterns)
 

--- a/tests/unit/client/test_git.py
+++ b/tests/unit/client/test_git.py
@@ -1,14 +1,19 @@
 # tests/unit/client/test_git.py
 """Tests for git worktree context detection.
 
-Worktree context is resolved in a SINGLE git invocation:
+Worktree context is resolved in a SINGLE git invocation for the common case:
 ``git rev-parse --is-inside-work-tree --is-bare-repository --show-toplevel
---abbrev-ref HEAD --short HEAD``. Each flag emits one output line, in order:
+--abbrev-ref HEAD``. Each flag emits one output line, in order:
     1. is_inside_work_tree  ("true" / "false")
     2. is_bare              ("true" / "false")
     3. toplevel             (absolute worktree root)
     4. branch               (branch name, or "HEAD" when detached)
-    5. short_sha            (short commit sha)
+
+For detached HEAD only, a second call ``git rev-parse --short HEAD`` fetches
+the short sha.  --short cannot be combined with --abbrev-ref in the same
+rev-parse invocation: --abbrev-ref is a sticky output-format mode that
+overrides --short, causing git to emit the abbrev-ref value ("HEAD") instead
+of the commit sha.
 """
 from unittest.mock import MagicMock, patch
 
@@ -16,7 +21,12 @@ import pytest
 
 
 def _combined(*lines: str) -> str:
-    """Build the multi-line stdout `git rev-parse` emits for the combined call."""
+    """Build the multi-line stdout `git rev-parse` emits for the combined call.
+
+    Only 4 lines are emitted by the combined invocation (is_inside_work_tree,
+    is_bare, toplevel, branch).  A 5th line is NOT produced; see module
+    docstring for why --short cannot be combined with --abbrev-ref.
+    """
     return "".join(f"{line}\n" for line in lines)
 
 
@@ -30,7 +40,7 @@ class TestGetWorktreeContext:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0,
-                stdout=_combined("true", "false", "/home/user/repo", "main", "abc1234"),
+                stdout=_combined("true", "false", "/home/user/repo", "main"),
                 stderr="",
             )
 
@@ -40,7 +50,8 @@ class TestGetWorktreeContext:
             assert isinstance(name, str)
             assert path == "/home/user/repo"
             assert name == "main"
-            # Acceptance criterion: a SINGLE git invocation resolves context.
+            # Acceptance criterion: a SINGLE git invocation resolves context
+            # for the common (non-detached) case.
             assert mock_run.call_count == 1
 
     def test_raises_when_not_in_git_repo(self):
@@ -78,39 +89,57 @@ class TestGetWorktreeContext:
     def test_handles_detached_head(self):
         """Uses short commit hash as name for detached HEAD.
 
-        When detached, --abbrev-ref HEAD emits the literal "HEAD"; the name is
-        derived from the short sha line of the SAME combined output.
+        When detached, --abbrev-ref HEAD emits "HEAD" on line 4.  Because
+        --abbrev-ref is a sticky output-format mode in git rev-parse, the
+        short sha cannot be retrieved from the same invocation; get_worktree_context
+        issues a second targeted ``git rev-parse --short HEAD`` call to obtain it.
         """
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=_combined("true", "false", "/home/user/repo", "HEAD", "abc1234"),
-                stderr="",
-            )
+            mock_run.side_effect = [
+                # First call: combined rev-parse; line 4 is "HEAD" (detached).
+                MagicMock(
+                    returncode=0,
+                    stdout=_combined("true", "false", "/home/user/repo", "HEAD"),
+                    stderr="",
+                ),
+                # Second call: targeted --short HEAD to get the actual sha.
+                MagicMock(returncode=0, stdout="abc1234\n", stderr=""),
+            ]
 
             path, name = get_worktree_context()
 
             assert path == "/home/user/repo"
             assert name == "detached-abc1234"
-            assert mock_run.call_count == 1
+            assert mock_run.call_count == 2
 
     def test_handles_detached_head_missing_hash(self):
-        """Falls back to 'detached' if the short hash line is empty."""
+        """Falls back to directory name if the targeted --short HEAD call fails.
+
+        This covers the unborn-branch case (git init, no commits yet): git
+        reports is-inside-work-tree=true but --short HEAD fails with rc=128
+        because HEAD is unresolvable.  The fallback is the directory name,
+        matching pre-PR behavior.
+        """
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=_combined("true", "false", "/home/user/repo", "HEAD", ""),
-                stderr="",
-            )
+            mock_run.side_effect = [
+                # First call: combined rev-parse; line 4 is "HEAD" (detached or unborn).
+                MagicMock(
+                    returncode=128,
+                    stdout=_combined("true", "false", "/home/user/repo", "HEAD"),
+                    stderr="fatal: ambiguous argument 'HEAD'",
+                ),
+                # Second call: --short HEAD fails (e.g., unborn branch / no commits).
+                MagicMock(returncode=128, stdout="", stderr="fatal"),
+            ]
 
             path, name = get_worktree_context()
 
             assert path == "/home/user/repo"
-            assert name == "detached"
+            assert name == "repo"
 
     def test_empty_branch_name_uses_directory(self):
         """Uses directory name if the branch line is empty."""
@@ -119,7 +148,7 @@ class TestGetWorktreeContext:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0,
-                stdout=_combined("true", "false", "/home/user/project", "", ""),
+                stdout=_combined("true", "false", "/home/user/project", ""),
                 stderr="",
             )
 
@@ -139,9 +168,7 @@ class TestGetWorktreeContext:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0,
-                stdout=_combined(
-                    "true", "false", "/home/user/repo", "feature/foo-bar", "abc1234"
-                ),
+                stdout=_combined("true", "false", "/home/user/repo", "feature/foo-bar"),
                 stderr="",
             )
 

--- a/tests/unit/client/test_git.py
+++ b/tests/unit/client/test_git.py
@@ -1,30 +1,38 @@
 # tests/unit/client/test_git.py
-"""Tests for git worktree context detection."""
-import subprocess
+"""Tests for git worktree context detection.
+
+Worktree context is resolved in a SINGLE git invocation:
+``git rev-parse --is-inside-work-tree --is-bare-repository --show-toplevel
+--abbrev-ref HEAD --short HEAD``. Each flag emits one output line, in order:
+    1. is_inside_work_tree  ("true" / "false")
+    2. is_bare              ("true" / "false")
+    3. toplevel             (absolute worktree root)
+    4. branch               (branch name, or "HEAD" when detached)
+    5. short_sha            (short commit sha)
+"""
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
+def _combined(*lines: str) -> str:
+    """Build the multi-line stdout `git rev-parse` emits for the combined call."""
+    return "".join(f"{line}\n" for line in lines)
+
+
 class TestGetWorktreeContext:
     """Tests for get_worktree_context function."""
 
-    def test_returns_tuple(self):
-        """Returns (worktree_path, worktree_name) tuple."""
+    def test_returns_tuple_in_single_invocation(self):
+        """Resolves context in ONE git call and parses combined output."""
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            # Mock git rev-parse --is-inside-work-tree
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="true\n", stderr=""
+                returncode=0,
+                stdout=_combined("true", "false", "/home/user/repo", "main", "abc1234"),
+                stderr="",
             )
-
-            # Second call: git rev-parse --show-toplevel
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),
-                MagicMock(returncode=0, stdout="/home/user/repo\n", stderr=""),
-                MagicMock(returncode=0, stdout="main\n", stderr=""),
-            ]
 
             path, name = get_worktree_context()
 
@@ -32,28 +40,35 @@ class TestGetWorktreeContext:
             assert isinstance(name, str)
             assert path == "/home/user/repo"
             assert name == "main"
+            # Acceptance criterion: a SINGLE git invocation resolves context.
+            assert mock_run.call_count == 1
 
     def test_raises_when_not_in_git_repo(self):
         """Raises ValueError when not in a git repository."""
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=128, stdout="false\n", stderr="not a git repository"
-            )
+            # Combined rev-parse exits non-zero with no usable stdout, then the
+            # bare-repository probe reports false.
+            mock_run.side_effect = [
+                MagicMock(returncode=128, stdout="", stderr="not a git repository"),
+                MagicMock(returncode=128, stdout="false\n", stderr=""),
+            ]
 
             with pytest.raises(ValueError, match="Not inside a git repository"):
                 get_worktree_context()
 
     def test_raises_when_in_bare_repo(self):
-        """Raises ValueError when in a bare repository."""
+        """Raises ValueError when in a bare repository.
+
+        In a bare repo, --show-toplevel makes the combined rev-parse exit
+        non-zero, so the follow-up --is-bare-repository probe disambiguates.
+        """
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            # First call: --is-inside-work-tree (fails)
-            # Second call: --is-bare-repository (true)
             mock_run.side_effect = [
-                MagicMock(returncode=128, stdout="false\n", stderr=""),
+                MagicMock(returncode=128, stdout="false\ntrue\n", stderr="fatal"),
                 MagicMock(returncode=0, stdout="true\n", stderr=""),
             ]
 
@@ -61,82 +76,91 @@ class TestGetWorktreeContext:
                 get_worktree_context()
 
     def test_handles_detached_head(self):
-        """Uses short commit hash as name for detached HEAD."""
+        """Uses short commit hash as name for detached HEAD.
+
+        When detached, --abbrev-ref HEAD emits the literal "HEAD"; the name is
+        derived from the short sha line of the SAME combined output.
+        """
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),  # is-inside-work-tree
-                MagicMock(returncode=0, stdout="/home/user/repo\n", stderr=""),  # show-toplevel
-                MagicMock(returncode=0, stdout="HEAD\n", stderr=""),  # abbrev-ref HEAD
-                MagicMock(returncode=0, stdout="abc1234\n", stderr=""),  # short hash
-            ]
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_combined("true", "false", "/home/user/repo", "HEAD", "abc1234"),
+                stderr="",
+            )
 
             path, name = get_worktree_context()
 
             assert path == "/home/user/repo"
             assert name == "detached-abc1234"
+            assert mock_run.call_count == 1
 
-    def test_handles_detached_head_hash_failure(self):
-        """Falls back to 'detached' if short hash fails."""
+    def test_handles_detached_head_missing_hash(self):
+        """Falls back to 'detached' if the short hash line is empty."""
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),  # is-inside-work-tree
-                MagicMock(returncode=0, stdout="/home/user/repo\n", stderr=""),  # show-toplevel
-                MagicMock(returncode=0, stdout="HEAD\n", stderr=""),  # abbrev-ref HEAD
-                subprocess.CalledProcessError(1, "git"),  # short hash fails
-            ]
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_combined("true", "false", "/home/user/repo", "HEAD", ""),
+                stderr="",
+            )
 
             path, name = get_worktree_context()
 
             assert path == "/home/user/repo"
             assert name == "detached"
 
-    def test_uses_directory_name_when_branch_detection_fails(self):
-        """Falls back to directory name if branch detection fails."""
-        from amelia.client.git import get_worktree_context
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),  # is-inside-work-tree
-                MagicMock(returncode=0, stdout="/home/user/my-repo\n", stderr=""),  # show-toplevel
-                subprocess.CalledProcessError(1, "git"),  # abbrev-ref fails
-            ]
-
-            path, name = get_worktree_context()
-
-            assert path == "/home/user/my-repo"
-            assert name == "my-repo"
-
-    def test_raises_runtime_error_on_toplevel_failure(self):
-        """Raises RuntimeError if git rev-parse --show-toplevel fails."""
-        from amelia.client.git import get_worktree_context
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),  # is-inside-work-tree
-                subprocess.CalledProcessError(
-                    1, "git", stderr="fatal: not a git repository"
-                ),  # show-toplevel
-            ]
-
-            with pytest.raises(RuntimeError, match="Failed to determine worktree root"):
-                get_worktree_context()
-
     def test_empty_branch_name_uses_directory(self):
-        """Uses directory name if branch name is empty."""
+        """Uses directory name if the branch line is empty."""
         from amelia.client.git import get_worktree_context
 
         with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="true\n", stderr=""),  # is-inside-work-tree
-                MagicMock(returncode=0, stdout="/home/user/project\n", stderr=""),  # show-toplevel
-                MagicMock(returncode=0, stdout="\n", stderr=""),  # empty branch name
-            ]
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_combined("true", "false", "/home/user/project", "", ""),
+                stderr="",
+            )
 
             path, name = get_worktree_context()
 
             assert path == "/home/user/project"
             assert name == "project"
+
+    def test_branch_with_slash_is_preserved(self):
+        """A branch name containing '/' must not be split or truncated.
+
+        This is the shape that breaks naive parsing that splits on '/' or
+        assumes the path is the last token.
+        """
+        from amelia.client.git import get_worktree_context
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_combined(
+                    "true", "false", "/home/user/repo", "feature/foo-bar", "abc1234"
+                ),
+                stderr="",
+            )
+
+            path, name = get_worktree_context()
+
+            assert path == "/home/user/repo"
+            assert name == "feature/foo-bar"
+
+    def test_truncated_output_raises_runtime_error(self):
+        """Raises RuntimeError if combined output is missing required lines."""
+        from amelia.client.git import get_worktree_context
+
+        with patch("subprocess.run") as mock_run:
+            # rev-parse succeeded but emitted fewer lines than expected.
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_combined("true", "false"),
+                stderr="",
+            )
+
+            with pytest.raises(RuntimeError, match="Failed to determine worktree root"):
+                get_worktree_context()

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -354,6 +354,33 @@ class TestLocalSandbox:
         assert sync_result.output == async_result.output
         assert sync_result.exit_code == async_result.exit_code
 
+    async def test_aexecute_runs_blocking_subprocess_off_event_loop(
+        self, sandbox: LocalSandbox
+    ) -> None:
+        """The blocking shell subprocess must not run on the event loop thread.
+
+        Observable consequence: the thread that runs ``execute`` (and therefore
+        the blocking ``subprocess.run``) is a worker thread, distinct from the
+        event-loop thread. If ``aexecute`` ever called ``execute`` directly, the
+        captured thread id would equal the loop thread and the loop would block.
+        """
+        import threading
+
+        loop_thread_id = threading.get_ident()
+        captured: dict[str, int] = {}
+
+        original_execute = sandbox.execute
+
+        def _spy(command: str):  # type: ignore[no-untyped-def]
+            captured["thread_id"] = threading.get_ident()
+            return original_execute(command)
+
+        with patch.object(sandbox, "execute", side_effect=_spy):
+            result = await sandbox.aexecute("echo offloaded")
+
+        assert "offloaded" in result.output
+        assert captured["thread_id"] != loop_thread_id
+
     def test_virtual_mode_resolves_virtual_paths_under_cwd(self, tmp_path: Path) -> None:
         """virtual_mode=True should resolve /path/to/file as {cwd}/path/to/file.
 

--- a/tests/unit/tools/test_file_bundler.py
+++ b/tests/unit/tools/test_file_bundler.py
@@ -1,5 +1,6 @@
 """Tests for FileBundler utility."""
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -38,9 +39,8 @@ class TestBundleFiles:
     """Tests for the bundle_files async function."""
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_single_file(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should gather a single file matching a pattern."""
         repo = tmp_path / "repo"
@@ -58,9 +58,8 @@ class TestBundleFiles:
         assert bundle.total_tokens > 0
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_glob_pattern(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should resolve glob patterns."""
         repo = tmp_path / "repo"
@@ -79,9 +78,8 @@ class TestBundleFiles:
         assert paths == ["src/a.py", "src/b.py"]
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_respects_gitignore(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should exclude gitignored files (via mocked tracked set)."""
         repo = tmp_path / "repo"
@@ -100,9 +98,8 @@ class TestBundleFiles:
         assert "ignored.py" not in paths
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_skips_binary_files(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should skip binary files (null bytes detected)."""
         repo = tmp_path / "repo"
@@ -119,9 +116,8 @@ class TestBundleFiles:
         assert "binary.bin" not in paths
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_path_traversal_blocked(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should reject paths that escape working_dir."""
         repo = tmp_path / "repo"
@@ -134,9 +130,8 @@ class TestBundleFiles:
             )
 
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_exclude_patterns(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files should respect exclude_patterns."""
         repo = tmp_path / "repo"
@@ -170,10 +165,78 @@ class TestBundleFiles:
         assert "main.py" in paths
         assert "node_modules/dep.js" not in paths
 
+    async def test_ls_files_failure_falls_back_without_extra_probe(
+        self, tmp_path: Path
+    ):
+        """A failing `git ls-files` alone signals non-git mode.
+
+        The redundant `rev-parse --git-dir` probe is gone: `git ls-files` is the
+        only git subprocess, and when it exits non-zero the bundler falls back to
+        non-git mode (default directory exclusions) without any second probe.
+        """
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "main.py").write_text("main")
+        node_modules = work / "node_modules"
+        node_modules.mkdir()
+        (node_modules / "dep.js").write_text("dep")
+
+        with patch("amelia.tools.file_bundler.subprocess.run") as mock_run:
+            # ls-files fails -> _get_git_tracked_files returns None -> non-git mode.
+            mock_run.return_value = MagicMock(
+                returncode=128, stdout="", stderr="not a git repository"
+            )
+
+            bundle = await bundle_files(
+                working_dir=str(work),
+                patterns=["**/*.py", "**/*.js"],
+            )
+
+        # Exactly one git subprocess (ls-files); no separate rev-parse pre-check.
+        assert mock_run.call_count == 1
+        invoked_args = mock_run.call_args.args[0]
+        assert invoked_args[:2] == ["git", "ls-files"]
+
+        # Observable consequence: non-git exclusions applied (node_modules dropped).
+        paths = [f.path for f in bundle.files]
+        assert "main.py" in paths
+        assert "node_modules/dep.js" not in paths
+
+    async def test_git_mode_uses_real_ls_files(self, tmp_path: Path):
+        """Real `git ls-files` in an actual repo respects tracking/.gitignore.
+
+        Drives the production subprocess path (no mocks) to confirm the single
+        ls-files probe correctly distinguishes tracked from gitignored files.
+        """
+        import subprocess as real_subprocess
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        real_subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        (repo / ".gitignore").write_text("ignored.py\n")
+        (repo / "tracked.py").write_text("x = 1")
+        (repo / "ignored.py").write_text("y = 2")
+        real_subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+        real_subprocess.run(
+            ["git", "commit", "-qm", "init"], cwd=repo, check=True, env=env
+        )
+
+        bundle = await bundle_files(working_dir=str(repo), patterns=["*.py"])
+
+        paths = [f.path for f in bundle.files]
+        assert "tracked.py" in paths
+        assert "ignored.py" not in paths
+
     @patch("amelia.tools.file_bundler._get_git_tracked_files")
-    @patch("amelia.tools.file_bundler._is_git_repo", return_value=True)
     async def test_bundle_empty_patterns(
-        self, mock_is_git: MagicMock, mock_tracked: MagicMock, tmp_path: Path
+        self, mock_tracked: MagicMock, tmp_path: Path
     ):
         """bundle_files with no matching patterns should return empty bundle."""
         repo = tmp_path / "repo"


### PR DESCRIPTION
## Problem
`client/git.py` ran up to 5 serial blocking `subprocess.run` git probes; `file_bundler.py` ran a redundant repo pre-check; a sync `shell=True` subprocess could block the loop.

## Change
- Collapse worktree-context detection into a single `git rev-parse` invocation, parsing combined output.
- Drop the redundant `_is_git_repo` probe in `file_bundler` — a failing `git ls-files` already signals non-git.
- Ensure the blocking shell subprocess runs via `asyncio.to_thread` (loop never blocked).

## Verification
Pre-push gate (ruff, mypy, pytest, pnpm build) passed on push. Tests cover in-repo / bare / not-a-repo / detached-HEAD / slash-branch / truncated shapes and the off-loop boundary.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH