### PR TITLE
perf(reviewer): hoist and async-wrap load_skills + diff writes (#646)

### DIFF
--- a/amelia/pipelines/nodes.py
+++ b/amelia/pipelines/nodes.py
@@ -18,7 +18,7 @@ from amelia.agents.reviewer import Reviewer
 from amelia.core.types import ReviewResult
 from amelia.pipelines.implementation.state import ImplementationState
 from amelia.pipelines.utils import extract_node_config, wrap_with_recording
-from amelia.skills.review import REVIEW_TYPE_SKILLS, detect_stack, load_skills
+from amelia.skills.review import REVIEW_TYPE_SKILLS, detect_stack, load_skills_by_type
 from amelia.tools.git_utils import get_current_commit
 
 
@@ -267,9 +267,9 @@ async def call_reviewer_node(
     changed_files = [f for f in changed_files_raw.splitlines() if f.strip()]
     tags = detect_stack(changed_files, diff_content)
 
-    # Write diff to a shared temp file (written once, read by all review passes)
+    # Write diff to a shared temp file (written once, read by all review passes).
+    # mkdir/write_text are synchronous, so run them off the event loop.
     diff_dir = Path(f"/tmp/amelia-review-{nc.workflow_id}")
-    diff_dir.mkdir(parents=True, exist_ok=True)
     diff_path = diff_dir / "diff.patch"
 
     file_list_str = "\n".join(f"  {f}" for f in changed_files)
@@ -278,7 +278,8 @@ async def call_reviewer_node(
         f"Changed files:\n{file_list_str}\n\n"
         f"{diff_content}"
     )
-    diff_path.write_text(diff_file_content)
+    await asyncio.to_thread(diff_dir.mkdir, parents=True, exist_ok=True)
+    await asyncio.to_thread(diff_path.write_text, diff_file_content)
     logger.info("Wrote diff file for review", diff_path=str(diff_path), size=len(diff_file_content))
 
     logger.info(
@@ -288,6 +289,12 @@ async def call_reviewer_node(
         review_types=review_types,
     )
 
+    # Tags and diff are fixed for this invocation, so resolve every review
+    # type's skills in a single off-event-loop pass. Shared base/tag skill
+    # files are read from disk only once here instead of once per pass and per
+    # retry iteration.
+    guidelines_by_type = await asyncio.to_thread(load_skills_by_type, tags, review_types)
+
     # Run a separate reviewer per review type. Passes are independent (they share
     # the read-only diff file written above), so run them concurrently. When more
     # than one type is configured, give each pass a distinct display name so its
@@ -296,7 +303,7 @@ async def call_reviewer_node(
 
     async def _run_pass(review_type: str) -> tuple[ReviewResult, str | None]:
         """Run a single reviewer pass for one review type and return its result and session id."""
-        guidelines = load_skills(tags, [review_type])
+        guidelines = guidelines_by_type[review_type]
         pass_name = f"{agent_name}:{review_type}" if multi_pass else agent_name
         logger.info(
             "Running review pass",

--- a/amelia/skills/review/__init__.py
+++ b/amelia/skills/review/__init__.py
@@ -149,13 +149,17 @@ def _collect_paths(tags: set[str], review_types: list[str]) -> list[str]:
     paths: list[str] = []
     for review_type in review_types:
         paths.extend(REVIEW_TYPE_SKILLS.get(review_type, []))
-    for tag in tags:
+    for tag in sorted(tags):
         paths.extend(REVIEW_SKILLS.get(tag, []))
     return paths
 
 
 def load_skills(tags: set[str], review_types: list[str]) -> str:
     """Load and concatenate review skill files for the given tags and types.
+
+    Retained as the parity oracle for ``load_skills_by_type`` — all production
+    callers route through the batched variant. Tests in
+    ``tests/unit/skills/test_review.py`` verify both produce identical output.
 
     Args:
         tags: Technology tags from detect_stack().

--- a/amelia/skills/review/__init__.py
+++ b/amelia/skills/review/__init__.py
@@ -118,6 +118,42 @@ def detect_stack(file_paths: list[str], diff_content: str) -> set[str]:
     return tags
 
 
+def _read_skill_files(rel_paths: list[str], cache: dict[str, str]) -> str:
+    """Read and concatenate skill files, reading each file at most once.
+
+    Args:
+        rel_paths: Skill file paths to include (order-independent; output is
+            sorted for determinism).
+        cache: Mutable cache mapping rel_path -> stripped file content. Shared
+            across calls so the same base/general skill file is read from disk
+            only once even when multiple review types reference it.
+
+    Returns:
+        Concatenated markdown content joined with "---" separators.
+    """
+    sections: list[str] = []
+    for rel_path in sorted(set(rel_paths)):
+        if rel_path not in cache:
+            full_path = _SKILLS_DIR / rel_path
+            cache[rel_path] = (
+                full_path.read_text(encoding="utf-8").strip() if full_path.exists() else ""
+            )
+        content = cache[rel_path]
+        if content:
+            sections.append(content)
+    return "\n\n---\n\n".join(sections)
+
+
+def _collect_paths(tags: set[str], review_types: list[str]) -> list[str]:
+    """Collect skill file paths for the given tags and review types."""
+    paths: list[str] = []
+    for review_type in review_types:
+        paths.extend(REVIEW_TYPE_SKILLS.get(review_type, []))
+    for tag in tags:
+        paths.extend(REVIEW_SKILLS.get(tag, []))
+    return paths
+
+
 def load_skills(tags: set[str], review_types: list[str]) -> str:
     """Load and concatenate review skill files for the given tags and types.
 
@@ -128,25 +164,27 @@ def load_skills(tags: set[str], review_types: list[str]) -> str:
     Returns:
         Concatenated markdown content from all matched skill files.
     """
-    seen_paths: set[str] = set()
-    sections: list[str] = []
+    return _read_skill_files(_collect_paths(tags, review_types), cache={})
 
-    # Collect file paths from review types
-    for review_type in review_types:
-        for rel_path in REVIEW_TYPE_SKILLS.get(review_type, []):
-            if rel_path not in seen_paths:
-                seen_paths.add(rel_path)
 
-    # Collect file paths from technology tags
-    for tag in sorted(tags):
-        for rel_path in REVIEW_SKILLS.get(tag, []):
-            if rel_path not in seen_paths:
-                seen_paths.add(rel_path)
+def load_skills_by_type(tags: set[str], review_types: list[str]) -> dict[str, str]:
+    """Load review skills for several review types in a single pass.
 
-    # Read and concatenate
-    for rel_path in sorted(seen_paths):
-        full_path = _SKILLS_DIR / rel_path
-        if full_path.exists():
-            sections.append(full_path.read_text(encoding="utf-8").strip())
+    Tag-based skills are shared across review types while each review type has
+    its own base skills. This reads every distinct skill file from disk at most
+    once (shared tag/base files are cached), so callers can resolve guidelines
+    for all configured review types without re-reading shared files per type or
+    per retry iteration.
 
-    return "\n\n---\n\n".join(sections)
+    Args:
+        tags: Technology tags from detect_stack() (fixed for the invocation).
+        review_types: Review types to resolve (e.g., ["general", "security"]).
+
+    Returns:
+        Mapping of review_type -> concatenated markdown guidelines.
+    """
+    cache: dict[str, str] = {}
+    return {
+        review_type: _read_skill_files(_collect_paths(tags, [review_type]), cache)
+        for review_type in review_types
+    }

--- a/tests/unit/core/test_orchestrator_review.py
+++ b/tests/unit/core/test_orchestrator_review.py
@@ -33,7 +33,10 @@ def _mock_skill_detection():
             return_value="",
         ),
         patch("amelia.pipelines.nodes.detect_stack", return_value=set()),
-        patch("amelia.pipelines.nodes.load_skills", return_value=""),
+        patch(
+            "amelia.pipelines.nodes.load_skills_by_type",
+            side_effect=lambda tags, review_types: {rt: "" for rt in review_types},
+        ),
     ):
         yield
 
@@ -207,7 +210,10 @@ class TestCallReviewNodeMultipleReviewTypes:
                 side_effect=mock_git_cmd,
             ),
             patch("amelia.pipelines.nodes.detect_stack", return_value={"python"}),
-            patch("amelia.pipelines.nodes.load_skills", return_value="# Guidelines") as mock_load,
+            patch(
+                "amelia.pipelines.nodes.load_skills_by_type",
+                return_value={"general": "# General", "security": "# Security"},
+            ) as mock_load,
             patch("amelia.pipelines.nodes.Reviewer") as mock_reviewer_cls,
         ):
             mock_reviewer = MagicMock()
@@ -219,10 +225,8 @@ class TestCallReviewNodeMultipleReviewTypes:
 
             # Reviewer constructed twice (once per review type)
             assert mock_reviewer_cls.call_count == 2
-            # load_skills called once per review type
-            assert mock_load.call_count == 2
-            mock_load.assert_any_call({"python"}, ["general"])
-            mock_load.assert_any_call({"python"}, ["security"])
+            # Skills resolved once for the whole invocation, covering all types.
+            mock_load.assert_called_once_with({"python"}, ["general", "security"])
 
             # Result contains both reviews, tagged with review type
             reviews = result["last_reviews"]
@@ -451,7 +455,10 @@ class TestCallReviewNodeMultipleReviewTypes:
                 return_value="",
             ),
             patch("amelia.pipelines.nodes.detect_stack", return_value=set()),
-            patch("amelia.pipelines.nodes.load_skills", return_value="") as mock_load,
+            patch(
+                "amelia.pipelines.nodes.load_skills_by_type",
+                return_value={"general": ""},
+            ) as mock_load,
             patch("amelia.pipelines.nodes.Reviewer") as mock_reviewer_cls,
         ):
             mock_reviewer = MagicMock()

--- a/tests/unit/core/test_skill_injection.py
+++ b/tests/unit/core/test_skill_injection.py
@@ -16,8 +16,8 @@ class TestSkillInjection:
         mock_execution_state_factory,
         mock_runnable_config,
     ) -> None:
-        """Verify detect_stack and load_skills are called and review_guidelines
-        is passed to the Reviewer constructor."""
+        """Verify detect_stack and load_skills_by_type are called and
+        review_guidelines is passed to the Reviewer constructor."""
         state, profile = mock_execution_state_factory(
             goal="Test goal",
             base_commit="abc123",
@@ -38,8 +38,8 @@ class TestSkillInjection:
                 return_value={"python", "fastapi"},
             ) as mock_detect,
             patch(
-                "amelia.pipelines.nodes.load_skills",
-                return_value="# Python Review Guidelines\n...",
+                "amelia.pipelines.nodes.load_skills_by_type",
+                return_value={"general": "# Python Review Guidelines\n..."},
             ) as mock_load,
             patch("amelia.pipelines.nodes.Reviewer") as mock_reviewer_cls,
             patch(
@@ -66,7 +66,8 @@ class TestSkillInjection:
                 "from fastapi import FastAPI\n",
             )
 
-            # Verify load_skills was called per review type (default: ["general"])
+            # Verify load_skills_by_type was called once with the default
+            # review type list (skills resolved once per node invocation).
             mock_load.assert_called_once_with({"python", "fastapi"}, ["general"])
 
             # Verify Reviewer was constructed with review_guidelines
@@ -81,7 +82,7 @@ class TestSkillInjection:
         mock_execution_state_factory,
         mock_runnable_config,
     ) -> None:
-        """Verify review_types from agent_config.options are passed to load_skills."""
+        """Verify review_types from agent_config.options are passed to load_skills_by_type."""
         state, profile = mock_execution_state_factory(
             goal="Test goal",
             base_commit="abc123",
@@ -116,8 +117,8 @@ class TestSkillInjection:
                 return_value={"python"},
             ),
             patch(
-                "amelia.pipelines.nodes.load_skills",
-                return_value="# Guidelines",
+                "amelia.pipelines.nodes.load_skills_by_type",
+                return_value={"general": "# Guidelines", "security": "# Security Guidelines"},
             ) as mock_load,
             patch("amelia.pipelines.nodes.Reviewer") as mock_reviewer_cls,
             patch(
@@ -136,10 +137,10 @@ class TestSkillInjection:
 
             await call_reviewer_node(state, config)
 
-            # Verify load_skills was called once per review type
-            assert mock_load.call_count == 2
-            mock_load.assert_any_call({"python"}, ["general"])
-            mock_load.assert_any_call({"python"}, ["security"])
+            # Skills are resolved once per node invocation: a single
+            # load_skills_by_type call covering all configured review types,
+            # not one call per type.
+            mock_load.assert_called_once_with({"python"}, ["general", "security"])
 
     @pytest.mark.asyncio
     async def test_empty_skills_when_no_matching_tags(
@@ -168,8 +169,8 @@ class TestSkillInjection:
                 return_value=set(),
             ),
             patch(
-                "amelia.pipelines.nodes.load_skills",
-                return_value="",
+                "amelia.pipelines.nodes.load_skills_by_type",
+                return_value={"general": ""},
             ),
             patch("amelia.pipelines.nodes.Reviewer") as mock_reviewer_cls,
             patch(

--- a/tests/unit/pipelines/test_reviewer_node_config.py
+++ b/tests/unit/pipelines/test_reviewer_node_config.py
@@ -8,6 +8,7 @@ import pytest
 from amelia.core.types import AgentConfig, Issue, Profile, ReviewResult
 from amelia.pipelines.implementation.state import ImplementationState
 from amelia.pipelines.nodes import call_reviewer_node
+from amelia.skills.review import load_skills_by_type
 
 
 @pytest.fixture
@@ -213,3 +214,70 @@ async def test_call_reviewer_node_cleans_up_diff_on_error(profile_with_agents, m
 
     # The diff directory must be cleaned up even after an exception
     assert not expected_dir.exists(), "diff directory must be cleaned up even on error"
+
+
+@pytest.mark.asyncio
+async def test_call_reviewer_node_loads_skills_once_for_multiple_types(
+    profile_with_agents, mock_state
+):
+    """Skills must be resolved once per node invocation, not once per review type.
+
+    With N>1 review types configured, the node must call load_skills_by_type a
+    single time (tags/diff are fixed for the invocation), and each review type's
+    pass must still receive its own correct guidelines.
+    """
+    config = {
+        "configurable": {
+            "profile": profile_with_agents,
+            "thread_id": str(uuid4()),
+            "review_types": ["general", "security"],
+        }
+    }
+
+    mock_review_result = ReviewResult(
+        severity="none",
+        approved=True,
+        comments=[],
+        reviewer_persona="Senior Engineer",
+    )
+
+    # Capture the guidelines each Reviewer pass was constructed with.
+    guidelines_by_call: list[str] = []
+
+    def reviewer_factory(*args, **kwargs):
+        guidelines_by_call.append(kwargs.get("review_guidelines"))
+        mock_reviewer = MagicMock()
+        mock_reviewer.agentic_review = AsyncMock(return_value=(mock_review_result, "session-1"))
+        mock_reviewer.driver = MagicMock()
+        return mock_reviewer
+
+    with patch("amelia.pipelines.nodes.Reviewer", side_effect=reviewer_factory), patch(
+        "amelia.pipelines.nodes.load_skills_by_type",
+        wraps=load_skills_by_type,
+    ) as spy_load, patch(
+        "amelia.pipelines.nodes._run_git_command", new_callable=AsyncMock
+    ) as mock_git:
+        mock_git.side_effect = [
+            "src/app.py",  # --name-only
+            "diff --git a/src/app.py b/src/app.py\n+new",  # diff
+            "1 file changed",  # --stat
+        ]
+
+        await call_reviewer_node(mock_state, config)
+
+    # load_skills_by_type must be invoked exactly once despite N=2 review types.
+    assert spy_load.call_count == 1, "skills must be resolved once per node invocation, not per type"
+    call_review_types = spy_load.call_args[0][1]
+    assert call_review_types == ["general", "security"]
+
+    # Each review type's pass receives correct, distinct guidelines.
+    assert len(guidelines_by_call) == 2, "expected one Reviewer pass per review type"
+    general_guidelines, security_guidelines = guidelines_by_call
+    # general gets the general/verification base skills...
+    assert "General Code Review" in general_guidelines
+    assert "verification" in general_guidelines.lower()
+    # ...and the python tag skill (detected from src/app.py).
+    assert "Python Code Review" in general_guidelines
+    # security gets its own base skill, not the general one.
+    assert "Security" in security_guidelines
+    assert "General Code Review" not in security_guidelines

--- a/tests/unit/skills/test_review.py
+++ b/tests/unit/skills/test_review.py
@@ -1,5 +1,7 @@
 """Tests for review skill detection and loading."""
-from amelia.skills.review import detect_stack, load_skills
+from unittest.mock import patch
+
+from amelia.skills.review import detect_stack, load_skills, load_skills_by_type
 
 
 class TestDetectStack:
@@ -118,3 +120,47 @@ class TestLoadSkills:
         content = load_skills({"python"}, ["general"])
         # Count occurrences of a unique header
         assert content.count("# Python Code Review") == 1
+
+
+class TestLoadSkillsByType:
+    """Tests for load_skills_by_type()."""
+
+    def test_returns_per_type_guidelines(self) -> None:
+        result = load_skills_by_type({"python"}, ["general", "security"])
+        assert set(result.keys()) == {"general", "security"}
+        # general gets its base skills + the shared python tag skill
+        assert "General Code Review" in result["general"]
+        assert "Python Code Review" in result["general"]
+        # security gets its own base skill + the same shared python tag skill,
+        # but not general's base skills
+        assert "Security" in result["security"]
+        assert "Python Code Review" in result["security"]
+        assert "General Code Review" not in result["security"]
+
+    def test_matches_per_type_load_skills(self) -> None:
+        """Each entry must equal the single-type load_skills() result."""
+        tags = {"python", "fastapi"}
+        result = load_skills_by_type(tags, ["general", "security"])
+        assert result["general"] == load_skills(tags, ["general"])
+        assert result["security"] == load_skills(tags, ["security"])
+
+    def test_reads_shared_files_once(self) -> None:
+        """A skill file shared across review types is read from disk only once.
+
+        The python tag skill is shared by both review types here; across the
+        two types the underlying file must be read exactly once, proving the
+        per-type dedup that the old per-pass loop lacked.
+        """
+        from pathlib import Path as _Path
+
+        real_read_text = _Path.read_text
+        read_counts: dict[str, int] = {}
+
+        def counting_read_text(self: _Path, *args, **kwargs):
+            read_counts[self.name] = read_counts.get(self.name, 0) + 1
+            return real_read_text(self, *args, **kwargs)
+
+        with patch.object(_Path, "read_text", counting_read_text):
+            load_skills_by_type({"python"}, ["general", "security"])
+
+        assert read_counts.get("python.md") == 1, "shared python skill must be read exactly once"


### PR DESCRIPTION
## Problem

`call_reviewer_node` resolved review skills *inside* the per-review-type pass loop via `load_skills(tags, [review_type])`. That did synchronous `read_text` over the skill markdown files **on the event loop**, and re-read the same base/general skill files on every pass and every retry iteration (the `seen_paths` dedup was per-call, not across passes). The diff `mkdir` + `write_text` were also synchronous in an async function.

## Change

- Added `load_skills_by_type(tags, review_types) -> dict[str, str]` that reads every distinct skill file from disk **at most once** (shared tag/base files cached) while still giving each review type its own correct guidelines.
- Hoisted skill resolution out of the pass loop: all review types' guidelines are computed **once per node invocation** via a single `asyncio.to_thread(load_skills_by_type, ...)` call; each pass reads its entry from the resulting dict.
- Wrapped the diff dir `mkdir` and `diff.patch` `write_text` in `asyncio.to_thread` (matching the implementation node's existing pattern).

No synchronous file I/O remains on the event loop in the reviewer node.

## Verification

- `uv run ruff check --fix amelia tests` — All checks passed
- `uv run mypy amelia` — Success: no issues found in 183 source files
- `uv run pytest tests/unit/` — 2445 passed, 56 deselected
- Reviewer/skills integration tests — 43 passed
- Pre-push gate (ruff, mypy, pytest, `pnpm build`) — All checks passed

New tests assert `load_skills_by_type` is invoked **once** even with N>1 review types, each type still receives its correct (distinct) skills, and a shared tag skill file is read from disk exactly once across types.

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH