### PR TITLE
perf(sandbox): reuse Daytona session per sandbox; drop per-call rm (#641)

### DIFF
--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -101,6 +101,10 @@ class DaytonaSandboxProvider:
         self._workflow_branch = workflow_branch
         self._worker_env: dict[str, str] = dict(worker_env) if worker_env else {}
         self._sandbox: AsyncSandbox | None = None
+        # One reusable command session per sandbox, created lazily on the
+        # first exec_stream and deleted only at teardown (#641). Avoids a
+        # create/delete round-trip on every command.
+        self._session_id: str | None = None
 
     @property
     def _git_auth(self) -> dict[str, str]:
@@ -184,6 +188,8 @@ class DaytonaSandboxProvider:
             with contextlib.suppress(Exception):
                 await self._sandbox.delete()
             self._sandbox = None
+            # The old sandbox (and its session) is gone; force a fresh one.
+            self._session_id = None
 
         logger.info("Creating Daytona sandbox", target=self._target)
 
@@ -310,6 +316,20 @@ class DaytonaSandboxProvider:
                     await created_sandbox.delete()
             raise
 
+    async def _ensure_session(self, sandbox: AsyncSandbox) -> str:
+        """Return the reusable command session id, creating it on first use.
+
+        A single session is created per sandbox and reused across every
+        command, rather than created and deleted per call. It is deleted
+        only at teardown.
+        """
+        if self._session_id is None:
+            session_id = f"amelia-{uuid.uuid4().hex[:12]}"
+            await sandbox.process.create_session(session_id)
+            self._session_id = session_id
+            logger.debug("Created reusable Daytona session", session_id=session_id)
+        return self._session_id
+
     def resolve_cwd(self, cwd: str) -> str:
         """Map host paths to the sandbox repo path.
 
@@ -363,18 +383,13 @@ class DaytonaSandboxProvider:
         if cwd:
             cmd_str = f"cd {shlex.quote(cwd)} && {cmd_str}"
 
-        session_id = f"amelia-{uuid.uuid4().hex[:12]}"
-        await sandbox.process.create_session(session_id)
+        # Reuse one session per sandbox; create lazily, delete at teardown.
+        session_id = await self._ensure_session(sandbox)
 
-        try:
-            resp = await sandbox.process.execute_session_command(
-                session_id,
-                SessionExecuteRequest(command=cmd_str, run_async=True),
-            )
-        except Exception:
-            with contextlib.suppress(Exception):
-                await sandbox.process.delete_session(session_id)
-            raise
+        resp = await sandbox.process.execute_session_command(
+            session_id,
+            SessionExecuteRequest(command=cmd_str, run_async=True),
+        )
         cmd_id = resp.cmd_id
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -423,24 +438,19 @@ class DaytonaSandboxProvider:
                 if task_exc is not None:
                     raise task_exc
 
-            # Check exit code before deleting the session.
-            try:
-                cmd_info = await sandbox.process.get_session_command(
-                    session_id, cmd_id,
-                )
-                if cmd_info.exit_code is not None and cmd_info.exit_code != 0:
-                    stderr_text = "".join(stderr_chunks).strip()
-                    detail = f"Command exited with code {cmd_info.exit_code}: {cmd_str}"
-                    if stderr_text:
-                        # Limit stderr to last 2000 chars to avoid huge error messages.
-                        tail = stderr_text[-2000:]
-                        detail += f"\n\nStderr:\n{tail}"
-                    raise RuntimeError(detail)
-            finally:
-                try:
-                    await sandbox.process.delete_session(session_id)
-                except Exception as exc:
-                    logger.debug("Failed to delete Daytona session", session_id=session_id, error=exc)
+            # Check exit code. The session is reused across commands and is
+            # deleted only at teardown — no per-command delete round-trip.
+            cmd_info = await sandbox.process.get_session_command(
+                session_id, cmd_id,
+            )
+            if cmd_info.exit_code is not None and cmd_info.exit_code != 0:
+                stderr_text = "".join(stderr_chunks).strip()
+                detail = f"Command exited with code {cmd_info.exit_code}: {cmd_str}"
+                if stderr_text:
+                    # Limit stderr to last 2000 chars to avoid huge error messages.
+                    tail = stderr_text[-2000:]
+                    detail += f"\n\nStderr:\n{tail}"
+                raise RuntimeError(detail)
 
     async def write_file(self, path: str, content: bytes) -> None:
         """Write content to a file inside the sandbox via Daytona FS API."""
@@ -461,10 +471,22 @@ class DaytonaSandboxProvider:
         await self._sandbox.git.pull(path, **self._git_auth)
 
     async def teardown(self) -> None:
-        """Delete the ephemeral Daytona sandbox."""
+        """Delete the reusable session, then the ephemeral Daytona sandbox."""
         if self._sandbox is None:
             return
         logger.info("Tearing down Daytona sandbox", sandbox_id=self._sandbox.id)
+        # Delete the reusable command session before destroying the sandbox.
+        if self._session_id is not None:
+            try:
+                await self._sandbox.process.delete_session(self._session_id)
+            except Exception as exc:
+                logger.debug(
+                    "Failed to delete Daytona session",
+                    session_id=self._session_id,
+                    error=exc,
+                )
+            finally:
+                self._session_id = None
         try:
             await self._sandbox.delete()
         except Exception as exc:

--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -21,6 +21,7 @@ from daytona_sdk import (
     CreateSandboxFromImageParams,
     CreateSandboxFromSnapshotParams,
     DaytonaConfig,
+    DaytonaError,
     Image,
     Resources,
     SessionExecuteRequest,
@@ -327,7 +328,9 @@ class DaytonaSandboxProvider:
 
         A single session is created per sandbox and reused across every
         command, rather than created and deleted per call. It is deleted
-        only at teardown.
+        only at teardown. The session is cumulative: shell state (cwd,
+        exported env vars, created files) persists across every command on
+        this sandbox.
 
         Uses double-checked locking: the fast path (session already exists)
         returns without acquiring the lock, while the slow path re-checks
@@ -390,21 +393,43 @@ class DaytonaSandboxProvider:
             logger.warning("Daytona exec_stream does not support stdin — use write_file() instead")
 
         # Build command string with cwd/env baked in (session API has no
-        # cwd/env params).
+        # cwd/env params). Env is applied per-command via `env` rather than
+        # `export`, so it does not mutate the reused session's environment and
+        # leak into later no-env commands (session reuse, #641).
         cmd_str = shlex.join(command)
         if env:
             exports = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
-            cmd_str = f"export {exports} && {cmd_str}"
+            cmd_str = f"env {exports} {cmd_str}"
         if cwd:
             cmd_str = f"cd {shlex.quote(cwd)} && {cmd_str}"
 
-        # Reuse one session per sandbox; create lazily, delete at teardown.
-        session_id = await self._ensure_session(sandbox)
-
-        resp = await sandbox.process.execute_session_command(
-            session_id,
-            SessionExecuteRequest(command=cmd_str, run_async=True),
-        )
+        # Launch the command against the reusable session. A stale/evicted
+        # session surfaces here as a session-level DaytonaError *before* the
+        # command starts server-side, so retrying is safe. health_check probes
+        # via process.exec('true') (not through the session), so a dead session
+        # would never trip it or trigger sandbox replacement. Recover the way
+        # the old per-call design did: drop the cached id, re-enter
+        # _ensure_session to create a fresh one, and retry the launch once.
+        attempt = 0
+        while True:
+            session_id = await self._ensure_session(sandbox)
+            try:
+                resp = await sandbox.process.execute_session_command(
+                    session_id,
+                    SessionExecuteRequest(command=cmd_str, run_async=True),
+                )
+            except DaytonaError as exc:
+                if attempt == 0:
+                    logger.warning(
+                        "Daytona session error, recreating session and retrying",
+                        session_id=session_id,
+                        error=str(exc),
+                    )
+                    self._session_id = None
+                    attempt += 1
+                    continue
+                raise
+            break
         cmd_id = resp.cmd_id
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -442,6 +467,14 @@ class DaytonaSandboxProvider:
             if buf:
                 yield buf
         finally:
+            # Accept-and-bound contract for early break / cancellation /
+            # exception: the server-side command (run_async=True) keeps running
+            # to completion. The Daytona SDK exposes no per-command
+            # stop/terminate API (only whole-session delete_session), and
+            # deleting the session here would defeat the deliberate per-sandbox
+            # session reuse (#641). We accept the leak and bound it locally:
+            # cancel the streaming task so we stop consuming, and leave the
+            # session intact so the next command reuses it.
             if not log_task.done():
                 log_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -528,7 +528,7 @@ class DaytonaSandboxProvider:
             try:
                 await self._sandbox.process.delete_session(self._session_id)
             except Exception as exc:
-                logger.debug(
+                logger.warning(
                     "Failed to delete Daytona session",
                     session_id=self._session_id,
                     error=exc,

--- a/amelia/sandbox/daytona.py
+++ b/amelia/sandbox/daytona.py
@@ -105,6 +105,12 @@ class DaytonaSandboxProvider:
         # first exec_stream and deleted only at teardown (#641). Avoids a
         # create/delete round-trip on every command.
         self._session_id: str | None = None
+        # Guards the _session_id check-then-create in _ensure_session so
+        # concurrent exec_stream calls (e.g. an asyncio.gather fan-out on a
+        # shared provider) can't each create their own session and orphan
+        # the losers. Only session creation is serialized; concurrent
+        # commands still run in parallel (each gets its own cmd_id).
+        self._session_lock = asyncio.Lock()
 
     @property
     def _git_auth(self) -> dict[str, str]:
@@ -322,8 +328,17 @@ class DaytonaSandboxProvider:
         A single session is created per sandbox and reused across every
         command, rather than created and deleted per call. It is deleted
         only at teardown.
+
+        Uses double-checked locking: the fast path (session already exists)
+        returns without acquiring the lock, while the slow path re-checks
+        under the lock so two concurrent callers can't both create a
+        session and orphan one.
         """
-        if self._session_id is None:
+        if self._session_id is not None:
+            return self._session_id
+        async with self._session_lock:
+            if self._session_id is not None:
+                return self._session_id
             session_id = f"amelia-{uuid.uuid4().hex[:12]}"
             await sandbox.process.create_session(session_id)
             self._session_id = session_id

--- a/amelia/sandbox/driver.py
+++ b/amelia/sandbox/driver.py
@@ -154,6 +154,10 @@ class ContainerDriver:
     async def _write_prompt(self, prompt: str, workflow_id: str | None = None) -> str:
         """Write the prompt to a temp file inside the container.
 
+        The file lives under ``/tmp`` in the sandbox's ephemeral filesystem
+        and is reclaimed when the sandbox is torn down, so callers need not
+        issue a per-command ``rm`` round-trip to clean it up (#641).
+
         Args:
             prompt: The prompt text to write.
             workflow_id: Optional workflow identifier for the filename.
@@ -165,15 +169,6 @@ class ContainerDriver:
         prompt_path = f"/tmp/prompt-{suffix}.txt"
         await self._provider.write_file(prompt_path, prompt.encode())
         return prompt_path
-
-    async def _cleanup_prompt(self, prompt_path: str) -> None:
-        """Remove the temp prompt file from the container.
-
-        Args:
-            prompt_path: Path to the temp file to remove.
-        """
-        async for _ in self._provider.exec_stream(["rm", "-f", prompt_path]):
-            pass
 
     async def execute_agentic(
         self,
@@ -236,24 +231,24 @@ class ContainerDriver:
         # One-shot fallback: fresh worker process per call.
         workflow_id = kwargs.get("workflow_id")
         prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
-        try:
-            cmd = [
-                *self._provider.worker_cmd, "agentic",
-                "--prompt-file", prompt_path,
-                "--cwd", sandbox_cwd,
-                "--model", self.model,
-            ]
-            if instructions:
-                cmd.extend(["--instructions", instructions])
+        # The prompt file lives in the sandbox's ephemeral filesystem and is
+        # reclaimed when the sandbox is torn down, so there is no per-call
+        # `rm -f` remote round-trip (#641).
+        cmd = [
+            *self._provider.worker_cmd, "agentic",
+            "--prompt-file", prompt_path,
+            "--cwd", sandbox_cwd,
+            "--model", self.model,
+        ]
+        if instructions:
+            cmd.extend(["--instructions", instructions])
 
-            async for line in self._provider.exec_stream(cmd, cwd=sandbox_cwd, env=self._env):
-                msg = _parse_worker_message(line)
-                if msg.type == AgenticMessageType.USAGE:
-                    self._last_usage = msg.usage
-                else:
-                    yield msg
-        finally:
-            await self._cleanup_prompt(prompt_path)
+        async for line in self._provider.exec_stream(cmd, cwd=sandbox_cwd, env=self._env):
+            msg = _parse_worker_message(line)
+            if msg.type == AgenticMessageType.USAGE:
+                self._last_usage = msg.usage
+            else:
+                yield msg
 
     async def generate(
         self,
@@ -309,23 +304,21 @@ class ContainerDriver:
             # One-shot fallback: fresh worker process per call.
             workflow_id = kwargs.get("workflow_id")
             prompt_path = await self._write_prompt(prompt, workflow_id=workflow_id)
-            try:
-                cmd = [
-                    *self._provider.worker_cmd, "generate",
-                    "--prompt-file", prompt_path,
-                    "--model", self.model,
-                ]
-                if schema_path:
-                    cmd.extend(["--schema", schema_path])
+            # Prompt file is reclaimed at sandbox teardown — no per-call rm (#641).
+            cmd = [
+                *self._provider.worker_cmd, "generate",
+                "--prompt-file", prompt_path,
+                "--model", self.model,
+            ]
+            if schema_path:
+                cmd.extend(["--schema", schema_path])
 
-                async for line in self._provider.exec_stream(cmd, env=self._env):
-                    msg = _parse_worker_message(line)
-                    if msg.type == AgenticMessageType.USAGE:
-                        self._last_usage = msg.usage
-                    elif msg.type == AgenticMessageType.RESULT:
-                        result_content = msg.content
-            finally:
-                await self._cleanup_prompt(prompt_path)
+            async for line in self._provider.exec_stream(cmd, env=self._env):
+                msg = _parse_worker_message(line)
+                if msg.type == AgenticMessageType.USAGE:
+                    self._last_usage = msg.usage
+                elif msg.type == AgenticMessageType.RESULT:
+                    result_content = msg.content
 
         if result_content is None:
             raise RuntimeError("Worker did not emit a RESULT message")

--- a/tests/unit/sandbox/test_container_driver.py
+++ b/tests/unit/sandbox/test_container_driver.py
@@ -123,7 +123,13 @@ class TestExecuteAgentic:
             async for _ in driver.execute_agentic(prompt="test", cwd="/work"):
                 pass
 
-    async def test_prompt_file_cleanup_on_success(self) -> None:
+    async def test_no_per_call_rm_round_trip_on_success(self) -> None:
+        """No per-command `rm -f` remote round-trip (#641).
+
+        The temp prompt lives in the sandbox's ephemeral filesystem and is
+        reclaimed when the sandbox is torn down, so the worker is the ONLY
+        exec_stream call.
+        """
         from amelia.sandbox.driver import ContainerDriver
 
         result = AgenticMessage(type=AgenticMessageType.RESULT, content="Done")
@@ -153,12 +159,12 @@ class TestExecuteAgentic:
         async for _ in driver.execute_agentic(prompt="test", cwd="/work"):
             pass
 
-        # 2 exec_stream calls: worker + rm (write_file replaces tee)
-        assert len(calls) == 2
-        assert calls[1][0] == "rm"
-        assert calls[1][1] == "-f"
+        # Exactly one exec_stream call (the worker). No `rm` round-trip.
+        assert len(calls) == 1
+        assert all(cmd[0] != "rm" for cmd in calls)
 
-    async def test_prompt_file_cleanup_on_exception(self) -> None:
+    async def test_no_per_call_rm_round_trip_on_exception(self) -> None:
+        """Even when the worker output is malformed, no `rm` round-trip fires."""
         from amelia.sandbox.driver import ContainerDriver
 
         calls: list[list[str]] = []
@@ -185,7 +191,7 @@ class TestExecuteAgentic:
             async for _ in driver.execute_agentic(prompt="test", cwd="/work"):
                 pass
 
-        assert any(cmd[0] == "rm" for cmd in calls)
+        assert all(cmd[0] != "rm" for cmd in calls)
 
 
 class TestGenerate:

--- a/tests/unit/sandbox/test_container_driver.py
+++ b/tests/unit/sandbox/test_container_driver.py
@@ -191,6 +191,8 @@ class TestExecuteAgentic:
             async for _ in driver.execute_agentic(prompt="test", cwd="/work"):
                 pass
 
+        # Exactly one exec_stream call (the worker) even on the parse-error path.
+        assert len(calls) == 1
         assert all(cmd[0] != "rm" for cmd in calls)
 
 

--- a/tests/unit/sandbox/test_daytona_provider.py
+++ b/tests/unit/sandbox/test_daytona_provider.py
@@ -905,6 +905,42 @@ class TestDaytonaSandboxProviderSessionReuse:
             mock_sandbox.delete.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_session_reset_when_sandbox_replaced(self) -> None:
+        """Replacing an unhealthy sandbox forces the next command to create a new session."""
+        with (
+            patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls,
+            patch("amelia.sandbox.daytona.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            first_sandbox = _make_mock_sandbox(["first\n"])
+            second_sandbox = _make_mock_sandbox(["second\n"])
+            mock_client.create.side_effect = [first_sandbox, second_sandbox]
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            async for _ in provider.exec_stream(["echo", "first"]):
+                pass
+            first_session_id = first_sandbox.process.create_session.call_args[0][0]
+
+            provider.health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
+            await provider.ensure_running()
+            async for _ in provider.exec_stream(["echo", "second"]):
+                pass
+            second_session_id = second_sandbox.process.create_session.call_args[0][0]
+
+            assert mock_client.create.call_count == 2
+            first_sandbox.delete.assert_called_once()
+            first_sandbox.process.create_session.assert_called_once()
+            second_sandbox.process.create_session.assert_called_once()
+            assert first_session_id != second_session_id
+
+    @pytest.mark.asyncio
     async def test_exec_stream_bakes_cwd_and_env_into_command(self) -> None:
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider

--- a/tests/unit/sandbox/test_daytona_provider.py
+++ b/tests/unit/sandbox/test_daytona_provider.py
@@ -828,6 +828,53 @@ class TestDaytonaSandboxProviderSessionReuse:
             mock_sandbox.process.delete_session.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_concurrent_exec_stream_creates_one_session(self) -> None:
+        """Concurrent exec_stream calls share one session (no orphans).
+
+        Regression guard for the check-then-act race in _ensure_session: an
+        asyncio.gather fan-out on a shared provider (e.g. parallel review
+        passes) must not let each caller create its own session and orphan
+        the losers (#641). ``create_session`` yields to the loop so every
+        caller reaches the create point before any assigns ``_session_id``,
+        which forces the race on the unlocked path (create_session would be
+        called once per caller instead of once total).
+        """
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            # Yield at the create point so concurrent callers overlap inside
+            # _ensure_session's check-then-create window.
+            async def slow_create_session(_sid: str) -> None:
+                await asyncio.sleep(0)
+
+            mock_sandbox.process.create_session.side_effect = slow_create_session
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            async def run(cmd: str) -> list[str]:
+                return [line async for line in provider.exec_stream([cmd])]
+
+            await asyncio.gather(run("one"), run("two"), run("three"))
+
+            # Exactly one session created across three concurrent commands.
+            mock_sandbox.process.create_session.assert_called_once()
+            # All three commands ran against that single session id.
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 3
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            for call in exec_calls:
+                assert call[0][0] == session_id
+
+    @pytest.mark.asyncio
     async def test_teardown_deletes_session_exactly_once(self) -> None:
         """Reusable session is deleted once at teardown, before the sandbox."""
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:

--- a/tests/unit/sandbox/test_daytona_provider.py
+++ b/tests/unit/sandbox/test_daytona_provider.py
@@ -712,7 +712,8 @@ class TestDaytonaSandboxProviderExecStream:
             assert lines == ["partial"]
 
     @pytest.mark.asyncio
-    async def test_exec_stream_cleans_up_session_on_error(self) -> None:
+    async def test_exec_stream_does_not_delete_session_on_error(self) -> None:
+        """The reusable session survives a failed command (deleted at teardown)."""
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider
 
@@ -734,10 +735,10 @@ class TestDaytonaSandboxProviderExecStream:
                 async for _ in provider.exec_stream(["false"]):
                     pass
 
-            mock_sandbox.process.delete_session.assert_called_once()
+            mock_sandbox.process.delete_session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_exec_stream_cleans_up_session_on_success(self) -> None:
+    async def test_exec_stream_does_not_delete_session_on_success(self) -> None:
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider
 
@@ -758,10 +759,10 @@ class TestDaytonaSandboxProviderExecStream:
             async for _ in provider.exec_stream(["echo", "ok"]):
                 pass
 
-            mock_sandbox.process.delete_session.assert_called_once()
+            mock_sandbox.process.delete_session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_exec_stream_cleans_up_on_early_break(self) -> None:
+    async def test_exec_stream_does_not_delete_session_on_early_break(self) -> None:
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider
 
@@ -784,7 +785,124 @@ class TestDaytonaSandboxProviderExecStream:
                 break  # Break after first line
             await stream.aclose()
 
-            mock_sandbox.process.delete_session.assert_called_once()
+            mock_sandbox.process.delete_session.assert_not_called()
+
+
+class TestDaytonaSandboxProviderSessionReuse:
+    """A single Daytona session is created per sandbox and reused (#641)."""
+
+    @pytest.mark.asyncio
+    async def test_session_created_once_across_multiple_commands(self) -> None:
+        """create_session called once; both commands run in the same session."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            mock_sandbox.process.create_session.reset_mock()
+
+            async for _ in provider.exec_stream(["echo", "one"]):
+                pass
+            async for _ in provider.exec_stream(["echo", "two"]):
+                pass
+
+            # Session created exactly once across two commands.
+            mock_sandbox.process.create_session.assert_called_once()
+            reused_session_id = mock_sandbox.process.create_session.call_args[0][0]
+
+            # Both commands executed against the SAME session id.
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 2
+            assert exec_calls[0][0][0] == reused_session_id
+            assert exec_calls[1][0][0] == reused_session_id
+
+            # No per-command teardown.
+            mock_sandbox.process.delete_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_teardown_deletes_session_exactly_once(self) -> None:
+        """Reusable session is deleted once at teardown, before the sandbox."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            async for _ in provider.exec_stream(["echo", "one"]):
+                pass
+            async for _ in provider.exec_stream(["echo", "two"]):
+                pass
+
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            await provider.teardown()
+
+            mock_sandbox.process.delete_session.assert_called_once_with(session_id)
+            mock_sandbox.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_teardown_cleans_up_session_after_command_error(self) -> None:
+        """Error path: failed command still leaves session cleaned up at teardown."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox([], exit_code=1)
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            with pytest.raises(RuntimeError):
+                async for _ in provider.exec_stream(["false"]):
+                    pass
+
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            # Not deleted by the failed command itself.
+            mock_sandbox.process.delete_session.assert_not_called()
+
+            await provider.teardown()
+            mock_sandbox.process.delete_session.assert_called_once_with(session_id)
+
+    @pytest.mark.asyncio
+    async def test_teardown_without_session_skips_session_delete(self) -> None:
+        """No commands ran => no session created => teardown deletes only sandbox."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _mock_sandbox_with_install()
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            await provider.teardown()
+
+            mock_sandbox.process.delete_session.assert_not_called()
+            mock_sandbox.delete.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_exec_stream_bakes_cwd_and_env_into_command(self) -> None:

--- a/tests/unit/sandbox/test_daytona_provider.py
+++ b/tests/unit/sandbox/test_daytona_provider.py
@@ -762,7 +762,16 @@ class TestDaytonaSandboxProviderExecStream:
             mock_sandbox.process.delete_session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_exec_stream_does_not_delete_session_on_early_break(self) -> None:
+    async def test_exec_stream_early_break_preserves_reusable_session(self) -> None:
+        """Early break leaks the server-side command; accept-and-bound it.
+
+        Contract: the Daytona SDK exposes no per-command stop/terminate API
+        (only whole-session delete_session), and deleting the session here
+        would defeat the deliberate per-sandbox session reuse (#641). So we
+        accept that the run_async=True command keeps running server-side, and
+        bound it by (a) cancelling local streaming and (b) leaving the session
+        intact and reusable for the next command.
+        """
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider
 
@@ -778,6 +787,7 @@ class TestDaytonaSandboxProviderExecStream:
                 repo_url="https://github.com/org/repo.git",
             )
             await provider.ensure_running()
+            mock_sandbox.process.create_session.reset_mock()
             mock_sandbox.process.delete_session.reset_mock()
 
             stream = provider.exec_stream(["echo", "hello"])
@@ -785,6 +795,21 @@ class TestDaytonaSandboxProviderExecStream:
                 break  # Break after first line
             await stream.aclose()
 
+            # Accept: we do NOT tear down the (reused) session to stop the
+            # leaked server-side command.
+            mock_sandbox.process.delete_session.assert_not_called()
+
+            # Bound: the leaked command does not poison the session — a
+            # follow-up command reuses it (no new create_session).
+            async for _ in provider.exec_stream(["echo", "again"]):
+                pass
+
+            mock_sandbox.process.create_session.assert_called_once()
+            reused_id = mock_sandbox.process.create_session.call_args[0][0]
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 2
+            assert exec_calls[0][0][0] == reused_id
+            assert exec_calls[1][0][0] == reused_id
             mock_sandbox.process.delete_session.assert_not_called()
 
 
@@ -988,7 +1013,93 @@ class TestDaytonaSandboxProviderSessionReuse:
             assert first_session_id != second_session_id
 
     @pytest.mark.asyncio
+    async def test_stale_session_is_recovered_on_next_command(self) -> None:
+        """A stale/evicted session (session-level error at launch) is recovered.
+
+        The cached session id is dropped, a fresh session is created, and the
+        command is retried once — without duplicate output (#641). health_check
+        probes outside the session, so exec_stream must self-heal here.
+        """
+        from daytona_sdk import DaytonaError
+
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            # First exec establishes the reusable session.
+            async for _ in provider.exec_stream(["echo", "one"]):
+                pass
+            first_session_id = mock_sandbox.process.create_session.call_args[0][0]
+            mock_sandbox.process.create_session.reset_mock()
+            mock_sandbox.process.execute_session_command.reset_mock()
+
+            # Simulate the cached session going stale: the launch fails with a
+            # session-level error, then succeeds on the retry.
+            mock_sandbox.process.execute_session_command.side_effect = [
+                DaytonaError("Failed to execute session command: not found (404)"),
+                MagicMock(cmd_id="recovered-cmd-id"),
+            ]
+
+            lines: list[str] = []
+            async for line in provider.exec_stream(["echo", "two"]):
+                lines.append(line)
+
+            # Stale id dropped, fresh session created for the retry.
+            mock_sandbox.process.create_session.assert_called_once()
+            second_session_id = mock_sandbox.process.create_session.call_args[0][0]
+            assert second_session_id != first_session_id
+            # Command launched twice (first failed, retry succeeded).
+            assert mock_sandbox.process.execute_session_command.call_count == 2
+            # Output delivered exactly once (no duplicate from the retry).
+            assert lines == ["out"]
+            assert provider._session_id == second_session_id
+
+    @pytest.mark.asyncio
+    async def test_repeated_session_error_propagates_after_one_retry(self) -> None:
+        """A session error that persists past the single retry is raised."""
+        from daytona_sdk import DaytonaError
+
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            # Every launch fails — the single retry also fails.
+            mock_sandbox.process.execute_session_command.side_effect = DaytonaError(
+                "Failed to execute session command: not found (404)"
+            )
+
+            with pytest.raises(DaytonaError):
+                async for _ in provider.exec_stream(["echo", "x"]):
+                    pass
+
+            # Exactly two attempts (initial + one retry).
+            assert mock_sandbox.process.execute_session_command.call_count == 2
+            # A fresh session is created for each attempt (id dropped on retry).
+            assert mock_sandbox.process.create_session.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_exec_stream_bakes_cwd_and_env_into_command(self) -> None:
+        """env is applied per-command so it never leaks into the reused session."""
         with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
             from amelia.sandbox.daytona import DaytonaSandboxProvider
 
@@ -1015,6 +1126,7 @@ class TestDaytonaSandboxProviderSessionReuse:
             assert "cd" in req.command
             assert "/workspace" in req.command
             assert "FOO=bar" in req.command
+            assert "export" not in req.command
             assert req.run_async is True
 
 

--- a/tests/unit/sandbox/test_daytona_session.py
+++ b/tests/unit/sandbox/test_daytona_session.py
@@ -1,0 +1,305 @@
+"""Unit tests for DaytonaSandboxProvider session reuse (#641).
+
+Extraction target for the session-reuse behaviour pulled out of
+test_daytona_provider.py to keep that module focused and within budget.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.unit.sandbox.test_daytona_provider import (
+    _make_mock_sandbox,
+    _mock_sandbox_with_install,
+)
+
+
+class TestDaytonaSandboxProviderSessionReuse:
+    """A single Daytona session is created per sandbox and reused (#641)."""
+
+    @pytest.mark.asyncio
+    async def test_session_created_once_across_multiple_commands(self) -> None:
+        """create_session called once; both commands run in the same session."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            mock_sandbox.process.create_session.reset_mock()
+
+            async for _ in provider.exec_stream(["echo", "one"]):
+                pass
+            async for _ in provider.exec_stream(["echo", "two"]):
+                pass
+
+            # Session created exactly once across two commands.
+            mock_sandbox.process.create_session.assert_called_once()
+            reused_session_id = mock_sandbox.process.create_session.call_args[0][0]
+
+            # Both commands executed against the SAME session id.
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 2
+            assert exec_calls[0][0][0] == reused_session_id
+            assert exec_calls[1][0][0] == reused_session_id
+
+            # No per-command teardown.
+            mock_sandbox.process.delete_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_teardown_deletes_session_exactly_once(self) -> None:
+        """Reusable session is deleted once at teardown, before the sandbox."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            async for _ in provider.exec_stream(["echo", "one"]):
+                pass
+            async for _ in provider.exec_stream(["echo", "two"]):
+                pass
+
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            await provider.teardown()
+
+            mock_sandbox.process.delete_session.assert_called_once_with(session_id)
+            mock_sandbox.delete.assert_called_once()
+
+            # Ordering: session deleted before the sandbox (per docstring + impl).
+            calls = mock_sandbox.mock_calls
+            session_idx = next(
+                i for i, c in enumerate(calls) if c[0] == "process.delete_session"
+            )
+            sandbox_idx = next(i for i, c in enumerate(calls) if c[0] == "delete")
+            assert session_idx < sandbox_idx
+
+    @pytest.mark.asyncio
+    async def test_teardown_cleans_up_session_after_command_error(self) -> None:
+        """Error path: failed command still leaves session cleaned up at teardown."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox([], exit_code=1)
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            with pytest.raises(RuntimeError):
+                async for _ in provider.exec_stream(["false"]):
+                    pass
+
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            # Not deleted by the failed command itself.
+            mock_sandbox.process.delete_session.assert_not_called()
+
+            await provider.teardown()
+            mock_sandbox.process.delete_session.assert_called_once_with(session_id)
+
+    @pytest.mark.asyncio
+    async def test_teardown_without_session_skips_session_delete(self) -> None:
+        """No commands ran => no session created => teardown deletes only sandbox."""
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _mock_sandbox_with_install()
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            await provider.teardown()
+
+            mock_sandbox.process.delete_session.assert_not_called()
+            mock_sandbox.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_session_reset_when_sandbox_replaced(self) -> None:
+        """Replacing an unhealthy sandbox forces the next command to create a new session."""
+        with (
+            patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls,
+            patch("amelia.sandbox.daytona.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            first_sandbox = _make_mock_sandbox(["first\n"])
+            second_sandbox = _make_mock_sandbox(["second\n"])
+            mock_client.create.side_effect = [first_sandbox, second_sandbox]
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            async for _ in provider.exec_stream(["echo", "first"]):
+                pass
+            first_session_id = first_sandbox.process.create_session.call_args[0][0]
+
+            provider.health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
+            await provider.ensure_running()
+            async for _ in provider.exec_stream(["echo", "second"]):
+                pass
+            second_session_id = second_sandbox.process.create_session.call_args[0][0]
+
+            assert mock_client.create.call_count == 2
+            first_sandbox.delete.assert_called_once()
+            first_sandbox.process.create_session.assert_called_once()
+            second_sandbox.process.create_session.assert_called_once()
+            assert first_session_id != second_session_id
+
+    @pytest.mark.asyncio
+    async def test_exec_stream_bakes_cwd_and_env_into_command(self) -> None:
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["ok\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                api_url="https://test.daytona.io/api",
+                target="us",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            async for _ in provider.exec_stream(
+                ["ls"], cwd="/workspace", env={"FOO": "bar"},
+            ):
+                pass
+
+            call_args = mock_sandbox.process.execute_session_command.call_args
+            req = call_args[0][1]
+            assert "cd" in req.command
+            assert "/workspace" in req.command
+            assert "FOO=bar" in req.command
+            assert req.run_async is True
+
+    @pytest.mark.asyncio
+    async def test_env_and_cwd_baked_independently_per_command(self) -> None:
+        """Each command's env/cwd is baked into its own command string.
+
+        The session is reused across commands (#641), so this guards that
+        per-call command construction stays independent: a later no-env /
+        no-cwd caller's command string is not contaminated by a prior call's
+        exports or working directory. cwd is re-applied on every call (so it
+        is safe); runtime env accumulation in the shared persistent shell is
+        a known, accepted nuance of #641 and is not asserted here.
+        """
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+
+            # First command exports an env var and cd's into a subdir.
+            async for _ in provider.exec_stream(
+                ["echo", "first"],
+                cwd="/workspace/sub",
+                env={"LEAKED": "yes"},
+            ):
+                pass
+            # Second command passes no env / no cwd.
+            async for _ in provider.exec_stream(["echo", "second"]):
+                pass
+
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 2
+            first_cmd = exec_calls[0][0][1].command
+            second_cmd = exec_calls[1][0][1].command
+
+            # First command bakes its own env/cwd into its command string.
+            assert "LEAKED=yes" in first_cmd
+            assert "/workspace/sub" in first_cmd
+
+            # Second command's string is built only from its own args: it
+            # neither cd's nor exports, and must not carry the first command's
+            # env or cwd (session reuse must not merge per-call construction).
+            assert second_cmd == "echo second"
+            assert "LEAKED" not in second_cmd
+            assert "/workspace/sub" not in second_cmd
+
+    @pytest.mark.asyncio
+    async def test_concurrent_exec_stream_creates_one_session(self) -> None:
+        """Concurrent exec_stream calls on one provider share one session.
+
+        _ensure_session's double-checked lock serializes the _session_id
+        check-then-create so an asyncio.gather fan-out cannot each create its
+        own session and orphan the losers (#641).
+        """
+        with patch("amelia.sandbox.daytona.AsyncDaytona") as mock_cls:
+            from amelia.sandbox.daytona import DaytonaSandboxProvider
+
+            mock_client = AsyncMock()
+            mock_sandbox = _make_mock_sandbox(["out\n"])
+
+            # Model a real create_session round-trip: yield to the loop so
+            # concurrent callers genuinely overlap at the check-then-create.
+            # Without _ensure_session's lock this overlap would let each caller
+            # observe _session_id is None and create its own session.
+            async def _yield(*_args: object, **_kwargs: object) -> None:
+                await asyncio.sleep(0)
+
+            mock_sandbox.process.create_session.side_effect = _yield
+            mock_client.create.return_value = mock_sandbox
+            mock_cls.return_value = mock_client
+
+            provider = DaytonaSandboxProvider(
+                api_key="test-key",
+                repo_url="https://github.com/org/repo.git",
+            )
+            await provider.ensure_running()
+            # Clear call history but keep the yielding side_effect.
+            mock_sandbox.process.create_session.reset_mock(side_effect=False)
+
+            async def run(cmd: str) -> list[str]:
+                return [line async for line in provider.exec_stream([cmd])]
+
+            await asyncio.gather(run("one"), run("two"), run("three"))
+
+            # Exactly one session created across three concurrent commands.
+            mock_sandbox.process.create_session.assert_called_once()
+            # All three commands ran against that single session id.
+            exec_calls = mock_sandbox.process.execute_session_command.call_args_list
+            assert len(exec_calls) == 3
+            session_id = mock_sandbox.process.create_session.call_args[0][0]
+            for call in exec_calls:
+                assert call[0][0] == session_id


### PR DESCRIPTION
## Problem

On the Daytona path, every command did a full `create_session` → `execute_session_command` → `get_session_command` → `delete_session` cycle — a create/delete round-trip to the Daytona cloud API for *each* command, including the trivial prompt-cleanup. On top of that, the container driver issued a separate per-call `rm -f` remote round-trip to delete each temp prompt file. That is ~3-4 extra remote API calls per agent step.

## Change

- **One reusable session per sandbox.** `daytona.py` now creates a single command session lazily on the first `exec_stream` (`_ensure_session`) and reuses it for every subsequent command. The session is deleted exactly once at `teardown()`, before the sandbox is destroyed, and reset whenever the sandbox is recreated.
- **No per-command `rm` round-trip.** `driver.py` drops `_cleanup_prompt` and its two `finally`-block call sites (the `rm -f` at :59). The temp prompt lives in the sandbox's ephemeral `/tmp` and is reclaimed when the sandbox is torn down.
- Net effect: remote API calls per agent step drop ~3-4×.

## Verification

- `uv run ruff check --fix amelia tests` → All checks passed
- `uv run mypy amelia` → Success: no issues found in 183 source files
- `uv run pytest tests/unit/` → 2445 passed
- Daytona/driver tests + integration: `tests/unit/sandbox/test_daytona_provider.py`, `test_container_driver.py`, `tests/integration/test_daytona_sandbox.py` all pass
- Pre-push gate (full pytest 2481 passed + `pnpm build`) passed

New tests assert observable call-counts/sequence (Daytona SDK mocked at the boundary): session `create_session` called once across ≥2 commands, both commands run against the same session id, no per-command `delete_session`, `teardown` deletes the session exactly once, and the error path still cleans up the session at teardown.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QWYyUP5msrRwkRyh69HKH