### PR TITLE
perf(pr-autofix): parallelize per-comment reply/resolve (#643)

### DIFF
--- a/amelia/pipelines/pr_auto_fix/nodes.py
+++ b/amelia/pipelines/pr_auto_fix/nodes.py
@@ -8,6 +8,7 @@ resolve threads).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +37,11 @@ from amelia.services.classifier import (
 )
 from amelia.services.github_pr import GitHubPRService
 from amelia.tools.git_utils import GitOperations
+
+
+# Max concurrent gh subprocesses for per-comment reply/resolve in reply_resolve_node.
+# Keeps the resolution phase ~constant in comment count while staying polite to the API.
+_REPLY_RESOLVE_CONCURRENCY = 5
 
 
 async def classify_node(
@@ -489,8 +495,13 @@ async def reply_resolve_node(
         c.id: c for c in state.comments
     }
 
-    resolution_results: list[ResolutionResult] = []
+    # Bound concurrent gh subprocesses to stay polite to the GitHub API. Replies
+    # across DIFFERENT comments are independent; resolve depends only on its own
+    # reply, so we chain reply->resolve WITHIN each per-comment coroutine and run
+    # those coroutines concurrently under a semaphore.
+    semaphore = asyncio.Semaphore(_REPLY_RESOLVE_CONCURRENCY)
 
+    tasks: list[asyncio.Task[ResolutionResult | None]] = []
     for group_result in state.group_results:
         for comment_id in group_result.comment_ids:
             comment = comments_by_id.get(comment_id)
@@ -500,109 +511,134 @@ async def reply_resolve_node(
                     comment_id=comment_id,
                 )
                 continue
-
-            # Guard: skip reply/resolve when commit or push failed.
-            if group_result.status == GroupFixStatus.FIXED and not state.commit_sha:
-                # Developer "completed" without producing real file changes
-                logger.warning(
-                    "Group marked FIXED but no commit was made, skipping reply/resolve",
-                    comment_id=comment_id,
-                    file_path=group_result.file_path,
-                )
-                resolution_results.append(
-                    ResolutionResult(
-                        comment_id=comment.id,
-                        replied=False,
-                        resolved=False,
-                        error="No commit was made despite FIXED status",
+            tasks.append(
+                asyncio.create_task(
+                    _reply_resolve_comment(
+                        github_service,
+                        state,
+                        group_result,
+                        comment,
+                        semaphore,
                     )
-                )
-                continue
-
-            if group_result.status == GroupFixStatus.FIXED and state.status == "failed":
-                # Commit succeeded but push failed — changes aren't on the remote
-                logger.warning(
-                    "Group marked FIXED but push failed, skipping reply/resolve",
-                    comment_id=comment_id,
-                    file_path=group_result.file_path,
-                    commit_sha=state.commit_sha,
-                )
-                resolution_results.append(
-                    ResolutionResult(
-                        comment_id=comment.id,
-                        replied=False,
-                        resolved=False,
-                        error="Fix committed but push to remote failed",
-                    )
-                )
-                continue
-
-            replied = False
-            resolved = False
-            error_msg: str | None = None
-
-            body = _build_reply_body(
-                group_result.status,
-                comment.author,
-                state.commit_sha,
-                group_result.error,
-            )
-            try:
-                await github_service.reply_to_comment(
-                    state.pr_number,
-                    comment.id,
-                    body,
-                    in_reply_to_id=comment.in_reply_to_id,
-                )
-                replied = True
-            except Exception as e:
-                logger.error(
-                    "Failed to reply to comment",
-                    comment_id=comment.id,
-                    error=str(e),
-                )
-                error_msg = str(e)
-
-            should_resolve = (
-                group_result.status == GroupFixStatus.FIXED
-                or (
-                    group_result.status == GroupFixStatus.NO_CHANGES
-                    and state.autofix_config.resolve_no_changes
                 )
             )
 
-            if should_resolve and replied:
-                if comment.thread_id:
-                    try:
-                        await github_service.resolve_thread(comment.thread_id)
-                        resolved = True
-                    except Exception as e:
-                        logger.error(
-                            "Failed to resolve thread",
-                            comment_id=comment.id,
-                            thread_id=comment.thread_id,
-                            error=str(e),
-                        )
-                        error_msg = str(e)
-                else:
-                    logger.warning(
-                        "No thread_id for comment, skipping resolve",
-                        comment_id=comment.id,
-                    )
-            elif should_resolve and not replied:
-                logger.warning(
-                    "Skipping thread resolve because reply was not posted",
-                    comment_id=comment.id,
-                    thread_id=comment.thread_id,
-                )
-
-            resolution_results.append(
-                ResolutionResult(
-                    comment_id=comment.id,
-                    replied=replied,
-                    resolved=resolved,
-                    error=error_msg,
-                )
-            )
+    # gather preserves input order, so resolution_results stays deterministic
+    # regardless of completion order. No shared mutable state across coroutines:
+    # each builds and returns its own ResolutionResult.
+    gathered = await asyncio.gather(*tasks)
+    resolution_results: list[ResolutionResult] = [r for r in gathered if r is not None]
 
     return {"status": "completed", "resolution_results": resolution_results}
+
+
+async def _reply_resolve_comment(
+    github_service: GitHubPRService,
+    state: PRAutoFixState,
+    group_result: GroupFixResult,
+    comment: PRReviewComment,
+    semaphore: asyncio.Semaphore,
+) -> ResolutionResult | None:
+    """Reply to one comment and (conditionally) resolve its thread.
+
+    Runs reply->resolve serially WITHIN this coroutine (resolve depends on its
+    own reply), but the coroutine itself runs concurrently with others under the
+    shared semaphore. Owns all its local state; returns a single ResolutionResult.
+    """
+    # Guard: skip reply/resolve when commit or push failed.
+    if group_result.status == GroupFixStatus.FIXED and not state.commit_sha:
+        # Developer "completed" without producing real file changes
+        logger.warning(
+            "Group marked FIXED but no commit was made, skipping reply/resolve",
+            comment_id=comment.id,
+            file_path=group_result.file_path,
+        )
+        return ResolutionResult(
+            comment_id=comment.id,
+            replied=False,
+            resolved=False,
+            error="No commit was made despite FIXED status",
+        )
+
+    if group_result.status == GroupFixStatus.FIXED and state.status == "failed":
+        # Commit succeeded but push failed — changes aren't on the remote
+        logger.warning(
+            "Group marked FIXED but push failed, skipping reply/resolve",
+            comment_id=comment.id,
+            file_path=group_result.file_path,
+            commit_sha=state.commit_sha,
+        )
+        return ResolutionResult(
+            comment_id=comment.id,
+            replied=False,
+            resolved=False,
+            error="Fix committed but push to remote failed",
+        )
+
+    replied = False
+    resolved = False
+    error_msg: str | None = None
+
+    body = _build_reply_body(
+        group_result.status,
+        comment.author,
+        state.commit_sha,
+        group_result.error,
+    )
+
+    async with semaphore:
+        try:
+            await github_service.reply_to_comment(
+                state.pr_number,
+                comment.id,
+                body,
+                in_reply_to_id=comment.in_reply_to_id,
+            )
+            replied = True
+        except Exception as e:
+            logger.error(
+                "Failed to reply to comment",
+                comment_id=comment.id,
+                error=str(e),
+            )
+            error_msg = str(e)
+
+        should_resolve = (
+            group_result.status == GroupFixStatus.FIXED
+            or (
+                group_result.status == GroupFixStatus.NO_CHANGES
+                and state.autofix_config.resolve_no_changes
+            )
+        )
+
+        if should_resolve and replied:
+            if comment.thread_id:
+                try:
+                    await github_service.resolve_thread(comment.thread_id)
+                    resolved = True
+                except Exception as e:
+                    logger.error(
+                        "Failed to resolve thread",
+                        comment_id=comment.id,
+                        thread_id=comment.thread_id,
+                        error=str(e),
+                    )
+                    error_msg = str(e)
+            else:
+                logger.warning(
+                    "No thread_id for comment, skipping resolve",
+                    comment_id=comment.id,
+                )
+        elif should_resolve and not replied:
+            logger.warning(
+                "Skipping thread resolve because reply was not posted",
+                comment_id=comment.id,
+                thread_id=comment.thread_id,
+            )
+
+    return ResolutionResult(
+        comment_id=comment.id,
+        replied=replied,
+        resolved=resolved,
+        error=error_msg,
+    )

--- a/amelia/pipelines/pr_auto_fix/nodes.py
+++ b/amelia/pipelines/pr_auto_fix/nodes.py
@@ -498,10 +498,10 @@ async def reply_resolve_node(
     # Bound concurrent gh subprocesses to stay polite to the GitHub API. Replies
     # across DIFFERENT comments are independent; resolve depends only on its own
     # reply, so we chain reply->resolve WITHIN each per-comment coroutine and run
-    # those coroutines concurrently under a semaphore.
+    # those coroutines concurrently, with each GitHub call using the semaphore.
     semaphore = asyncio.Semaphore(_REPLY_RESOLVE_CONCURRENCY)
 
-    tasks: list[asyncio.Task[ResolutionResult | None]] = []
+    tasks: list[asyncio.Task[ResolutionResult]] = []
     for group_result in state.group_results:
         for comment_id in group_result.comment_ids:
             comment = comments_by_id.get(comment_id)
@@ -526,8 +526,7 @@ async def reply_resolve_node(
     # gather preserves input order, so resolution_results stays deterministic
     # regardless of completion order. No shared mutable state across coroutines:
     # each builds and returns its own ResolutionResult.
-    gathered = await asyncio.gather(*tasks)
-    resolution_results: list[ResolutionResult] = [r for r in gathered if r is not None]
+    resolution_results: list[ResolutionResult] = list(await asyncio.gather(*tasks))
 
     return {"status": "completed", "resolution_results": resolution_results}
 
@@ -538,11 +537,11 @@ async def _reply_resolve_comment(
     group_result: GroupFixResult,
     comment: PRReviewComment,
     semaphore: asyncio.Semaphore,
-) -> ResolutionResult | None:
+) -> ResolutionResult:
     """Reply to one comment and (conditionally) resolve its thread.
 
     Runs reply->resolve serially WITHIN this coroutine (resolve depends on its
-    own reply), but the coroutine itself runs concurrently with others under the
+    own reply), but each GitHub service call is individually bounded by the
     shared semaphore. Owns all its local state; returns a single ResolutionResult.
     """
     # Guard: skip reply/resolve when commit or push failed.
@@ -586,55 +585,56 @@ async def _reply_resolve_comment(
         group_result.error,
     )
 
-    async with semaphore:
-        try:
+    try:
+        async with semaphore:
             await github_service.reply_to_comment(
                 state.pr_number,
                 comment.id,
                 body,
                 in_reply_to_id=comment.in_reply_to_id,
             )
-            replied = True
-        except Exception as e:
-            logger.error(
-                "Failed to reply to comment",
-                comment_id=comment.id,
-                error=str(e),
-            )
-            error_msg = str(e)
-
-        should_resolve = (
-            group_result.status == GroupFixStatus.FIXED
-            or (
-                group_result.status == GroupFixStatus.NO_CHANGES
-                and state.autofix_config.resolve_no_changes
-            )
+        replied = True
+    except Exception as e:
+        logger.error(
+            "Failed to reply to comment",
+            comment_id=comment.id,
+            error=str(e),
         )
+        error_msg = str(e)
 
-        if should_resolve and replied:
-            if comment.thread_id:
-                try:
+    should_resolve = (
+        group_result.status == GroupFixStatus.FIXED
+        or (
+            group_result.status == GroupFixStatus.NO_CHANGES
+            and state.autofix_config.resolve_no_changes
+        )
+    )
+
+    if should_resolve and replied:
+        if comment.thread_id:
+            try:
+                async with semaphore:
                     await github_service.resolve_thread(comment.thread_id)
-                    resolved = True
-                except Exception as e:
-                    logger.error(
-                        "Failed to resolve thread",
-                        comment_id=comment.id,
-                        thread_id=comment.thread_id,
-                        error=str(e),
-                    )
-                    error_msg = str(e)
-            else:
-                logger.warning(
-                    "No thread_id for comment, skipping resolve",
+                resolved = True
+            except Exception as e:
+                logger.error(
+                    "Failed to resolve thread",
                     comment_id=comment.id,
+                    thread_id=comment.thread_id,
+                    error=str(e),
                 )
-        elif should_resolve and not replied:
+                error_msg = str(e)
+        else:
             logger.warning(
-                "Skipping thread resolve because reply was not posted",
+                "No thread_id for comment, skipping resolve",
                 comment_id=comment.id,
-                thread_id=comment.thread_id,
             )
+    elif should_resolve and not replied:
+        logger.warning(
+            "Skipping thread resolve because reply was not posted",
+            comment_id=comment.id,
+            thread_id=comment.thread_id,
+        )
 
     return ResolutionResult(
         comment_id=comment.id,

--- a/tests/unit/pipelines/pr_auto_fix/conftest.py
+++ b/tests/unit/pipelines/pr_auto_fix/conftest.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.runnables import RunnableConfig
 
 from amelia.agents.schemas.classifier import CommentCategory, CommentClassification
 from amelia.core.types import (
@@ -109,7 +110,7 @@ def make_node_profile() -> Profile:
     )
 
 
-def make_runnable_config(profile: Profile | None = None) -> dict[str, Any]:
+def make_runnable_config(profile: Profile | None = None) -> RunnableConfig:
     """Build a LangGraph-style RunnableConfig."""
     if profile is None:
         profile = make_node_profile()

--- a/tests/unit/pipelines/pr_auto_fix/test_nodes.py
+++ b/tests/unit/pipelines/pr_auto_fix/test_nodes.py
@@ -633,6 +633,117 @@ class TestReplyResolveNode:
         assert "Developer error" in body
         mock_gh.resolve_thread.assert_not_called()
 
+    async def test_replies_resolves_run_concurrently_semaphore_bounded(self) -> None:
+        """N comments: replies/resolves run concurrently, bounded by the semaphore,
+        and each resolve follows its OWN reply (per-comment ordering preserved).
+
+        Observable consequences asserted:
+        - max concurrent in-flight calls <= semaphore bound (5)
+        - all replies start before any resolve completes (true concurrency, not serial)
+        - per-comment reply->resolve pairing (resolve(thread) only after reply(comment))
+        """
+        import asyncio
+
+        from amelia.pipelines.pr_auto_fix import nodes as nodes_mod
+
+        n = 6  # > semaphore bound to prove bounding; > 3 per acceptance criteria
+        cids = list(range(1, n + 1))
+        tids = [f"T_{cid}" for cid in cids]
+        # Map each comment id -> its thread id, to verify pairing.
+        comment_to_thread = dict(zip(cids, tids, strict=True))
+
+        state, config = _make_reply_resolve_state(
+            comment_ids=cids,
+            authors=[f"rev{cid}" for cid in cids],
+            thread_ids=tids,
+        )
+
+        class FakeGitHub:
+            def __init__(self) -> None:
+                self.events: list[tuple[str, Any]] = []
+                self.in_flight = 0
+                self.max_in_flight = 0
+                self.replied_comments: set[int] = set()
+                self.resolved_threads: list[str] = []
+                # comment_id at reply time -> thread_id at resolve time, to check pairing
+                self.reply_order: list[int] = []
+                self.resolve_after_reply: dict[str, set[int]] = {}
+
+            async def _track(self) -> None:
+                self.in_flight += 1
+                self.max_in_flight = max(self.max_in_flight, self.in_flight)
+                # Yield enough times to let all coroutines reach peak concurrency.
+                for _ in range(5):
+                    await asyncio.sleep(0)
+
+            async def reply_to_comment(
+                self, pr_number: int, comment_id: int, body: str, in_reply_to_id: Any = None,
+            ) -> None:
+                await self._track()
+                self.events.append(("reply_start", comment_id))
+                self.replied_comments.add(comment_id)
+                self.reply_order.append(comment_id)
+                await asyncio.sleep(0)
+                self.events.append(("reply_done", comment_id))
+                self.in_flight -= 1
+
+            async def resolve_thread(self, thread_node_id: str) -> None:
+                await self._track()
+                # Per-comment pairing: the matching reply MUST have completed first.
+                self.resolve_after_reply[thread_node_id] = set(self.replied_comments)
+                self.events.append(("resolve_start", thread_node_id))
+                self.resolved_threads.append(thread_node_id)
+                await asyncio.sleep(0)
+                self.events.append(("resolve_done", thread_node_id))
+                self.in_flight -= 1
+
+        fake = FakeGitHub()
+        with patch.object(nodes_mod, "GitHubPRService", return_value=fake):
+            result = await reply_resolve_node(state, config)
+
+        # All comments replied and all threads resolved.
+        assert fake.replied_comments == set(cids)
+        assert sorted(fake.resolved_threads) == sorted(tids)
+
+        # Semaphore bound respected.
+        assert fake.max_in_flight <= 5, f"max in-flight {fake.max_in_flight} exceeded bound 5"
+
+        # True concurrency: more than one call was in flight at once (would be 1 if serial).
+        assert fake.max_in_flight > 1, "calls ran serially -- no concurrency"
+
+        # Concurrency across comments: the first resolve starts before the last reply
+        # done -- impossible under strictly-serial reply-all-then-resolve-all... but more
+        # importantly, replies for distinct comments overlap. Assert at least 2 replies
+        # were in flight simultaneously by checking interleaving in the event log.
+        reply_starts_before_first_done = 0
+        first_reply_done_idx = next(
+            i for i, (k, _) in enumerate(fake.events) if k == "reply_done"
+        )
+        reply_starts_before_first_done = sum(
+            1 for k, _ in fake.events[:first_reply_done_idx] if k == "reply_start"
+        )
+        assert reply_starts_before_first_done >= 2, (
+            "replies did not overlap -- ran serially"
+        )
+
+        # Per-comment pairing: each thread resolved only AFTER its own comment's reply.
+        for tid in tids:
+            replied_at_resolve = fake.resolve_after_reply[tid]
+            # tid == f"T_{cid}"; the owning comment must have been replied before resolve.
+            owning_cid = int(tid.split("_")[1])
+            assert owning_cid in replied_at_resolve, (
+                f"thread {tid} resolved before its own comment {owning_cid} reply"
+            )
+
+        # Results: every comment replied + resolved.
+        assert result["status"] == "completed"
+        assert len(result["resolution_results"]) == n
+        for res in result["resolution_results"]:
+            assert res.replied is True
+            assert res.resolved is True
+        # Sanity: pairing map covers exactly our comment->thread mapping.
+        assert {int(t.split("_")[1]) for t in comment_to_thread.values()} == set(cids)
+
     async def test_graph_includes_reply_resolve(self) -> None:
         from amelia.pipelines.pr_auto_fix.graph import create_pr_auto_fix_graph
 

--- a/tests/unit/pipelines/pr_auto_fix/test_nodes.py
+++ b/tests/unit/pipelines/pr_auto_fix/test_nodes.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.runnables import RunnableConfig
 
 from amelia.agents.prompts.defaults import PROMPT_DEFAULTS
 from amelia.agents.schemas.classifier import CommentCategory
@@ -448,10 +450,10 @@ def _make_reply_resolve_state(
     error: str | None = None,
     commit_sha: str = "abc1234567890",
     authors: list[str] | None = None,
-    thread_ids: list[str | None] | None = None,
+    thread_ids: Sequence[str | None] | None = None,
     autofix_config: PRAutoFixConfig | None = None,
     pipeline_status: str = "pending",
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[Any, RunnableConfig]:
     """Build state + config for reply_resolve_node tests."""
     cids = comment_ids or [1]
     auths = authors or ["reviewer1"] * len(cids)
@@ -485,7 +487,7 @@ class TestReplyResolveNode:
 
     @staticmethod
     async def _run_node(
-        state: Any, config: dict[str, Any], *, setup_mock: Any = None,
+        state: Any, config: RunnableConfig, *, setup_mock: Any = None,
     ) -> tuple[dict[str, Any], AsyncMock]:
         with patch("amelia.pipelines.pr_auto_fix.nodes.GitHubPRService") as mock_gh_cls:
             mock_gh = AsyncMock()
@@ -639,7 +641,7 @@ class TestReplyResolveNode:
 
         Observable consequences asserted:
         - max concurrent in-flight calls <= semaphore bound (5)
-        - all replies start before any resolve completes (true concurrency, not serial)
+        - semaphore scope is one GitHub call, not one whole per-comment sequence
         - per-comment reply->resolve pairing (resolve(thread) only after reply(comment))
         """
         import asyncio
@@ -679,19 +681,19 @@ class TestReplyResolveNode:
             async def reply_to_comment(
                 self, pr_number: int, comment_id: int, body: str, in_reply_to_id: Any = None,
             ) -> None:
-                await self._track()
                 self.events.append(("reply_start", comment_id))
-                self.replied_comments.add(comment_id)
+                await self._track()
                 self.reply_order.append(comment_id)
                 await asyncio.sleep(0)
                 self.events.append(("reply_done", comment_id))
                 self.in_flight -= 1
+                self.replied_comments.add(comment_id)
 
             async def resolve_thread(self, thread_node_id: str) -> None:
+                self.events.append(("resolve_start", thread_node_id))
                 await self._track()
                 # Per-comment pairing: the matching reply MUST have completed first.
                 self.resolve_after_reply[thread_node_id] = set(self.replied_comments)
-                self.events.append(("resolve_start", thread_node_id))
                 self.resolved_threads.append(thread_node_id)
                 await asyncio.sleep(0)
                 self.events.append(("resolve_done", thread_node_id))
@@ -724,6 +726,16 @@ class TestReplyResolveNode:
         )
         assert reply_starts_before_first_done >= 2, (
             "replies did not overlap -- ran serially"
+        )
+
+        first_resolve_start_idx = next(
+            i for i, (k, _) in enumerate(fake.events) if k == "resolve_start"
+        )
+        reply_starts_before_first_resolve = sum(
+            1 for k, _ in fake.events[:first_resolve_start_idx] if k == "reply_start"
+        )
+        assert reply_starts_before_first_resolve == n, (
+            "semaphore was held across an entire per-comment reply/resolve sequence"
         )
 
         # Per-comment pairing: each thread resolved only AFTER its own comment's reply.


### PR DESCRIPTION
## Problem

The PR-auto-fix resolution node (`reply_resolve_node`) looped over every group's every comment and `await`ed `reply_to_comment` then `resolve_thread` **strictly serially**. Each call spawns a fresh `gh` subprocess (~300ms–1s via `_run_gh` → `create_subprocess_exec`), so a PR with N comments cost **2N serial subprocesses** on the critical path — all *after* the fix was already committed and pushed.

## Change

- Extracted a per-comment coroutine `_reply_resolve_comment` that chains `reply → resolve` for its **own** comment (resolve depends only on its own reply, so per-comment ordering is preserved).
- `reply_resolve_node` now builds one coroutine per comment and runs them concurrently via `asyncio.gather`, bounded by `asyncio.Semaphore(5)` to stay polite to the GitHub API.
- Each coroutine owns its local state and returns a single `ResolutionResult` — no shared mutable state. `gather` preserves input order, so `resolution_results` stays deterministic regardless of completion order.

Resolution-phase wall time goes from ~linear to ~constant in comment count.

## Verification

All run from the worktree:

- `uv run ruff check --fix amelia tests` → 1 fixed, 0 remaining
- `uv run mypy amelia` → Success: no issues found in 183 source files
- `uv run pytest tests/unit/` → 2442 passed, 56 deselected
- `uv run pytest tests/integration/test_pr_autofix_flow.py` → 17 passed
- Pre-push gate (ruff + mypy + pytest + `pnpm build`) → all checks passed

New TDD test `test_replies_resolves_run_concurrently_semaphore_bounded` (N=6 > bound) uses a fake github_pr service recording call order/timing and asserts observable consequences: max in-flight ≤ semaphore bound (5), replies overlap (not serial), and each thread resolves only after its **own** comment's reply (per-comment pairing). It failed against the serial implementation and passes after the change.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH
