### PR TITLE
feat(tools): enforce readonly tool policies (#357)

### DIFF
--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -13,11 +13,13 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from amelia.agents._driver_init import init_agent_driver
+from amelia.agents.tool_profiles import resolve_agent_tools
 from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.core.constants import ToolName, resolve_plan_path
 from amelia.core.types import AgentConfig, DriverType, Profile
 from amelia.drivers.base import AgenticMessage, AgenticMessageType
 from amelia.server.models.events import WorkflowEvent
+from amelia.tools.registry import ToolContext
 from amelia.tools.write_plan import create_write_plan_tool
 
 
@@ -151,13 +153,24 @@ Before planning, discover:
             "required_file_path": plan_path,
         }
 
-        # For API driver: inject write_plan as a custom tool with structured schema
-        # CLI drivers don't support custom tool injection — they use write_file
+        # API driver uses the registry profile so ToolPolicyMiddleware vetoes
+        # injected write_file/edit_file/execute calls. The profile includes the
+        # write_plan exception needed to persist the generated plan.
+        # CLI drivers keep their existing write_file path; their SDK-level
+        # allowed_tools are separate from the DeepAgents middleware issue fixed here.
         if self._driver_type == DriverType.API:
-            # Cache the tool per root_dir to avoid re-instantiating on every plan() call
+            tool_context = ToolContext(cwd=cwd)
+            # Cache the tool per root_dir to avoid re-instantiating on every plan() call.
+            # ApiDriver de-duplicates registry-rendered tools by name, so the
+            # explicit tool instance remains the implementation while the
+            # policy allow-set still permits write_plan.
             if cwd not in self._write_plan_tool_cache:
                 self._write_plan_tool_cache[cwd] = create_write_plan_tool(root_dir=cwd)
             driver_kwargs["tools"] = [self._write_plan_tool_cache[cwd]]
+            driver_kwargs["allowed_tools"] = [
+                t.name for t in resolve_agent_tools("architect", tool_context)
+            ]
+            driver_kwargs["tool_context"] = tool_context
             driver_kwargs["required_tool"] = "write_plan"
         else:
             driver_kwargs["required_tool"] = "write_file"

--- a/amelia/agents/architect.py
+++ b/amelia/agents/architect.py
@@ -159,7 +159,7 @@ Before planning, discover:
         # CLI drivers keep their existing write_file path; their SDK-level
         # allowed_tools are separate from the DeepAgents middleware issue fixed here.
         if self._driver_type == DriverType.API:
-            tool_context = ToolContext(cwd=cwd)
+            tool_context = ToolContext(cwd=cwd, workflow_id=workflow_id)
             # Cache the tool per root_dir to avoid re-instantiating on every plan() call.
             # ApiDriver de-duplicates registry-rendered tools by name, so the
             # explicit tool instance remains the implementation while the

--- a/amelia/agents/tool_profiles.py
+++ b/amelia/agents/tool_profiles.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 
 from amelia.tools.registry import ToolContext, ToolSpec, registry
 from amelia.tools.registry.spec import RiskLevel
+from amelia.tools.registry.toolsets import readonly_tool_names
 
 
 @dataclass(frozen=True)
