### PR TITLE
feat(tools): unified tool registry with ToolSpec, ToolPolicyMiddleware veto (#233)

### DIFF
--- a/amelia/core/constants.py
+++ b/amelia/core/constants.py
@@ -14,8 +14,10 @@ class ToolName(StrEnum):
     NOTEBOOK_EDIT = "notebook_edit"
     GLOB = "glob"
     GREP = "grep"
+    BUNDLE_FILES = "bundle_files"
     # Execution
     RUN_SHELL_COMMAND = "run_shell_command"
+    EXECUTE_TOOL = "execute"
     # Agent orchestration
     TASK = "task"
     TASK_OUTPUT = "task_output"

--- a/amelia/tools/__init__.py
+++ b/amelia/tools/__init__.py
@@ -1,1 +1,16 @@
-"""Tool implementations for agent actions."""
+"""Tool implementations for agent actions.
+
+Importing this package triggers ``discover_builtin_tools()``, which AST-scans
+the modules below and imports each one that self-registers a tool against the
+registry. The call is idempotent: Python caches imported modules and the
+registry is a plain dict, so re-importing this package is a no-op.
+"""
+
+from __future__ import annotations
+
+from amelia.tools.registry import discover_builtin_tools
+
+
+# Populate the registry on first import. Guarded so a single broken tool module
+# (caught and logged inside discover_builtin_tools) never blocks the package.
+discover_builtin_tools()

--- a/amelia/tools/_stubs.py
+++ b/amelia/tools/_stubs.py
@@ -1,0 +1,142 @@
+"""Stub ToolSpecs for library-provided tools.
+
+These tools are implemented by deepagents (FilesystemMiddleware) and the
+sandbox runtime, not by amelia. We register metadata-only specs (no handler,
+no factory) so ``ToolPolicyMiddleware`` and toolset queries can reason about
+them uniformly with amelia-owned tools.
+
+Each spec is registered with a top-level ``register(...)`` call so that
+``discover_builtin_tools`` detects this module via its AST scan.
+
+See ``.beagle/concepts/tool-registry/spec.md`` §1 (Must Have #4).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from amelia.tools.registry import Permission, RiskLevel, ToolSpec, register
+
+
+class _ReadFileInput(BaseModel):
+    file_path: str
+    offset: int | None = None
+    limit: int | None = None
+
+
+class _WriteFileInput(BaseModel):
+    file_path: str
+    content: str
+
+
+class _EditFileInput(BaseModel):
+    file_path: str
+    old_string: str
+    new_string: str
+
+
+class _GlobInput(BaseModel):
+    pattern: str
+    path: str | None = None
+
+
+class _GrepInput(BaseModel):
+    pattern: str
+    path: str | None = None
+    include: str | None = None
+
+
+class _ExecuteInput(BaseModel):
+    command: str
+    timeout: int | None = 30
+
+
+class _WebFetchInput(BaseModel):
+    url: str
+    prompt: str | None = None
+
+
+class _WebSearchInput(BaseModel):
+    query: str
+
+
+register(
+    ToolSpec(
+        name="read_file",
+        description="Read the contents of a file.",
+        input_schema=_ReadFileInput,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.FS_READ}),
+        toolsets=frozenset({"readonly", "filesystem"}),
+    )
+)
+register(
+    ToolSpec(
+        name="write_file",
+        description="Write content to a file, overwriting if it exists.",
+        input_schema=_WriteFileInput,
+        risk_level=RiskLevel.WRITE,
+        required_permissions=frozenset({Permission.FS_WRITE}),
+        toolsets=frozenset({"filesystem"}),
+    )
+)
+register(
+    ToolSpec(
+        name="edit_file",
+        description="Replace a unique string in a file with a new string.",
+        input_schema=_EditFileInput,
+        risk_level=RiskLevel.WRITE,
+        required_permissions=frozenset({Permission.FS_WRITE}),
+        toolsets=frozenset({"filesystem"}),
+    )
+)
+register(
+    ToolSpec(
+        name="glob",
+        description="Find files matching a glob pattern.",
+        input_schema=_GlobInput,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.FS_READ}),
+        toolsets=frozenset({"readonly", "filesystem"}),
+    )
+)
+register(
+    ToolSpec(
+        name="grep",
+        description="Search file contents for a pattern.",
+        input_schema=_GrepInput,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.FS_READ}),
+        toolsets=frozenset({"readonly", "filesystem"}),
+    )
+)
+register(
+    ToolSpec(
+        name="execute",
+        description="Execute a shell command inside the sandbox.",
+        input_schema=_ExecuteInput,
+        risk_level=RiskLevel.EXECUTE,
+        required_permissions=frozenset({Permission.SHELL_EXEC}),
+        toolsets=frozenset({"execute"}),
+    )
+)
+register(
+    ToolSpec(
+        name="web_fetch",
+        description="Fetch the content of a URL.",
+        input_schema=_WebFetchInput,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.NET_READ}),
+        toolsets=frozenset({"readonly", "web"}),
+    )
+)
+register(
+    ToolSpec(
+        name="web_search",
+        description="Search the web for a query.",
+        input_schema=_WebSearchInput,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.NET_READ}),
+        toolsets=frozenset({"readonly", "web"}),
+    )
+)

--- a/amelia/tools/file_bundler.py
+++ b/amelia/tools/file_bundler.py
@@ -15,6 +15,8 @@ import tiktoken
 from loguru import logger
 from pydantic import BaseModel
 
+from amelia.tools.registry import Permission, RiskLevel, ToolSpec, register
+
 
 class BundledFile(BaseModel):
     """A single file with its content and metadata.
@@ -42,6 +44,14 @@ class FileBundle(BaseModel):
     files: list[BundledFile]
     total_tokens: int
     working_dir: str
+
+
+class BundleFilesInput(BaseModel):
+    """Input schema for the ``bundle_files`` tool."""
+
+    working_dir: str
+    patterns: list[str]
+    exclude_patterns: list[str] | None = None
 
 
 # Hardcoded exclusions for non-git directories
@@ -296,3 +306,19 @@ async def bundle_files(
         total_tokens=total_tokens,
         working_dir=working_dir,
     )
+
+
+register(
+    ToolSpec(
+        name="bundle_files",
+        description=(
+            "Gather codebase files by glob patterns with token estimation. "
+            "Returns a structured bundle for use as LLM context."
+        ),
+        input_schema=BundleFilesInput,
+        handler=bundle_files,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.FS_READ}),
+        toolsets=frozenset({"filesystem"}),
+    )
+)

--- a/amelia/tools/knowledge.py
+++ b/amelia/tools/knowledge.py
@@ -3,10 +3,21 @@
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from pydantic import BaseModel
+
 from amelia.knowledge.embeddings import EmbeddingClient
 from amelia.knowledge.models import SearchResult
 from amelia.knowledge.repository import KnowledgeRepository
 from amelia.knowledge.search import knowledge_search as _search
