### PR TITLE
feat(tools): add security guardrail policies (#228)

### DIFF
--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -573,6 +573,7 @@ class ApiDriver(DriverInterface):
                     allow_unregistered=submit_tool_names,
                 ),
                 event_bus=getattr(ctx, "event_bus", None),
+                workflow_id=getattr(ctx, "workflow_id", None),
             )
             middleware = [policy_mw, *(middleware or [])]
 

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -571,7 +571,8 @@ class ApiDriver(DriverInterface):
                     allowed=frozenset(allow_set),
                     max_risk=max_risk,
                     allow_unregistered=submit_tool_names,
-                )
+                ),
+                event_bus=getattr(ctx, "event_bus", None),
             )
             middleware = [policy_mw, *(middleware or [])]
 

--- a/amelia/server/models/events.py
+++ b/amelia/server/models/events.py
@@ -155,7 +155,6 @@ TRACE_TYPES: frozenset[AnyEventType] = frozenset({
     EventType.CLAUDE_THINKING,
     EventType.CLAUDE_TOOL_CALL,
     EventType.CLAUDE_TOOL_RESULT,
-    EventType.TOOL_POLICY_DECISION,
     EventType.AGENT_OUTPUT,
     # Oracle streaming
     EventType.ORACLE_CONSULTATION_THINKING,

--- a/amelia/server/models/events.py
+++ b/amelia/server/models/events.py
@@ -72,6 +72,7 @@ class EventType(StrEnum):
     # System
     SYSTEM_ERROR = "system_error"
     SYSTEM_WARNING = "system_warning"
+    TOOL_POLICY_DECISION = "tool_policy_decision"
 
     # Streaming (ephemeral, not persisted)
     STREAM = "stream"
@@ -154,6 +155,7 @@ TRACE_TYPES: frozenset[AnyEventType] = frozenset({
     EventType.CLAUDE_THINKING,
     EventType.CLAUDE_TOOL_CALL,
     EventType.CLAUDE_TOOL_RESULT,
+    EventType.TOOL_POLICY_DECISION,
     EventType.AGENT_OUTPUT,
     # Oracle streaming
     EventType.ORACLE_CONSULTATION_THINKING,

--- a/amelia/tools/registry/__init__.py
+++ b/amelia/tools/registry/__init__.py
@@ -8,7 +8,14 @@ Re-exports the public surface so callers can write::
 from __future__ import annotations
 
 from amelia.tools.registry.context import ToolContext
-from amelia.tools.registry.policy import ToolPolicy, ToolPolicyMiddleware
+from amelia.tools.registry.policy import (
+    HighRiskDecision,
+    ToolPolicy,
+    ToolPolicyAuditDecision,
+    ToolPolicyMiddleware,
+    ToolValidationContext,
+    ToolValidationResult,
+)
 from amelia.tools.registry.registry import (
     ToolRegistry,
     discover_builtin_tools,
@@ -26,11 +33,15 @@ from amelia.tools.registry.spec import (
 __all__ = [
     "Permission",
     "RiskLevel",
+    "HighRiskDecision",
     "ToolContext",
     "ToolPolicy",
+    "ToolPolicyAuditDecision",
     "ToolPolicyMiddleware",
     "ToolRegistry",
     "ToolSpec",
+    "ToolValidationContext",
+    "ToolValidationResult",
     "discover_builtin_tools",
     "get",
     "register",

--- a/amelia/tools/registry/context.py
+++ b/amelia/tools/registry/context.py
@@ -8,6 +8,7 @@ agent construction. ``ToolContext`` is the single carrier for those deps so
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -30,9 +31,11 @@ class ToolContext:
         embedding_client: Embedding client for semantic-search tools.
         knowledge_repo: Knowledge repository for documentation tools.
         event_bus: Optional event bus for tool-emitted events.
+        workflow_id: Optional workflow UUID for correlating audit events.
     """
 
     cwd: str | None = None
     embedding_client: EmbeddingClient | None = None
     knowledge_repo: KnowledgeRepository | None = None
     event_bus: EventBus | None = None
+    workflow_id: uuid.UUID | None = None

--- a/amelia/tools/registry/policy.py
+++ b/amelia/tools/registry/policy.py
@@ -1,6 +1,6 @@
 """Tool policy + middleware that vetoes tool calls at runtime.
 
-``ToolPolicy`` is the declarative allow-list and risk ceiling.
+``ToolPolicy`` is the declarative allow-list and guardrail surface.
 ``ToolPolicyMiddleware`` enforces it by intercepting tool execution via
 ``wrap_tool_call`` / ``awrap_tool_call``: a denied call never reaches the handler, so its side
 effects never happen. This is the enforcement spine for #357 (read-only
@@ -14,23 +14,86 @@ that use ``invoke()`` or ``ainvoke()`` get identical veto behavior.
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Awaitable, Callable
-from typing import Any
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
 
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 from amelia.core.constants import normalize_tool_name
+from amelia.server.events.bus import EventBus
+from amelia.server.models.events import EPHEMERAL_SEQUENCE, EventLevel, EventType, WorkflowEvent
 from amelia.tools.registry.registry import registry
-from amelia.tools.registry.spec import RiskLevel
+from amelia.tools.registry.spec import Permission, RiskLevel, ToolSpec
 
 
 # The handler types wrapping hooks receive.
-type _AsyncToolHandler = Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
-type _SyncToolHandler = Callable[[ToolCallRequest], ToolMessage | Command[Any]]
+_AsyncToolHandler = Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
+_SyncToolHandler = Callable[[ToolCallRequest], ToolMessage | Command[Any]]
+ToolValidator = Callable[["ToolValidationContext"], "ToolValidationResult"]
+
+
+class HighRiskDecision(StrEnum):
+    """Policy behavior for high-risk calls at or above EXECUTE risk."""
+
+    AUTO = "auto"
+    DENY = "deny"
+    CONFIRM = "confirm"
+
+
+class ToolPolicyAuditDecision(StrEnum):
+    """Structured decision labels emitted to audit sinks."""
+
+    ALLOWED = "allowed"
+    DENIED = "denied"
+    RESULT = "result"
+
+
+@dataclass(frozen=True)
+class ToolValidationContext:
+    """Context passed to pre/post validators.
+
+    ``result`` is ``None`` for pre-execution validators and populated for
+    post-execution validators. Validators are intentionally small synchronous
+    extension points; async wrappers still enforce them before/after awaiting
+    the underlying handler.
+    """
+
+    tool_name: str
+    raw_name: str
+    args: dict[str, Any]
+    spec: ToolSpec | None
+    request: ToolCallRequest
+    result: ToolMessage | Command[Any] | None = None
+
+
+@dataclass(frozen=True)
+class ToolValidationResult:
+    """Result returned by a pre/post execution validator."""
+
+    action: Literal["allow", "deny", "replace"]
+    message: str | None = None
+    replacement: ToolMessage | Command[Any] | None = None
+
+    @classmethod
+    def allow(cls) -> ToolValidationResult:
+        return cls(action="allow")
+
+    @classmethod
+    def deny(cls, message: str) -> ToolValidationResult:
+        return cls(action="deny", message=message)
+
+    @classmethod
+    def replace(cls, replacement: ToolMessage | Command[Any]) -> ToolValidationResult:
+        return cls(action="replace", replacement=replacement)
 
 
 class ToolPolicy(BaseModel):
@@ -41,15 +104,36 @@ class ToolPolicy(BaseModel):
             normalized name is not in this set is denied.
         max_risk: Risk ceiling. A permitted tool whose ``risk_level`` exceeds
             this is still denied. Defaults to ``EXECUTE`` (permissive).
+        permissions: Capabilities granted to this policy. Registered tools whose
+            ``required_permissions`` are not a subset are denied.
+        pre_exec_validators: Synchronous validators that can deny a call based
+            on normalized tool metadata and raw parameters before execution.
+        post_exec_validators: Synchronous validators that can deny or replace a
+            handler result after execution.
+        high_risk_decision: Behavior for tools with risk >= ``EXECUTE``. In
+            headless mode, ``confirm`` is deterministic deny until an approval
+            UI is wired in.
         allow_unregistered: Dynamic tool names that are allowed even though
             they are not in the registry, such as per-run submit tools.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     allowed: frozenset[str]
     max_risk: RiskLevel = RiskLevel.EXECUTE
+    permissions: frozenset[Permission] = frozenset(Permission)
+    pre_exec_validators: tuple[ToolValidator, ...] = ()
+    post_exec_validators: tuple[ToolValidator, ...] = ()
+    high_risk_decision: HighRiskDecision = HighRiskDecision.AUTO
     allow_unregistered: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class _PolicyDecision:
+    decision: ToolPolicyAuditDecision
+    reason: str
+    message: str | None = None
+    spec: ToolSpec | None = None
 
 
 class ToolPolicyMiddleware(AgentMiddleware):
@@ -57,45 +141,214 @@ class ToolPolicyMiddleware(AgentMiddleware):
 
     Denials return a substitute ``ToolMessage(status="error")`` describing the
     reason; the underlying tool handler is never invoked, so side effects are
-    guaranteed not to occur.
+    guaranteed not to occur. Allowed/denied/result decisions are emitted to the
+    provided ``EventBus`` and loguru structured logs for auditability.
     """
 
-    def __init__(self, policy: ToolPolicy) -> None:
+    def __init__(
+        self,
+        policy: ToolPolicy,
+        *,
+        event_bus: EventBus | None = None,
+        workflow_id: uuid.UUID | None = None,
+        agent: str = "tool_policy",
+    ) -> None:
         self.policy = policy
+        self._event_bus = event_bus
+        self._workflow_id = workflow_id or uuid.uuid4()
+        self._agent = agent
 
-    def _veto_message(self, request: ToolCallRequest) -> ToolMessage | None:
-        """Return a denial message when ``request`` violates policy, else ``None``."""
+    def _veto_tool_message(self, request: ToolCallRequest, message: str) -> ToolMessage:
+        return ToolMessage(
+            content=message,
+            tool_call_id=request.tool_call["id"],
+            status="error",
+        )
+
+    def _audit(
+        self,
+        *,
+        request: ToolCallRequest,
+        name: str,
+        decision: ToolPolicyAuditDecision,
+        reason: str,
+        spec: ToolSpec | None,
+        result: ToolMessage | Command[Any] | None = None,
+        message: str | None = None,
+    ) -> None:
+        args = dict(request.tool_call.get("args") or {})
+        risk_level = spec.risk_level.name if spec else None
+        required_permissions = sorted(str(permission) for permission in (spec.required_permissions if spec else ()))
+        data: dict[str, Any] = {
+            "decision": decision.value,
+            "reason": reason,
+            "tool_name": name,
+            "raw_tool_name": request.tool_call["name"],
+            "tool_call_id": request.tool_call["id"],
+            "args": args,
+            "risk_level": risk_level,
+            "required_permissions": required_permissions,
+        }
+        if message is not None:
+            data["message"] = message
+        if result is not None:
+            data["result_type"] = type(result).__name__
+            if isinstance(result, ToolMessage):
+                data["tool_status"] = result.status
+
+        logger.bind(**data).info("tool_policy_decision")
+
+        if self._event_bus is None:
+            return
+        level = EventLevel.WARNING if decision == ToolPolicyAuditDecision.DENIED else EventLevel.DEBUG
+        self._event_bus.emit(
+            WorkflowEvent(
+                id=uuid.uuid4(),
+                workflow_id=self._workflow_id,
+                sequence=EPHEMERAL_SEQUENCE,
+                timestamp=datetime.now(UTC),
+                agent=self._agent,
+                event_type=EventType.TOOL_POLICY_DECISION,
+                level=level,
+                message=message or f"Tool policy {decision.value}: {name}",
+                data=data,
+                tool_name=name,
+                tool_input=args,
+                is_error=decision == ToolPolicyAuditDecision.DENIED,
+            )
+        )
+
+    def _evaluate_request(self, request: ToolCallRequest) -> tuple[str, _PolicyDecision]:
         raw_name = request.tool_call["name"]
         name = normalize_tool_name(raw_name)
-        tool_call_id = request.tool_call["id"]
 
         if name not in self.policy.allowed:
-            return ToolMessage(
-                content=f"Denied: tool '{raw_name}' is not permitted by the active policy.",
-                tool_call_id=tool_call_id,
-                status="error",
+            return name, _PolicyDecision(
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason="not_allowed",
+                message=f"Denied: tool '{raw_name}' is not permitted by the active policy.",
             )
 
         spec = registry.get(name)
         if spec is None:
             if name in self.policy.allow_unregistered:
-                return None
-            return ToolMessage(
-                content=f"Denied: tool '{name}' is not registered.",
-                tool_call_id=tool_call_id,
-                status="error",
+                return name, _PolicyDecision(
+                    decision=ToolPolicyAuditDecision.ALLOWED,
+                    reason="allowed_unregistered",
+                )
+            return name, _PolicyDecision(
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason="unregistered",
+                message=f"Denied: tool '{name}' is not registered.",
             )
+
         if spec.risk_level > self.policy.max_risk:
-            return ToolMessage(
-                content=(
+            return name, _PolicyDecision(
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason="risk_ceiling",
+                spec=spec,
+                message=(
                     f"Denied: tool '{name}' risk level ({spec.risk_level.name}) "
                     f"exceeds the policy ceiling ({self.policy.max_risk.name})."
                 ),
-                tool_call_id=tool_call_id,
-                status="error",
             )
 
-        return None
+        missing_permissions = spec.required_permissions - self.policy.permissions
+        if missing_permissions:
+            missing = ", ".join(sorted(str(permission) for permission in missing_permissions))
+            return name, _PolicyDecision(
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason="missing_permissions",
+                spec=spec,
+                message=f"Denied: tool '{name}' missing required permission(s): {missing}.",
+            )
+
+        if spec.risk_level >= RiskLevel.EXECUTE:
+            if self.policy.high_risk_decision == HighRiskDecision.DENY:
+                return name, _PolicyDecision(
+                    decision=ToolPolicyAuditDecision.DENIED,
+                    reason="high_risk_denied",
+                    spec=spec,
+                    message=f"Denied: tool '{name}' requires high-risk execution permission.",
+                )
+            if self.policy.high_risk_decision == HighRiskDecision.CONFIRM:
+                return name, _PolicyDecision(
+                    decision=ToolPolicyAuditDecision.DENIED,
+                    reason="confirmation_required",
+                    spec=spec,
+                    message=(
+                        f"Denied: tool '{name}' requires confirmation, which is unavailable "
+                        "in headless mode."
+                    ),
+                )
+
+        args = dict(request.tool_call.get("args") or {})
+        ctx = ToolValidationContext(
+            tool_name=name,
+            raw_name=raw_name,
+            args=args,
+            spec=spec,
+            request=request,
+        )
+        for validator in self.policy.pre_exec_validators:
+            validation = validator(ctx)
+            if validation.action == "deny":
+                return name, _PolicyDecision(
+                    decision=ToolPolicyAuditDecision.DENIED,
+                    reason="pre_validator",
+                    spec=spec,
+                    message=validation.message or f"Denied: tool '{name}' failed pre-exec validation.",
+                )
+
+        return name, _PolicyDecision(
+            decision=ToolPolicyAuditDecision.ALLOWED,
+            reason="allowed",
+            spec=spec,
+        )
+
+    def _apply_post_validators(
+        self,
+        *,
+        name: str,
+        request: ToolCallRequest,
+        spec: ToolSpec | None,
+        result: ToolMessage | Command[Any],
+    ) -> tuple[ToolMessage | Command[Any], _PolicyDecision | None]:
+        args = dict(request.tool_call.get("args") or {})
+        current = result
+        for validator in self.policy.post_exec_validators:
+            ctx = ToolValidationContext(
+                tool_name=name,
+                raw_name=request.tool_call["name"],
+                args=args,
+                spec=spec,
+                request=request,
+                result=current,
+            )
+            validation = validator(ctx)
+            if validation.action == "deny":
+                message = validation.message or f"Denied: tool '{name}' failed post-exec validation."
+                return self._veto_tool_message(request, message), _PolicyDecision(
+                    decision=ToolPolicyAuditDecision.DENIED,
+                    reason="post_validator",
+                    spec=spec,
+                    message=message,
+                )
+            if validation.action == "replace" and validation.replacement is not None:
+                current = validation.replacement
+        return current, None
+
+    def _deny(self, request: ToolCallRequest, name: str, decision: _PolicyDecision) -> ToolMessage:
+        message = decision.message or f"Denied: tool '{name}' by active policy."
+        self._audit(
+            request=request,
+            name=name,
+            decision=ToolPolicyAuditDecision.DENIED,
+            reason=decision.reason,
+            spec=decision.spec,
+            message=message,
+        )
+        return self._veto_tool_message(request, message)
 
     def wrap_tool_call(
         self,
@@ -103,9 +356,40 @@ class ToolPolicyMiddleware(AgentMiddleware):
         handler: _SyncToolHandler,
     ) -> ToolMessage | Command[Any]:
         """Sync interception hook matching ``awrap_tool_call`` semantics."""
-        if veto := self._veto_message(request):
-            return veto
-        return handler(request)
+        name, decision = self._evaluate_request(request)
+        if decision.decision == ToolPolicyAuditDecision.DENIED:
+            return self._deny(request, name, decision)
+        self._audit(
+            request=request,
+            name=name,
+            decision=ToolPolicyAuditDecision.ALLOWED,
+            reason=decision.reason,
+            spec=decision.spec,
+        )
+        result = handler(request)
+        result, post_decision = self._apply_post_validators(
+            name=name, request=request, spec=decision.spec, result=result
+        )
+        if post_decision is not None:
+            self._audit(
+                request=request,
+                name=name,
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason=post_decision.reason,
+                spec=post_decision.spec,
+                result=result,
+                message=post_decision.message,
+            )
+            return result
+        self._audit(
+            request=request,
+            name=name,
+            decision=ToolPolicyAuditDecision.RESULT,
+            reason="result",
+            spec=decision.spec,
+            result=result,
+        )
+        return result
 
     async def awrap_tool_call(
         self,
@@ -125,6 +409,37 @@ class ToolPolicyMiddleware(AgentMiddleware):
             The handler's ``ToolMessage``/``Command`` on success, or an
             error ``ToolMessage`` describing the denial otherwise.
         """
-        if veto := self._veto_message(request):
-            return veto
-        return await handler(request)
+        name, decision = self._evaluate_request(request)
+        if decision.decision == ToolPolicyAuditDecision.DENIED:
+            return self._deny(request, name, decision)
+        self._audit(
+            request=request,
+            name=name,
+            decision=ToolPolicyAuditDecision.ALLOWED,
+            reason=decision.reason,
+            spec=decision.spec,
+        )
+        result = await handler(request)
+        result, post_decision = self._apply_post_validators(
+            name=name, request=request, spec=decision.spec, result=result
+        )
+        if post_decision is not None:
+            self._audit(
+                request=request,
+                name=name,
+                decision=ToolPolicyAuditDecision.DENIED,
+                reason=post_decision.reason,
+                spec=post_decision.spec,
+                result=result,
+                message=post_decision.message,
+            )
+            return result
+        self._audit(
+            request=request,
+            name=name,
+            decision=ToolPolicyAuditDecision.RESULT,
+            reason="result",
+            spec=decision.spec,
+            result=result,
+        )
+        return result

--- a/amelia/tools/registry/policy.py
+++ b/amelia/tools/registry/policy.py
@@ -165,6 +165,29 @@ class ToolPolicyMiddleware(AgentMiddleware):
             status="error",
         )
 
+    # Argument keys whose values are redacted in audit payloads to prevent
+    # leaking secrets or user content to logs and event subscribers.
+    _REDACTED_ARG_KEYS: frozenset[str] = frozenset({
+        "content", "cmd", "command", "password", "token", "api_key",
+        "secret", "body", "data", "text", "input", "query", "url",
+    })
+
+    @classmethod
+    def _redact_args(cls, args: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of *args* with sensitive values replaced by '***'.
+
+        Only top-level string keys in ``_REDACTED_ARG_KEYS`` are redacted;
+        nested structures are left intact so the audit record stays readable
+        without deep traversal.
+        """
+        redacted: dict[str, Any] = {}
+        for key, value in args.items():
+            if key.lower() in cls._REDACTED_ARG_KEYS:
+                redacted[key] = "***"
+            else:
+                redacted[key] = value
+        return redacted
+
     def _audit(
         self,
         *,
@@ -176,7 +199,8 @@ class ToolPolicyMiddleware(AgentMiddleware):
         result: ToolMessage | Command[Any] | None = None,
         message: str | None = None,
     ) -> None:
-        args = dict(request.tool_call.get("args") or {})
+        raw_args = dict(request.tool_call.get("args") or {})
+        args = self._redact_args(raw_args)
         risk_level = spec.risk_level.name if spec else None
         required_permissions = sorted(str(permission) for permission in (spec.required_permissions if spec else ()))
         data: dict[str, Any] = {

--- a/dashboard/src/types/events.ts
+++ b/dashboard/src/types/events.ts
@@ -61,6 +61,7 @@ export type EventType =
   // System
   | 'system_error'
   | 'system_warning'
+  | 'tool_policy_decision'
   // Streaming (ephemeral, not persisted)
   | 'stream'
   // Trace (stream events)

--- a/tests/unit/tools/test_policy.py
+++ b/tests/unit/tools/test_policy.py
@@ -317,6 +317,31 @@ async def test_policy_required_permission_mismatch_denies_with_useful_message():
     assert "fs.write" in result.content
 
 
+async def test_policy_audit_redacts_sensitive_args():
+    """Audit events must not expose raw values of sensitive argument keys."""
+    bus, events = _collecting_bus()
+    policy = ToolPolicy(
+        allowed=frozenset({"write_file"}),
+        max_risk=RiskLevel.WRITE,
+        permissions=frozenset({Permission.FS_WRITE}),
+    )
+    mw = ToolPolicyMiddleware(policy=policy, event_bus=bus)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="redact")
+
+    await mw.awrap_tool_call(
+        _direct_request("write_file", {"file_path": "x.txt", "content": "SECRET"}, "redact"),
+        handler,
+    )
+
+    assert len(events) >= 1
+    for event in events:
+        assert event.data["args"]["content"] == "***"
+        assert event.data["args"]["file_path"] == "x.txt"
+        assert event.tool_input["content"] == "***"
+
+
 async def test_policy_normalizes_cli_tool_name_aliases(tmp_path):
     """A tool call using a CLI alias (e.g. 'Write') is normalized before the check.
 

--- a/tests/unit/tools/test_policy.py
+++ b/tests/unit/tools/test_policy.py
@@ -21,8 +21,16 @@ from langgraph.prebuilt.tool_node import ToolNode
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from amelia.tools.registry.policy import ToolPolicy, ToolPolicyMiddleware
-from amelia.tools.registry.spec import RiskLevel
+from amelia.server.events.bus import EventBus
+from amelia.server.models.events import EventType
+from amelia.tools.registry.policy import (
+    HighRiskDecision,
+    ToolPolicy,
+    ToolPolicyAuditDecision,
+    ToolPolicyMiddleware,
+    ToolValidationResult,
+)
+from amelia.tools.registry.spec import Permission, RiskLevel
 
 
 class _WriteFileInput(BaseModel):
@@ -109,6 +117,24 @@ class TestToolPolicy:
             policy.allowed = frozenset({"write_file"})  # type: ignore[misc]
 
 
+def _direct_request(name: str, args: dict[str, object] | None = None, call_id: str = "c"):
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+
+    return ToolCallRequest(
+        tool_call={"name": name, "args": args or {}, "id": call_id, "type": "tool_call"},
+        tool=None,
+        state={},
+        runtime=None,  # type: ignore[arg-type]
+    )
+
+
+def _collecting_bus() -> tuple[EventBus, list[Any]]:
+    bus = EventBus()
+    events: list[Any] = []
+    bus.subscribe(events.append)
+    return bus, events
+
+
 async def test_policy_vetoes_write_file_and_prevents_disk_write(tmp_path):
     """A denied write_file call must return an error ToolMessage AND write nothing.
 
@@ -146,6 +172,37 @@ async def test_policy_risk_ceiling_vetoes_high_risk(tmp_path):
     assert not target.exists()
 
 
+async def test_policy_denies_destructive_tool_and_emits_audit_event():
+    """High-risk decisions are deterministic and auditable."""
+    bus, events = _collecting_bus()
+    policy = ToolPolicy(
+        allowed=frozenset({"execute"}),
+        max_risk=RiskLevel.DESTRUCTIVE,
+        high_risk_decision=HighRiskDecision.CONFIRM,
+        permissions=frozenset({Permission.SHELL_EXEC}),
+    )
+    mw = ToolPolicyMiddleware(policy=policy, event_bus=bus)
+    invoked: list[str] = []
+
+    async def handler(_req: Any) -> ToolMessage:
+        invoked.append("yes")
+        return ToolMessage(content="should-not-run", tool_call_id="destructive")
+
+    result = await mw.awrap_tool_call(
+        _direct_request("execute", {"cmd": "rm -rf ."}, "destructive"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "confirmation" in result.content.lower()
+    assert invoked == []
+    assert events
+    event = events[-1]
+    assert event.event_type == EventType.TOOL_POLICY_DECISION
+    assert event.data["decision"] == ToolPolicyAuditDecision.DENIED
+    assert event.data["reason"] == "confirmation_required"
+
+
 async def test_policy_allows_permitted_tool_runs_handler(tmp_path):
     """A permitted, in-budget tool call must run and produce its real effect."""
     target = tmp_path / "ok.txt"
@@ -156,6 +213,108 @@ async def test_policy_allows_permitted_tool_runs_handler(tmp_path):
     # THE OBSERVABLE CONSEQUENCE: the file WAS written (handler executed).
     assert target.exists()
     assert target.read_text() == "secret"
+
+
+async def test_policy_allows_low_risk_tool_and_emits_allow_and_result_audit_events():
+    bus, events = _collecting_bus()
+    policy = ToolPolicy(
+        allowed=frozenset({"read_file"}),
+        max_risk=RiskLevel.READ_ONLY,
+        permissions=frozenset({Permission.FS_READ}),
+    )
+    mw = ToolPolicyMiddleware(policy=policy, event_bus=bus)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="read")
+
+    result = await mw.awrap_tool_call(
+        _direct_request("read_file", {"file_path": "README.md"}, "read"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+    assert [event.data["decision"] for event in events] == [
+        ToolPolicyAuditDecision.ALLOWED,
+        ToolPolicyAuditDecision.RESULT,
+    ]
+    assert all(event.event_type == EventType.TOOL_POLICY_DECISION for event in events)
+
+
+async def test_policy_pre_validator_blocks_parameters_without_handler_execution():
+    bus, events = _collecting_bus()
+    invoked: list[str] = []
+
+    def block_absolute_path(ctx: Any) -> ToolValidationResult:
+        if str(ctx.args.get("file_path", "")).startswith("/"):
+            return ToolValidationResult.deny("absolute paths are not allowed")
+        return ToolValidationResult.allow()
+
+    policy = ToolPolicy(
+        allowed=frozenset({"write_file"}),
+        max_risk=RiskLevel.WRITE,
+        permissions=frozenset({Permission.FS_WRITE}),
+        pre_exec_validators=(block_absolute_path,),
+    )
+    mw = ToolPolicyMiddleware(policy=policy, event_bus=bus)
+
+    async def handler(_req: Any) -> ToolMessage:
+        invoked.append("yes")
+        return ToolMessage(content="should-not-run", tool_call_id="pre")
+
+    result = await mw.awrap_tool_call(
+        _direct_request("write_file", {"file_path": "/tmp/x"}, "pre"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "absolute paths" in result.content
+    assert invoked == []
+    assert events[-1].data["reason"] == "pre_validator"
+
+
+async def test_policy_post_validator_can_transform_tool_message_result():
+    def redact_result(ctx: Any) -> ToolValidationResult:
+        assert isinstance(ctx.result, ToolMessage)
+        return ToolValidationResult.replace(
+            ToolMessage(content="redacted", tool_call_id=ctx.result.tool_call_id)
+        )
+
+    policy = ToolPolicy(
+        allowed=frozenset({"read_file"}),
+        max_risk=RiskLevel.READ_ONLY,
+        permissions=frozenset({Permission.FS_READ}),
+        post_exec_validators=(redact_result,),
+    )
+    mw = ToolPolicyMiddleware(policy=policy)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return ToolMessage(content="secret", tool_call_id="post")
+
+    result = await mw.awrap_tool_call(
+        _direct_request("read_file", {"file_path": "x"}, "post"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == "redacted"
+
+
+async def test_policy_required_permission_mismatch_denies_with_useful_message():
+    policy = ToolPolicy(
+        allowed=frozenset({"write_file"}),
+        max_risk=RiskLevel.WRITE,
+        permissions=frozenset({Permission.FS_READ}),
+    )
+    mw = ToolPolicyMiddleware(policy=policy)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return ToolMessage(content="should-not-run", tool_call_id="perm")
+
+    result = await mw.awrap_tool_call(_direct_request("write_file", {}, "perm"), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "missing required permission" in result.content.lower()
+    assert "fs.write" in result.content
 
 
 async def test_policy_normalizes_cli_tool_name_aliases(tmp_path):


### PR DESCRIPTION
Problem:
Amelia lacked defense-in-depth guardrails for high-risk tool calls, parameter/result validation, auditability, and unknown-tool collision protection.

Change:
- Extends ToolPolicy with permissions, validators, high-risk behavior, and explicit unregistered-tool compatibility handling.
- Enforces risk ceilings and required permissions in sync and async ToolPolicyMiddleware wrappers.
- Emits structured tool policy audit decisions through WorkflowEvent/EventBus and loguru.
- Adds tests for denial audit events, pre/post validators, permission mismatch, allowed low-risk audit events, and handler non-execution on deny.

Verification:
- uv run ruff check --fix amelia tests
- uv run mypy amelia
- unset SSL_CERT_FILE; GIT_CONFIG_GLOBAL=/dev/null uv run pytest tests/unit/
- push pre-push hook: ruff, mypy, 2618 passed, dashboard build passed

Depends on #660
Closes #228