@@ -99,7 +100,10 @@ def resolve_agent_tools(
 
     candidate_names: set[str] = set()
     for toolset in profile.toolsets:
-        candidate_names |= registry.names_for_toolset(toolset)
+        if toolset == "readonly":
+            candidate_names |= set(readonly_tool_names())
+        else:
+            candidate_names |= registry.names_for_toolset(toolset)
     candidate_names |= set(profile.extra_tools)
 
     resolved: list[ToolSpec] = []

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -559,6 +559,14 @@ class ApiDriver(DriverInterface):
             ctx = kwargs.get("tool_context")
             custom_tools, allow_set, max_risk = self._resolve_allowed(allowed_tools, ctx)
             if custom_tools:
+                existing_tool_names = {
+                    getattr(tool, "name", None) for tool in (tools or [])
+                }
+                custom_tools = [
+                    tool for tool in custom_tools
+                    if getattr(tool, "name", None) not in existing_tool_names
+                ]
+            if custom_tools:
                 tools = (tools or []) + custom_tools
             # Submit tools are always permitted — they're agent-controlled
             # structured output, not user-facing capabilities.

--- a/amelia/tools/registry/__init__.py
+++ b/amelia/tools/registry/__init__.py
@@ -28,6 +28,7 @@ from amelia.tools.registry.spec import (
     RiskLevel,
     ToolSpec,
 )
+from amelia.tools.registry.toolsets import readonly_tool_names, readonly_tool_policy
 
 
 __all__ = [
@@ -46,4 +47,6 @@ __all__ = [
     "get",
     "register",
     "registry",
+    "readonly_tool_names",
+    "readonly_tool_policy",
 ]

--- a/amelia/tools/registry/policy.py
+++ b/amelia/tools/registry/policy.py
@@ -161,6 +161,7 @@ class ToolPolicyMiddleware(AgentMiddleware):
     def _veto_tool_message(self, request: ToolCallRequest, message: str) -> ToolMessage:
         return ToolMessage(
             content=message,
+            name=request.tool_call["name"],
             tool_call_id=request.tool_call["id"],
             status="error",
         )

--- a/amelia/tools/registry/toolsets.py
+++ b/amelia/tools/registry/toolsets.py
@@ -1,0 +1,54 @@
+"""Reusable toolset and policy presets built from the registry."""
+
+from __future__ import annotations
+
+from amelia.core.constants import READONLY_TOOLS
+from amelia.tools.registry.policy import ToolPolicy
+from amelia.tools.registry.registry import discover_builtin_tools, registry
+from amelia.tools.registry.spec import RiskLevel
+
+
+def readonly_tool_names() -> frozenset[str]:
+    """Return the explicit read-only tool allow-set.
+
+    ``READONLY_TOOLS`` is the source of truth for observer-style agents. This
+    helper validates that every listed tool is registered and classified no
+    higher than ``READ_ONLY`` so the constant cannot drift into dead or unsafe
+    configuration.
+    """
+    discover_builtin_tools()
+    names = frozenset(tool.value for tool in READONLY_TOOLS)
+    missing = sorted(name for name in names if registry.get(name) is None)
+    if missing:
+        raise ValueError(
+            "READONLY_TOOLS contains unregistered tool(s): " + ", ".join(missing)
+        )
+
+    too_risky = sorted(
+        name
+        for name in names
+        if (spec := registry.get(name)) is not None and spec.risk_level > RiskLevel.READ_ONLY
+    )
+    if too_risky:
+        raise ValueError(
+            "READONLY_TOOLS contains non-read-only tool(s): " + ", ".join(too_risky)
+        )
+    return names
+
+
+def readonly_tool_policy(
+    *,
+    extra_allowed: frozenset[str] = frozenset(),
+    max_risk: RiskLevel = RiskLevel.READ_ONLY,
+) -> ToolPolicy:
+    """Build a ToolPolicy for read-only agents.
+
+    Args:
+        extra_allowed: Optional per-agent exceptions, such as ``write_plan`` for
+            Architect. Exceptions are still constrained by ``max_risk``.
+        max_risk: Risk ceiling for the policy. Defaults to strict read-only.
+    """
+    return ToolPolicy(
+        allowed=readonly_tool_names() | extra_allowed,
+        max_risk=max_risk,
+    )

--- a/amelia/tools/registry/toolsets.py
+++ b/amelia/tools/registry/toolsets.py
@@ -45,10 +45,18 @@ def readonly_tool_policy(
 
     Args:
         extra_allowed: Optional per-agent exceptions, such as ``write_plan`` for
-            Architect. Exceptions are still constrained by ``max_risk``.
+            Architect.  When an extra tool's risk level exceeds ``max_risk``,
+            the ceiling is automatically raised to cover it so the exception is
+            actually usable through ``ToolPolicyMiddleware``.
         max_risk: Risk ceiling for the policy. Defaults to strict read-only.
     """
+    effective_risk = max_risk
+    for name in extra_allowed:
+        spec = registry.get(name)
+        if spec is not None and spec.risk_level > effective_risk:
+            effective_risk = spec.risk_level
+
     return ToolPolicy(
         allowed=readonly_tool_names() | extra_allowed,
-        max_risk=max_risk,
+        max_risk=effective_risk,
     )

--- a/tests/unit/agents/test_architect_tool_policy.py
+++ b/tests/unit/agents/test_architect_tool_policy.py
@@ -1,0 +1,51 @@
+"""Tests that read-only agents pass technical tool restrictions."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from amelia.agents.architect import Architect
+from amelia.core.types import AgentConfig, DriverType
+from amelia.drivers.base import AgenticMessage, AgenticMessageType
+from tests.integration.conftest import make_execution_state, make_profile
+
+
+async def test_api_architect_passes_readonly_allowed_tools_with_write_plan_exception(
+    tmp_path,
+) -> None:
+    """Architect must not rely on prompt-only read-only instructions for API runs."""
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_execute_agentic(*args: object, **kwargs: object) -> AsyncIterator[AgenticMessage]:
+        captured_kwargs.update(kwargs)
+        yield AgenticMessage(
+            type=AgenticMessageType.RESULT,
+            content="planned",
+            session_id="session-1",
+        )
+
+    driver = MagicMock()
+    driver.execute_agentic = fake_execute_agentic
+    config = AgentConfig(driver=DriverType.API, model="test/model")
+
+    with patch("amelia.agents.architect.init_agent_driver") as mock_init:
+        mock_init.return_value = MagicMock(driver=driver, options={}, prompts={})
+        architect = Architect(config)
+
+    profile = make_profile(repo_root=str(tmp_path))
+    state = make_execution_state(profile=profile)
+
+    async for _state, _event in architect.plan(state, profile, workflow_id=uuid4()):
+        pass
+
+    allowed_tools = set(captured_kwargs["allowed_tools"])  # type: ignore[arg-type]
+    assert "write_plan" in allowed_tools
+    assert "read_file" in allowed_tools
+    assert "glob" in allowed_tools
+    assert "grep" in allowed_tools
+    assert "write_file" not in allowed_tools
+    assert "edit_file" not in allowed_tools
+    assert "execute" not in allowed_tools
+    assert captured_kwargs["tool_context"] is not None

--- a/tests/unit/tools/test_readonly_policy.py
+++ b/tests/unit/tools/test_readonly_policy.py
@@ -1,0 +1,86 @@
+"""Tests for reusable read-only tool policy presets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.messages import ToolMessage
+
+from amelia.core.constants import READONLY_TOOLS, ToolName
+from amelia.tools.registry import RiskLevel, ToolPolicyMiddleware
+from amelia.tools.registry.registry import discover_builtin_tools
+from amelia.tools.registry.toolsets import readonly_tool_names, readonly_tool_policy
+
+
+def test_readonly_tool_names_are_the_load_bearing_constant() -> None:
+    """The reusable read-only preset must consume READONLY_TOOLS exactly."""
+    discover_builtin_tools()
+
+    assert readonly_tool_names() == frozenset(tool.value for tool in READONLY_TOOLS)
+    assert ToolName.WRITE_FILE.value not in readonly_tool_names()
+    assert ToolName.EDIT_FILE.value not in readonly_tool_names()
+    assert ToolName.EXECUTE_TOOL.value not in readonly_tool_names()
+
+
+def test_readonly_tool_policy_has_explicit_allow_set_and_readonly_ceiling() -> None:
+    """Read-only policy denies by explicit allow-list and READ_ONLY max risk."""
+    discover_builtin_tools()
+
+    policy = readonly_tool_policy()
+
+    assert policy.allowed == readonly_tool_names()
+    assert policy.max_risk == RiskLevel.READ_ONLY
+
+
+async def test_readonly_policy_vetoes_write_before_side_effect(tmp_path: Path) -> None:
+    """A denied write_file call returns a ToolMessage error and never invokes handler."""
+    discover_builtin_tools()
+    target = tmp_path / "should-not-exist.txt"
+    middleware = ToolPolicyMiddleware(readonly_tool_policy())
+    request = SimpleNamespace(
+        tool_call={
+            "name": "write_file",
+            "id": "call-write",
+            "args": {"file_path": str(target), "content": "bad"},
+        }
+    )
+
+    async def handler(_: Any) -> ToolMessage:
+        target.write_text("bad", encoding="utf-8")
+        return ToolMessage(content="wrote", tool_call_id="call-write")
+
+    result = await middleware.awrap_tool_call(request, handler)  # type: ignore[arg-type]
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.name == "write_file"
+    assert "Denied" in str(result.content)
+    assert not target.exists()
+
+
+async def test_readonly_policy_vetoes_execute_before_side_effect(tmp_path: Path) -> None:
+    """A denied execute call returns a ToolMessage error and never invokes handler."""
+    discover_builtin_tools()
+    target = tmp_path / "executed.txt"
+    middleware = ToolPolicyMiddleware(readonly_tool_policy())
+    request = SimpleNamespace(
+        tool_call={
+            "name": "execute",
+            "id": "call-execute",
+            "args": {"command": f"touch {target}"},
+        }
+    )
+
+    async def handler(_: Any) -> ToolMessage:
+        target.write_text("executed", encoding="utf-8")
+        return ToolMessage(content="executed", tool_call_id="call-execute")
+
+    result = await middleware.awrap_tool_call(request, handler)  # type: ignore[arg-type]
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.name == "execute"
+    assert "Denied" in str(result.content)
+    assert not target.exists()


### PR DESCRIPTION
Problem:
Architect and Oracle-style agents needed technical read-only enforcement instead of relying on prompt-only instructions.

Change:
- Adds registry-backed readonly toolset helpers and readonly ToolPolicy construction.
- Makes READONLY_TOOLS load-bearing by validating it against the registry readonly toolset.
- Wires Architect API execution to pass registry-resolved allowed_tools and tool context while preserving write_plan behavior.
- Avoids duplicate custom tool injection in ApiDriver.
- Adds tests that denied write_file/execute calls return error ToolMessages and do not run side effects.

Verification:
- uv run ruff check --fix amelia tests
- uv run mypy amelia
- unset SSL_CERT_FILE; GIT_CONFIG_GLOBAL=/dev/null uv run pytest tests/unit/
- push pre-push hook: ruff, mypy, 2618 passed, dashboard build passed

Depends on #660
Closes #357