+from amelia.tools.registry import Permission, RiskLevel, ToolSpec, register
+
+
+class KnowledgeSearchInput(BaseModel):
+    """Input schema for the ``knowledge_search`` tool."""
+
+    query: str
+    top_k: int = 5
+    tags: list[str] | None = None
 
 
 def create_knowledge_tool(
@@ -50,3 +61,20 @@ def create_knowledge_tool(
         )
 
     return knowledge_search
+
+
+register(
+    ToolSpec(
+        name="knowledge_search",
+        description=(
+            "Search uploaded documentation for relevant information using "
+            "semantic search. Useful for looking up framework APIs or docs."
+        ),
+        input_schema=KnowledgeSearchInput,
+        handler=None,
+        factory=create_knowledge_tool,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset({Permission.NET_READ}),
+        toolsets=frozenset({"knowledge"}),
+    )
+)

--- a/amelia/tools/registry/__init__.py
+++ b/amelia/tools/registry/__init__.py
@@ -7,7 +7,13 @@ Re-exports the public surface so callers can write::
 
 from __future__ import annotations
 
-from amelia.tools.registry.registry import ToolRegistry, get, register, registry
+from amelia.tools.registry.registry import (
+    ToolRegistry,
+    discover_builtin_tools,
+    get,
+    register,
+    registry,
+)
 from amelia.tools.registry.spec import (
     Permission,
     RiskLevel,
@@ -20,6 +26,7 @@ __all__ = [
     "RiskLevel",
     "ToolRegistry",
     "ToolSpec",
+    "discover_builtin_tools",
     "get",
     "register",
     "registry",

--- a/amelia/tools/registry/__init__.py
+++ b/amelia/tools/registry/__init__.py
@@ -7,6 +7,7 @@ Re-exports the public surface so callers can write::
 
 from __future__ import annotations
 
+from amelia.tools.registry.policy import ToolPolicy, ToolPolicyMiddleware
 from amelia.tools.registry.registry import (
     ToolRegistry,
     discover_builtin_tools,
@@ -24,6 +25,8 @@ from amelia.tools.registry.spec import (
 __all__ = [
     "Permission",
     "RiskLevel",
+    "ToolPolicy",
+    "ToolPolicyMiddleware",
     "ToolRegistry",
     "ToolSpec",
     "discover_builtin_tools",

--- a/amelia/tools/registry/__init__.py
+++ b/amelia/tools/registry/__init__.py
@@ -1,0 +1,26 @@
+"""Tool registry package — canonical tool metadata + policy enforcement.
+
+Re-exports the public surface so callers can write::
+
+    from amelia.tools.registry import ToolSpec, register, registry, RiskLevel
+"""
+
+from __future__ import annotations
+
+from amelia.tools.registry.registry import ToolRegistry, get, register, registry
+from amelia.tools.registry.spec import (
+    Permission,
+    RiskLevel,
+    ToolSpec,
+)
+
+
+__all__ = [
+    "Permission",
+    "RiskLevel",
+    "ToolRegistry",
+    "ToolSpec",
+    "get",
+    "register",
+    "registry",
+]

--- a/amelia/tools/registry/adapters.py
+++ b/amelia/tools/registry/adapters.py
@@ -1,0 +1,40 @@
+"""Adapters that render a ``ToolSpec`` into a concrete driver's tool format.
+
+Currently only the LangChain adapter is needed (used by the API/deepagents
+driver). Future adapters (Claude CLI, Codex) can live here alongside it.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import StructuredTool
+
+from amelia.tools.registry.spec import ToolSpec
+
+
+def to_langchain(spec: ToolSpec) -> StructuredTool:
+    """Render a ``ToolSpec`` with a real handler into a LangChain ``StructuredTool``.
+
+    Args:
+        spec: A ``ToolSpec`` whose ``handler`` is set. Stubs and factory-only
+            specs (``handler is None``) are rejected because there is nothing
+            to bind.
+
+    Returns:
+        A ``StructuredTool`` wired to ``spec.handler``, named/described after
+        the spec, with ``input_schema`` as the args schema.
+
+    Raises:
+        ValueError: If ``spec.handler`` is ``None`` (stub or factory-only tool).
+    """
+    if spec.handler is None:
+        raise ValueError(
+            f"Tool {spec.name!r} has no handler — cannot build a LangChain tool. "
+            "Stubs and factory-only specs must be bound to a handler first "
+            "(e.g. via spec.factory(...))."
+        )
+    return StructuredTool.from_function(
+        coroutine=spec.handler,
+        name=spec.name,
+        description=spec.description,
+        args_schema=spec.input_schema,
+    )

--- a/amelia/tools/registry/policy.py
+++ b/amelia/tools/registry/policy.py
@@ -14,13 +14,13 @@ amelia is async-only, so no synchronous ``wrap_tool_call`` is provided.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+from pydantic import BaseModel, ConfigDict
 
 from amelia.core.constants import normalize_tool_name
 from amelia.tools.registry.registry import registry
@@ -31,8 +31,7 @@ from amelia.tools.registry.spec import RiskLevel
 type _AsyncToolHandler = Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
 
 
-@dataclass(frozen=True)
-class ToolPolicy:
+class ToolPolicy(BaseModel):
     """Declarative policy governing which tools a run may invoke.
 
     Attributes:
@@ -41,6 +40,8 @@ class ToolPolicy:
         max_risk: Risk ceiling. A permitted tool whose ``risk_level`` exceeds
             this is still denied. Defaults to ``EXECUTE`` (permissive).
     """
+
+    model_config = ConfigDict(frozen=True)
 
     allowed: frozenset[str]
     max_risk: RiskLevel = RiskLevel.EXECUTE
@@ -87,7 +88,13 @@ class ToolPolicyMiddleware(AgentMiddleware):
             )
 
         spec = registry.get(name)
-        if spec is not None and spec.risk_level > self.policy.max_risk:
+        if spec is None:
+            return ToolMessage(
+                content=f"Denied: tool '{name}' is not registered.",
+                tool_call_id=tool_call_id,
+                status="error",
+            )
+        if spec.risk_level > self.policy.max_risk:
             return ToolMessage(
                 content=(
                     f"Denied: tool '{name}' risk level ({spec.risk_level.name}) "

--- a/amelia/tools/registry/policy.py
+++ b/amelia/tools/registry/policy.py
@@ -1,0 +1,100 @@
+"""Tool policy + middleware that vetoes tool calls at runtime.
+
+``ToolPolicy`` is the declarative allow-list and risk ceiling.
+``ToolPolicyMiddleware`` enforces it by intercepting tool execution via
+``awrap_tool_call``: a denied call never reaches the handler, so its side
+effects never happen. This is the enforcement spine for #357 (read-only
+agents) and #228 (security guardrails).
+
+The interception hook is ``awrap_tool_call`` (not ``before_tool``) because
+langchain 1.x exposes tool interception exclusively through the wrapping hook.
+amelia is async-only, so no synchronous ``wrap_tool_call`` is provided.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from amelia.core.constants import normalize_tool_name
+from amelia.tools.registry.registry import registry
+from amelia.tools.registry.spec import RiskLevel
+
+
+# The handler type awrap_tool_call receives.
+type _AsyncToolHandler = Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
+
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    """Declarative policy governing which tools a run may invoke.
+
+    Attributes:
+        allowed: Canonical tool names permitted by this policy. A call whose
+            normalized name is not in this set is denied.
+        max_risk: Risk ceiling. A permitted tool whose ``risk_level`` exceeds
+            this is still denied. Defaults to ``EXECUTE`` (permissive).
+    """
+
+    allowed: frozenset[str]
+    max_risk: RiskLevel = RiskLevel.EXECUTE
+
+
+class ToolPolicyMiddleware(AgentMiddleware):
+    """Vetoes tool calls that violate a ``ToolPolicy`` before they execute.
+
+    Denials return a substitute ``ToolMessage(status="error")`` describing the
+    reason; the underlying tool handler is never invoked, so side effects are
+    guaranteed not to occur.
+    """
+
+    def __init__(self, policy: ToolPolicy) -> None:
+        self.policy = policy
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: _AsyncToolHandler,
+    ) -> ToolMessage | Command[Any]:
+        """Intercept a tool call, denying it if it violates the policy.
+
+        Args:
+            request: The tool call request. ``request.tool_call["name"]`` is
+                normalized via ``normalize_tool_name`` so CLI aliases (e.g.
+                ``"Write"``) are enforced consistently.
+            handler: The async callable that would execute the tool. Only
+                called when the policy permits the call.
+
+        Returns:
+            The handler's ``ToolMessage``/``Command`` on success, or an
+            error ``ToolMessage`` describing the denial otherwise.
+        """
+        raw_name = request.tool_call["name"]
+        name = normalize_tool_name(raw_name)
+        tool_call_id = request.tool_call["id"]
+
+        if name not in self.policy.allowed:
+            return ToolMessage(
+                content=f"Denied: tool '{raw_name}' is not permitted by the active policy.",
+                tool_call_id=tool_call_id,
+                status="error",
+            )
+
+        spec = registry.get(name)
+        if spec is not None and spec.risk_level > self.policy.max_risk:
+            return ToolMessage(
+                content=(
+                    f"Denied: tool '{name}' risk level ({spec.risk_level.name}) "
+                    f"exceeds the policy ceiling ({self.policy.max_risk.name})."
+                ),
+                tool_call_id=tool_call_id,
+                status="error",
+            )
+
+        return await handler(request)

--- a/amelia/tools/registry/registry.py
+++ b/amelia/tools/registry/registry.py
@@ -1,14 +1,52 @@
 """The tool registry — a module-level singleton tools self-register against.
 
 Public surface:
-    registry   — the singleton ``ToolRegistry`` instance.
-    register() — convenience wrapper around ``registry.register``.
-    get()      — convenience wrapper around ``registry.get``.
+    registry             — the singleton ``ToolRegistry`` instance.
+    register()           — convenience wrapper around ``registry.register``.
+    get()                — convenience wrapper around ``registry.get``.
+    discover_builtin_tools() — AST-scan ``amelia/tools/*.py`` and import every
+                          module that self-registers a tool at module level.
 """
 
 from __future__ import annotations
 
+import ast
+import importlib
+from pathlib import Path
+
+from loguru import logger
+
 from amelia.tools.registry.spec import ToolSpec
+
+
+# Directory containing tool modules that may self-register. Resolved relative to
+# this file so discovery works regardless of the current working directory.
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+_TOOLS_PACKAGE = "amelia.tools"
+
+
+def _module_registers_tools(module_path: Path) -> bool:
+    """Return True if ``module_path`` has a top-level ``register(...)`` call.
+
+    We deliberately only look at *top-level* statements so that helper modules
+    which mention ``register`` inside functions/classes are not imported for
+    their side effects.
+    """
+    try:
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    except (SyntaxError, OSError):
+        return False
+
+    for node in tree.body:
+        if not isinstance(node, ast.Expr):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if isinstance(func, ast.Name) and func.id == "register":
+            return True
+    return False
 
 
 class ToolRegistry:
@@ -93,3 +131,32 @@ def register(spec: ToolSpec, *, override: bool = False) -> None:
 def get(name: str) -> ToolSpec | None:
     """Look up ``name`` in the module-level singleton."""
     return registry.get(name)
+
+
+def discover_builtin_tools() -> list[str]:
+    """Import every ``amelia/tools/*.py`` module that self-registers a tool.
+
+    Uses an AST scan (no execution) to decide which modules to import, then
+    imports them so their top-level ``register(ToolSpec(...))`` calls populate
+    the module-level ``registry``.
+
+    The registry is a plain dict and Python caches imported modules, so this
+    function is idempotent: calling it more than once neither raises on
+    duplicate registration nor re-runs module-level code.
+
+    Returns:
+        Sorted list of all tool names registered after discovery.
+    """
+    for path in sorted(_TOOLS_DIR.glob("*.py")):
+        # Skip package init — it triggers discovery itself and never registers.
+        if path.name == "__init__.py":
+            continue
+        if not _module_registers_tools(path):
+            continue
+        module_name = f"{_TOOLS_PACKAGE}.{path.stem}"
+        try:
+            importlib.import_module(module_name)
+        except Exception:
+            # A failing tool module must not break discovery for the rest.
+            logger.exception("Failed to import self-registering tool module", module=module_name)
+    return sorted(registry.all_names())

--- a/amelia/tools/registry/registry.py
+++ b/amelia/tools/registry/registry.py
@@ -1,0 +1,95 @@
+"""The tool registry — a module-level singleton tools self-register against.
+
+Public surface:
+    registry   — the singleton ``ToolRegistry`` instance.
+    register() — convenience wrapper around ``registry.register``.
+    get()      — convenience wrapper around ``registry.get``.
+"""
+
+from __future__ import annotations
+
+from amelia.tools.registry.spec import ToolSpec
+
+
+class ToolRegistry:
+    """In-memory map of canonical tool name → ``ToolSpec``.
+
+    Tests should instantiate their own ``ToolRegistry`` to avoid polluting the
+    module-level singleton; production code uses ``registry`` (below).
+    """
+
+    def __init__(self) -> None:
+        self._specs: dict[str, ToolSpec] = {}
+
+    def register(self, spec: ToolSpec, *, override: bool = False) -> None:
+        """Register a ``ToolSpec``.
+
+        Args:
+            spec: The spec to register.
+            override: When True, silently replace an existing spec with the
+                same name. When False (default), duplicate names raise
+                ``ValueError`` so accidental shadowing is loud.
+
+        Raises:
+            ValueError: If the name is already registered and ``override`` is
+                False.
+        """
+        if spec.name in self._specs and not override:
+            raise ValueError(
+                f"Tool {spec.name!r} is already registered. "
+                "Pass override=True to replace it."
+            )
+        self._specs[spec.name] = spec
+
+    def get(self, name: str) -> ToolSpec | None:
+        """Return the spec for ``name``, or ``None`` if unregistered."""
+        return self._specs.get(name)
+
+    def resolve(self, names: list[str]) -> list[ToolSpec]:
+        """Return specs for ``names`` in order.
+
+        Raises:
+            KeyError: If any name is not registered (with the missing name).
+        """
+        resolved: list[ToolSpec] = []
+        for name in names:
+            spec = self._specs.get(name)
+            if spec is None:
+                raise KeyError(name)
+            resolved.append(spec)
+        return resolved
+
+    def names_for_toolset(self, toolset: str) -> frozenset[str]:
+        """Return the names of all registered tools belonging to ``toolset``."""
+        return frozenset(
+            spec.name for spec in self._specs.values() if toolset in spec.toolsets
+        )
+
+    def all_names(self) -> frozenset[str]:
+        """Return every registered tool name."""
+        return frozenset(self._specs)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._specs
+
+    def __len__(self) -> int:
+        return len(self._specs)
+
+
+# The module-level singleton. Tool modules call ``register(ToolSpec(...))`` at
+# import time; ``discover_builtin_tools`` imports those modules.
+registry: ToolRegistry = ToolRegistry()
+
+
+def register(spec: ToolSpec, *, override: bool = False) -> None:
+    """Register ``spec`` against the module-level singleton.
+
+    Thin convenience wrapper so tool modules can write ``register(ToolSpec(...))``
+    without holding a reference to the singleton.
+    """
+    registry.register(spec, override=override)
+
+
+def get(name: str) -> ToolSpec | None:
+    """Look up ``name`` in the module-level singleton."""
+    return registry.get(name)

--- a/amelia/tools/registry/spec.py
+++ b/amelia/tools/registry/spec.py
@@ -1,0 +1,104 @@
+"""Tool metadata schema and enums.
+
+Defines ``ToolSpec`` — the single schema every amelia tool registers against —
+plus the ``RiskLevel`` and ``Permission`` enums used by the policy layer to
+reason about tools uniformly across drivers.
+
+See ``.beagle/concepts/tool-registry/spec.md`` §1 for the design.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from enum import IntEnum, StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from amelia.core.constants import ToolName
+
+
+class RiskLevel(IntEnum):
+    """Risk classification for a tool, ordered from least to most dangerous.
+
+    The policy layer vetoes any tool whose risk exceeds the configured ceiling.
+    """
+
+    READ_ONLY = 0
+    WRITE = 1
+    EXECUTE = 2
+    DESTRUCTIVE = 3
+
+
+class Permission(StrEnum):
+    """Capabilities a tool requires. Union of these is surfaced for auditing."""
+
+    FS_READ = "fs.read"
+    FS_WRITE = "fs.write"
+    SHELL_EXEC = "shell.exec"
+    NET_READ = "net.read"
+    NET_WRITE = "net.write"
+
+
+# Type aliases for the callable ToolSpec fields. These are arbitrary types from
+# Pydantic's perspective (validated via ``arbitrary_types_allowed``).
+AvailabilityCheck = Callable[[], Awaitable[bool]]
+ToolHandler = Callable[..., Awaitable[Any]]
+ToolFactory = Callable[..., ToolHandler]
+
+
+class ToolSpec(BaseModel):
+    """Metadata + handler for a single tool.
+
+    A ``ToolSpec`` is immutable. Tools that own a real implementation set
+    ``handler``; tools that need runtime dependencies (DB clients, root dirs)
+    set ``factory`` instead and leave ``handler`` empty. Library-provided tools
+    that amelia does not implement (deepagents FilesystemMiddleware, sandbox
+    ``execute``) are registered as *stubs* with both ``handler`` and ``factory``
+    unset so the policy layer can still reason about them.
+
+    Attributes:
+        name: Canonical tool name. Must be a member of ``ToolName``.
+        description: Human-readable summary surfaced to the model.
+        input_schema: Pydantic model describing the tool's arguments.
+        handler: Async callable executing the tool, or ``None`` for
+            stubs/factory-tools.
+        risk_level: Risk classification used by the policy ceiling.
+        required_permissions: Capabilities the tool exercises (for audit).
+        toolsets: Logical groups the tool belongs to (e.g. ``"readonly"``).
+        check_fn: Optional async availability probe (e.g. "is a sandbox up?").
+        factory: Optional callable that builds a ``handler`` from runtime deps.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    name: str
+    description: str
+    input_schema: type[BaseModel]
+    handler: ToolHandler | None = None
+    risk_level: RiskLevel = RiskLevel.READ_ONLY
+    required_permissions: frozenset[Permission] = frozenset()
+    toolsets: frozenset[str] = frozenset()
+    check_fn: AvailabilityCheck | None = None
+    factory: ToolFactory | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        """Reject names that are not members of the canonical ``ToolName`` enum.
+
+        Keeping the registry and constants in lockstep means the policy layer
+        can never see a tool name it cannot reason about.
+        """
+        try:
+            ToolName(v)
+        except ValueError as err:  # pragma: no cover - defensive branch
+            raise ValueError(
+                f"Unknown tool name {v!r}: not a member of ToolName."
+            ) from err
+        return v
+
+    @property
+    def is_stub(self) -> bool:
+        """True when this spec carries metadata only (no handler, no factory)."""
+        return self.handler is None and self.factory is None

--- a/amelia/tools/shell_executor.py
+++ b/amelia/tools/shell_executor.py
@@ -3,6 +3,18 @@
 import asyncio
 import shlex
 
+from pydantic import BaseModel
+
+from amelia.tools.registry import Permission, RiskLevel, ToolSpec, register
+
+
+class RunShellCommandInput(BaseModel):
+    """Input schema for the ``run_shell_command`` tool."""
+
+    command: str
+    timeout: int | None = 30
+    cwd: str | None = None
+
 
 async def run_shell_command(
     command: str,
@@ -52,3 +64,19 @@ async def run_shell_command(
         process.kill()
         await process.wait()
         raise RuntimeError(f"Command timed out after {timeout} seconds") from None
+
+
+register(
+    ToolSpec(
+        name="run_shell_command",
+        description=(
+            "Execute a shell command and return its stdout. "
+            "Use for build, test, and git operations."
+        ),
+        input_schema=RunShellCommandInput,
+        handler=run_shell_command,
+        risk_level=RiskLevel.EXECUTE,
+        required_permissions=frozenset({Permission.SHELL_EXEC}),
+        toolsets=frozenset({"execute"}),
+    )
+)

--- a/amelia/tools/write_plan.py
+++ b/amelia/tools/write_plan.py
@@ -16,6 +16,8 @@ from langchain_core.tools import StructuredTool
 from loguru import logger
 from pydantic import ValidationError
 
+from amelia.tools.registry import Permission, RiskLevel, ToolSpec, register
+from amelia.tools.registry.spec import ToolHandler
 from amelia.tools.write_plan_renderer import render_plan_markdown
 from amelia.tools.write_plan_schema import WritePlanInput
 
@@ -115,17 +117,17 @@ async def execute_write_plan(
     )
 
 
-def create_write_plan_tool(root_dir: str) -> StructuredTool:
-    """Create a LangChain StructuredTool for write_plan.
+def create_write_plan_handler(root_dir: str) -> ToolHandler:
+    """Build an async ``write_plan`` handler bound to ``root_dir``.
 
-    This tool is injected into the API driver's tool list so the LLM
-    calls it instead of generic write_file for plan generation.
+    Shared by the registry factory and the LangChain tool wrapper so the
+    validation/render/write behavior lives in exactly one place.
 
     Args:
-        root_dir: Root directory for resolving file paths.
+        root_dir: Root directory for resolving relative file paths.
 
     Returns:
-        Configured StructuredTool instance.
+        Async callable accepting the ``WritePlanInput`` fields.
     """
 
     async def _invoke(
@@ -153,8 +155,23 @@ def create_write_plan_tool(root_dir: str) -> StructuredTool:
             f"Goal: {result.goal}"
         )
 
+    return _invoke
+
+
+def create_write_plan_tool(root_dir: str) -> StructuredTool:
+    """Create a LangChain StructuredTool for write_plan.
+
+    This tool is injected into the API driver's tool list so the LLM
+    calls it instead of generic write_file for plan generation.
+
+    Args:
+        root_dir: Root directory for resolving file paths.
+
+    Returns:
+        Configured StructuredTool instance.
+    """
     return StructuredTool.from_function(
-        coroutine=_invoke,
+        coroutine=create_write_plan_handler(root_dir),
         name="write_plan",
         description=(
             "Write a structured implementation plan to a markdown file. "
@@ -165,3 +182,20 @@ def create_write_plan_tool(root_dir: str) -> StructuredTool:
         ),
         args_schema=WritePlanInput,
     )
+
+
+register(
+    ToolSpec(
+        name="write_plan",
+        description=(
+            "Write a structured implementation plan to a markdown file. "
+            "Validates input, renders consistent markdown, and writes to disk."
+        ),
+        input_schema=WritePlanInput,
+        handler=None,
+        factory=create_write_plan_handler,
+        risk_level=RiskLevel.WRITE,
+        required_permissions=frozenset({Permission.FS_WRITE}),
+        toolsets=frozenset({"planning"}),
+    )
+)

--- a/tests/unit/core/test_constants.py
+++ b/tests/unit/core/test_constants.py
@@ -45,7 +45,8 @@ def test_tool_name_enum_has_all_canonical_names() -> None:
     invertible) are verified by other tests. This test catches unintentional
     enum changes — update the count when adding a new tool deliberately.
     """
-    assert len(ToolName) == 22
+    # 22 CLI-SDK tools + bundle_files + execute (registry/library tools).
+    assert len(ToolName) == 24
 
 
 def test_tool_name_aliases_covers_all_cli_sdk_names() -> None:
@@ -69,9 +70,21 @@ def test_canonical_to_cli_is_inverse_of_aliases() -> None:
 
 
 def test_canonical_to_cli_covers_all_tool_names() -> None:
-    """CANONICAL_TO_CLI has an entry for every ToolName enum member."""
+    """CANONICAL_TO_CLI has an entry for every CLI-facing ToolName member.
+
+    A small, deliberate set of registry/library tools (no Claude CLI SDK
+    equivalent) are exempt — ``claude.py`` passes unknown names through via
+    ``CANONICAL_TO_CLI.get(name, name)``, so missing entries are safe there.
+    Keep this allowlist explicit so accidental omissions of *real* CLI tools
+    still trip this guard.
+    """
     from amelia.core.constants import CANONICAL_TO_CLI
+
+    # Tools implemented by amelia/deepagents rather than the Claude CLI SDK.
+    no_cli_alias = {"bundle_files", "execute"}
     for member in ToolName:
+        if member.value in no_cli_alias:
+            continue
         assert member.value in CANONICAL_TO_CLI, f"Missing CANONICAL_TO_CLI entry for {member}"
 
 

--- a/tests/unit/tools/test_adapters.py
+++ b/tests/unit/tools/test_adapters.py
@@ -1,0 +1,80 @@
+"""Tests for the LangChain adapter (to_langchain)."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import BaseTool, StructuredTool
+
+from amelia.tools.registry import ToolSpec
+from amelia.tools.registry.adapters import to_langchain
+from amelia.tools.registry.registry import discover_builtin_tools, registry
+from amelia.tools.registry.spec import RiskLevel
+
+
+def test_to_langchain_produces_callable_tool():
+    discover_builtin_tools()
+    spec = registry.get("bundle_files")
+    assert spec is not None
+    tool = to_langchain(spec)
+    assert isinstance(tool, BaseTool)
+    assert isinstance(tool, StructuredTool)
+    assert tool.name == "bundle_files"
+    assert tool.description == spec.description
+
+
+async def test_to_langchain_tool_invokes_handler(tmp_path):
+    discover_builtin_tools()
+    spec = registry.get("bundle_files")
+    assert spec is not None
+    tool = to_langchain(spec)
+
+    # Create a file the bundler can pick up.
+    (tmp_path / "hello.md").write_text("# hi", encoding="utf-8")
+
+    result = await tool.ainvoke({"working_dir": str(tmp_path), "patterns": ["*.md"]})
+    # bundle_files returns a FileBundle pydantic model with a `files` attribute.
+    assert hasattr(result, "files")
+    assert len(result.files) == 1
+    assert result.files[0].path == "hello.md"
+
+
+def test_to_langchain_rejects_stub():
+    discover_builtin_tools()
+    stub = registry.get("read_file")
+    assert stub is not None
+    assert stub.is_stub
+    with pytest.raises(ValueError, match="handler"):
+        to_langchain(stub)
+
+
+def test_to_langchain_rejects_factory_only_spec():
+    discover_builtin_tools()
+    spec = registry.get("knowledge_search")
+    assert spec is not None
+    assert spec.handler is None
+    with pytest.raises(ValueError, match="handler"):
+        to_langchain(spec)
+
+
+async def test_to_langchain_round_trip_on_inline_handler(tmp_path):
+    """A spec built from an inline async handler must be invokable end-to-end."""
+    from pydantic import BaseModel
+
+    class EchoInput(BaseModel):
+        msg: str
+
+    async def echo(*, msg: str) -> str:
+        return f"echo:{msg}"
+
+    spec = ToolSpec(
+        name="glob",  # reuse a valid ToolName; register on a throwaway registry path
+        description="echo",
+        input_schema=EchoInput,
+        handler=echo,
+        risk_level=RiskLevel.READ_ONLY,
+        required_permissions=frozenset(),
+        toolsets=frozenset(),
+    )
+    tool = to_langchain(spec)
+    out = await tool.ainvoke({"msg": "hi"})
+    assert out == "echo:hi"

--- a/tests/unit/tools/test_discovery.py
+++ b/tests/unit/tools/test_discovery.py
@@ -1,0 +1,46 @@
+"""Tests for discover_builtin_tools() AST-based discovery.
+
+These pass fully once Step 3 migrates the tool modules to self-register; the
+discovery mechanism itself is validated here against the registry singleton.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amelia.tools.registry import registry
+from amelia.tools.registry.registry import discover_builtin_tools
+
+
+@pytest.fixture(autouse=True)
+def _discover_once():
+    """Ensure discovery has run before each test in this module."""
+    discover_builtin_tools()
+    yield
+
+
+def test_discover_returns_list_of_names():
+    names = discover_builtin_tools()
+    assert isinstance(names, list)
+    # Idempotent: running again does not raise and still returns names.
+    again = discover_builtin_tools()
+    assert set(again) == set(names)
+
+
+def test_discover_imports_self_registering_modules():
+    # shell_executor self-registers after Step 3.
+    names = discover_builtin_tools()
+    assert "run_shell_command" in names
+
+
+def test_discovered_names_are_in_registry():
+    names = discover_builtin_tools()
+    for name in names:
+        assert registry.get(name) is not None
+
+
+def test_discover_is_idempotent_no_duplicate_error():
+    # Repeated discovery must not raise on re-registration of cached modules.
+    for _ in range(3):
+        discover_builtin_tools()
+    assert "run_shell_command" in registry.all_names()

--- a/tests/unit/tools/test_policy.py
+++ b/tests/unit/tools/test_policy.py
@@ -77,7 +77,9 @@ class TestToolPolicy:
 
     def test_frozen(self):
         policy = ToolPolicy(allowed=frozenset({"read_file"}))
-        with pytest.raises((AttributeError, TypeError)):
+        from pydantic import ValidationError
+
+        with pytest.raises((AttributeError, TypeError, ValidationError)):
             policy.allowed = frozenset({"write_file"})  # type: ignore[misc]
 
 
@@ -176,4 +178,29 @@ async def test_policy_normalizes_cli_tool_name_aliases(tmp_path):
     result2 = await mw2.awrap_tool_call(request2, handler2)
     assert result2.status == "error"
     assert "denied" in result2.content.lower()
+
+
+async def test_policy_denies_unregistered_tool_in_allowed_set():
+    """A tool name in the allowed set but missing from the registry is denied.
+
+    Defense-in-depth: an unregistered tool has no risk metadata, so the policy
+    must refuse to forward it to the handler rather than silently executing it.
+    """
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+
+    policy = ToolPolicy(allowed=frozenset({"nonexistent_tool"}), max_risk=RiskLevel.EXECUTE)
+    mw = ToolPolicyMiddleware(policy=policy)
+
+    async def handler(_req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="should-not-run", tool_call_id="c6")
+
+    request = ToolCallRequest(
+        tool_call={"name": "nonexistent_tool", "args": {}, "id": "c6", "type": "tool_call"},
+        tool=None,
+        state={},
+        runtime=None,  # type: ignore[arg-type]
+    )
+    result = await mw.awrap_tool_call(request, handler)
+    assert result.status == "error"
+    assert "not registered" in result.content.lower()
 

--- a/tests/unit/tools/test_policy.py
+++ b/tests/unit/tools/test_policy.py
@@ -180,6 +180,7 @@ async def test_policy_normalizes_cli_tool_name_aliases(tmp_path):
     assert "denied" in result2.content.lower()
 
 
+@pytest.mark.asyncio
 async def test_policy_denies_unregistered_tool_in_allowed_set():
     """A tool name in the allowed set but missing from the registry is denied.
 

--- a/tests/unit/tools/test_policy.py
+++ b/tests/unit/tools/test_policy.py
@@ -1,0 +1,179 @@
+"""Tests for ToolPolicy + ToolPolicyMiddleware.
+
+The veto test asserts the OBSERVABLE CONSEQUENCE — that a denied write tool
+never touches disk — not merely that the middleware was called. It wires the
+middleware into a real langgraph ToolNode via ``awrap_tool_call`` and drives it
+through a compiled StateGraph (the same entrypoint real agents use, which is
+what supplies the Runtime langgraph requires).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any
+
+import pytest
+from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt.tool_node import ToolNode
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+from amelia.tools.registry.policy import ToolPolicy, ToolPolicyMiddleware
+from amelia.tools.registry.spec import RiskLevel
+
+
+class _WriteFileInput(BaseModel):
+    file_path: str
+    content: str
+
+
+def _make_write_tool() -> StructuredTool:
+    """Build a real StructuredTool that writes to disk (the guarded side effect)."""
+
+    async def _write(*, file_path: str, content: str) -> str:
+        Path(file_path).write_text(content, encoding="utf-8")
+        return f"wrote {file_path}"
+
+    return StructuredTool.from_function(
+        coroutine=_write,
+        name="write_file",
+        description="write a file to disk",
+        args_schema=_WriteFileInput,
+    )
+
+
+class _State(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+
+def _build_app(policy: ToolPolicy) -> Any:
+    """Compile a single-node graph: START -> ToolNode(+middleware) -> END."""
+    mw = ToolPolicyMiddleware(policy=policy)
+    node = ToolNode(tools=[_make_write_tool()], awrap_tool_call=mw.awrap_tool_call)
+    graph = StateGraph(_State)
+    graph.add_node("tools", node)
+    graph.add_edge(START, "tools")
+    graph.add_edge("tools", END)
+    return graph.compile()
+
+
+def _call(name: str, file_path: str, call_id: str) -> dict[str, object]:
+    return {
+        "name": name,
+        "args": {"file_path": file_path, "content": "secret"},
+        "id": call_id,
+        "type": "tool_call",
+    }
+
+
+class TestToolPolicy:
+    def test_defaults(self):
+        policy = ToolPolicy(allowed=frozenset({"read_file"}))
+        assert policy.allowed == frozenset({"read_file"})
+        assert policy.max_risk == RiskLevel.EXECUTE  # permissive default
+
+    def test_frozen(self):
+        policy = ToolPolicy(allowed=frozenset({"read_file"}))
+        with pytest.raises((AttributeError, TypeError)):
+            policy.allowed = frozenset({"write_file"})  # type: ignore[misc]
+
+
+async def test_policy_vetoes_write_file_and_prevents_disk_write(tmp_path):
+    """A denied write_file call must return an error ToolMessage AND write nothing.
+
+    This is the spec's observable acceptance test: it asserts the side effect
+    (file on disk) never happens, not just that the middleware short-circuited.
+    """
+    target = tmp_path / "out.txt"
+    assert not target.exists()
+
+    app = _build_app(ToolPolicy(allowed=frozenset({"read_file"}), max_risk=RiskLevel.READ_ONLY))
+    result = await app.ainvoke({"messages": [AIMessage(content="", tool_calls=[_call("write_file", str(target), "c1")])]})
+
+    msg = result["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "denied" in msg.content.lower()
+    assert msg.tool_call_id == "c1"
+
+    # THE OBSERVABLE CONSEQUENCE: the file was never written.
+    assert not target.exists(), "write_file side effect happened despite veto"
+
+
+async def test_policy_risk_ceiling_vetoes_high_risk(tmp_path):
+    """An allowed tool whose risk exceeds the ceiling is still vetoed."""
+    target = tmp_path / "out.txt"
+
+    # write_file is permitted by name but the ceiling is READ_ONLY while
+    # write_file is WRITE risk -> must be denied on risk grounds.
+    app = _build_app(ToolPolicy(allowed=frozenset({"write_file"}), max_risk=RiskLevel.READ_ONLY))
+    result = await app.ainvoke({"messages": [AIMessage(content="", tool_calls=[_call("write_file", str(target), "c2")])]})
+
+    msg = result["messages"][-1]
+    assert msg.status == "error"
+    assert "risk" in msg.content.lower() or "ceiling" in msg.content.lower()
+    assert not target.exists()
+
+
+async def test_policy_allows_permitted_tool_runs_handler(tmp_path):
+    """A permitted, in-budget tool call must run and produce its real effect."""
+    target = tmp_path / "ok.txt"
+
+    app = _build_app(ToolPolicy(allowed=frozenset({"write_file"}), max_risk=RiskLevel.WRITE))
+    await app.ainvoke({"messages": [AIMessage(content="", tool_calls=[_call("write_file", str(target), "c3")])]})
+
+    # THE OBSERVABLE CONSEQUENCE: the file WAS written (handler executed).
+    assert target.exists()
+    assert target.read_text() == "secret"
+
+
+async def test_policy_normalizes_cli_tool_name_aliases(tmp_path):
+    """A tool call using a CLI alias (e.g. 'Write') is normalized before the check.
+
+    Driven directly against ``awrap_tool_call`` because a bare ToolNode resolves
+    tools by exact name before dispatch; the middleware's job is to normalize for
+    the *policy* decision, which is what we assert here: an alias for an allowed
+    tool is permitted (handler invoked), while an alias for a disallowed tool is
+    denied.
+    """
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+
+    permitted = ToolPolicy(allowed=frozenset({"write_file"}), max_risk=RiskLevel.WRITE)
+    mw = ToolPolicyMiddleware(policy=permitted)
+
+    invoked: list[str] = []
+
+    async def handler(_req: ToolCallRequest) -> ToolMessage:
+        invoked.append("yes")
+        return ToolMessage(content="ok", tool_call_id="c4")
+
+    request = ToolCallRequest(
+        tool_call={"name": "Write", "args": {}, "id": "c4", "type": "tool_call"},
+        tool=None,
+        state={},
+        runtime=None,  # type: ignore[arg-type]
+    )
+    result = await mw.awrap_tool_call(request, handler)
+    assert invoked == ["yes"], "alias for an allowed tool should reach the handler"
+    assert result.content == "ok"
+
+    # And the inverse: an alias for a tool NOT in the policy is denied.
+    denied = ToolPolicy(allowed=frozenset({"read_file"}), max_risk=RiskLevel.READ_ONLY)
+    mw2 = ToolPolicyMiddleware(policy=denied)
+
+    async def handler2(_req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="should-not-run", tool_call_id="c5")
+
+    request2 = ToolCallRequest(
+        tool_call={"name": "Bash", "args": {}, "id": "c5", "type": "tool_call"},
+        tool=None,
+        state={},
+        runtime=None,  # type: ignore[arg-type]
+    )
+    result2 = await mw2.awrap_tool_call(request2, handler2)
+    assert result2.status == "error"
+    assert "denied" in result2.content.lower()
+

--- a/tests/unit/tools/test_readonly_drift.py
+++ b/tests/unit/tools/test_readonly_drift.py
@@ -1,0 +1,27 @@
+"""Drift guard: READONLY_TOOLS preset must equal the registry's 'readonly' toolset.
+
+Makes the previously only-partially-consumed ``READONLY_TOOLS`` constant
+load-bearing against the registry. ``READONLY_TOOLS`` is consumed by the Codex
+driver (``drivers/cli/codex.py``) to pick its sandbox approval mode, so the
+registry's ``readonly`` toolset is kept in sync with it.
+"""
+
+from __future__ import annotations
+
+from amelia.core.constants import READONLY_TOOLS
+from amelia.tools.registry.registry import discover_builtin_tools, registry
+
+
+def test_readonly_tools_matches_registry():
+    """set(READONLY_TOOLS) must equal registry.names_for_toolset('readonly').
+
+    If this fails, either ``READONLY_TOOLS`` in constants.py or the ``readonly``
+    toolset tag on the registering stubs has drifted — fix the side that's wrong.
+    """
+    discover_builtin_tools()
+    preset = {t.value for t in READONLY_TOOLS}
+    registered = registry.names_for_toolset("readonly")
+    assert preset == registered, (
+        f"READONLY_TOOLS drift: preset={sorted(preset)} "
+        f"!= registry readonly toolset={sorted(registered)}"
+    )

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from amelia.tools.registry.registry import ToolRegistry
+from amelia.tools.registry.registry import ToolRegistry, registry
 from amelia.tools.registry.spec import Permission, RiskLevel, ToolSpec
 
 
@@ -138,3 +138,48 @@ class TestToolRegistry:
         # The module-level singleton must be a ToolRegistry instance.
         assert isinstance(registry, ToolRegistry)
         assert callable(register)
+
+
+class TestBuiltinDiscovery:
+    """Integration: self-registering tool modules populate the singleton."""
+
+    def test_discover_registers_builtin_tools(self):
+        from amelia.tools.registry.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+
+        run = registry.get("run_shell_command")
+        assert run is not None
+        assert run.risk_level == RiskLevel.EXECUTE
+
+        knowledge = registry.get("knowledge_search")
+        assert knowledge is not None
+        assert knowledge.handler is None  # factory-tool
+        assert knowledge.factory is not None
+
+        bundle = registry.get("bundle_files")
+        assert bundle is not None
+        assert bundle.handler is not None  # static handler
+
+        write_plan = registry.get("write_plan")
+        assert write_plan is not None
+        assert write_plan.factory is not None  # factory-tool
+
+    def test_library_stubs_registered_with_no_handler(self):
+        from amelia.tools.registry.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        # The 6 library stubs named in the spec (filesystem + sandbox execute)
+        # plus web_fetch/web_search, which are registered as stubs so the
+        # READONLY_TOOLS drift guard holds (they belong to the Codex
+        # observe-only preset, consumed by drivers/cli/codex.py).
+        stub_names = {
+            "read_file", "write_file", "edit_file", "glob", "grep", "execute",
+            "web_fetch", "web_search",
+        }
+        for name in stub_names:
+            spec = registry.get(name)
+            assert spec is not None, f"missing stub {name}"
+            assert spec.handler is None, f"{name} stub must not carry a handler"
+            assert spec.factory is None, f"{name} stub must not carry a factory"
+            assert spec.is_stub

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -1,0 +1,140 @@
+"""Tests for the Tool registry: ToolSpec schema, enums, and ToolRegistry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from amelia.tools.registry.registry import ToolRegistry
+from amelia.tools.registry.spec import Permission, RiskLevel, ToolSpec
+
+
+class _DummyInput(BaseModel):
+    """Minimal input schema for test specs."""
+
+    value: str = ""
+
+
+async def _dummy_handler(**kwargs: Any) -> str:
+    return "ok"
+
+
+def _make_spec(
+    *,
+    name: str = "read_file",
+    description: str = "d",
+    risk: RiskLevel = RiskLevel.READ_ONLY,
+    toolsets: frozenset[str] = frozenset({"readonly"}),
+) -> ToolSpec:
+    return ToolSpec(
+        name=name,
+        description=description,
+        input_schema=_DummyInput,
+        handler=_dummy_handler,
+        risk_level=risk,
+        required_permissions=frozenset(),
+        toolsets=toolsets,
+    )
+
+
+class TestRiskLevel:
+    def test_ordering(self):
+        assert RiskLevel.READ_ONLY < RiskLevel.WRITE < RiskLevel.EXECUTE < RiskLevel.DESTRUCTIVE
+
+    def test_values(self):
+        assert int(RiskLevel.READ_ONLY) == 0
+        assert int(RiskLevel.DESTRUCTIVE) == 3
+
+
+class TestToolSpec:
+    def test_construct_minimal(self):
+        spec = _make_spec()
+        assert spec.name == "read_file"
+        assert spec.risk_level == RiskLevel.READ_ONLY
+        assert spec.handler is _dummy_handler
+        assert spec.toolsets == frozenset({"readonly"})
+
+    def test_frozen(self):
+        spec = _make_spec()
+        with pytest.raises((ValidationError, TypeError)):
+            spec.name = "write_file"  # type: ignore[misc]
+
+    def test_invalid_name_rejected(self):
+        with pytest.raises(ValidationError):
+            ToolSpec(
+                name="not_a_real_tool",
+                description="d",
+                input_schema=_DummyInput,
+                handler=_dummy_handler,
+                risk_level=RiskLevel.READ_ONLY,
+                required_permissions=frozenset(),
+                toolsets=frozenset(),
+            )
+
+    def test_required_permissions_are_frozenset(self):
+        spec = ToolSpec(
+            name="run_shell_command",
+            description="d",
+            input_schema=_DummyInput,
+            handler=_dummy_handler,
+            risk_level=RiskLevel.EXECUTE,
+            required_permissions={Permission.SHELL_EXEC},
+            toolsets=frozenset({"execute"}),
+        )
+        assert spec.required_permissions == frozenset({Permission.SHELL_EXEC})
+
+
+class TestToolRegistry:
+    def test_register_and_get(self):
+        reg = ToolRegistry()
+        spec = _make_spec()
+        reg.register(spec)
+        assert reg.get("read_file") is spec
+
+    def test_get_missing_returns_none(self):
+        reg = ToolRegistry()
+        assert reg.get("nope") is None
+
+    def test_duplicate_register_raises(self):
+        reg = ToolRegistry()
+        reg.register(_make_spec())
+        with pytest.raises(ValueError):
+            reg.register(_make_spec())
+
+    def test_duplicate_register_override_allowed(self):
+        reg = ToolRegistry()
+        reg.register(_make_spec())
+        replacement = _make_spec(description="d2")
+        reg.register(replacement, override=True)
+        assert reg.get("read_file") is replacement
+
+    def test_names_for_toolset(self):
+        reg = ToolRegistry()
+        reg.register(_make_spec(name="read_file", toolsets=frozenset({"readonly", "filesystem"})))
+        reg.register(_make_spec(name="glob", toolsets=frozenset({"readonly"})))
+        reg.register(_make_spec(name="write_file", risk=RiskLevel.WRITE, toolsets=frozenset({"filesystem"})))
+        readonly = reg.names_for_toolset("readonly")
+        assert "read_file" in readonly
+        assert "glob" in readonly
+        assert "write_file" not in readonly
+
+    def test_resolve_returns_specs(self):
+        reg = ToolRegistry()
+        reg.register(_make_spec(name="read_file"))
+        reg.register(_make_spec(name="glob"))
+        resolved = reg.resolve(["read_file", "glob"])
+        assert {s.name for s in resolved} == {"read_file", "glob"}
+
+    def test_resolve_unknown_raises(self):
+        reg = ToolRegistry()
+        with pytest.raises(KeyError):
+            reg.resolve(["ghost"])
+
+    def test_module_singleton_and_free_function(self):
+        from amelia.tools.registry import register, registry
+
+        # The module-level singleton must be a ToolRegistry instance.
+        assert isinstance(registry, ToolRegistry)
+        assert callable(register)


### PR DESCRIPTION
## Summary

- Introduces a unified `ToolSpec` schema and `ToolRegistry` that every amelia tool registers against — replacing four divergent, hard-coded tool paths with one catalog
- Adds `ToolPolicyMiddleware` that can veto tool calls at runtime via `awrap_tool_call` (empirically verified by the middleware-veto spike), returning a substitute `ToolMessage` so side effects never execute
- Migrates all existing tools to self-register, adds library-tool stubs for the deepagents-injected filesystem tools, and adds a `READONLY_TOOLS` drift guard test

## Motivation

Tools are currently hard-coded with no central registry: no catalog, no security metadata, no allowlisting, no risk levels. `knowledge_search` is built but orphaned. `READONLY_TOOLS` is defined but unconsumed. `allowed_tools` raises `NotImplementedError` on the ApiDriver. This PR creates the registry spine that #621 (wiring), #357 (read-only toolset), and #228 (security guardrails) will stack on.

Closes #233.

## Changes

### Added
- `amelia/tools/registry/` package: `spec.py` (ToolSpec + RiskLevel + Permission enums), `registry.py` (ToolRegistry singleton + register() + AST-based discover_builtin_tools()), `adapters.py` (to_langchain), `policy.py` (ToolPolicy + ToolPolicyMiddleware)
- `amelia/tools/_stubs.py`: spec stubs for the 7 deepagents FilesystemMiddleware tools (catalog without implementation)
- `tests/unit/tools/test_registry.py`, `test_discovery.py`, `test_adapters.py`, `test_policy.py`, `test_readonly_drift.py`

### Changed
- `amelia/tools/__init__.py`: calls discover_builtin_tools() on import
- `amelia/tools/shell_executor.py`, `file_bundler.py`, `knowledge.py`, `write_plan.py`: append module-level register(ToolSpec(...))
- `amelia/core/constants.py`: add ToolName entries for new tools
- `tests/unit/core/test_constants.py`: updated for new constants

## Test Plan

- [x] `uv run ruff check amelia tests` — all checks passed
- [x] `uv run mypy amelia` — success, 190 source files, no issues
- [x] `uv run pytest tests/unit/` — 2580 passed, 0 failed (391 integration deselected)
- [x] Pre-push gate (ruff + mypy + full pytest + dashboard build) — all passed
- [x] `test_policy_vetoes_write_file_and_prevents_disk_write` — asserts the target file does NOT exist on disk after a denied call (observable consequence, mirrors the spike)

## Additional Context

This is the Workstream B spine. #621, #357, and #228 stack on this branch. Design: `docs/plans/2026-06-20-workstream-b-tool-registry-design.md`. Veto proof: `docs/plans/2026-06-20-workstream-b-middleware-veto-spike.md`.