### PR TITLE
feat(context): compact oversized workflow context (#229)

### DIFF
--- a/amelia/agents/developer.py
+++ b/amelia/agents/developer.py
@@ -5,6 +5,7 @@ autonomous tool-calling LLM execution rather than structured step-by-step plans.
 """
 from __future__ import annotations
 
+import os
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
@@ -17,6 +18,12 @@ from amelia.agents.tool_profiles import resolve_agent_tools
 from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.core.types import AgentConfig, Profile, collect_rejected_comments
 from amelia.drivers.base import AgenticMessageType
+from amelia.pipelines.implementation.context_compaction import (
+    DEFAULT_COMPACTION_THRESHOLD,
+    DEFAULT_KEEP_LAST_N_TURNS,
+    compact_implementation_context,
+    should_compact_context,
+)
 from amelia.server.models.events import WorkflowEvent
 from amelia.tools.registry import ToolContext
 
@@ -188,6 +195,48 @@ class Developer:
                     "error": message.content if message.is_error else None,
                 })
                 yield current_state, event
+
+                usage = self.driver.get_usage()
+                threshold = float(
+                    os.environ.get(
+                        "AMELIA_CONTEXT_COMPACTION_THRESHOLD",
+                        str(DEFAULT_COMPACTION_THRESHOLD),
+                    )
+                )
+                keep_last = int(
+                    os.environ.get(
+                        "AMELIA_CONTEXT_KEEP_LAST_TURNS",
+                        str(DEFAULT_KEEP_LAST_N_TURNS),
+                    )
+                )
+                if should_compact_context(
+                    state.model_copy(update={
+                        "tool_calls": [*state.tool_calls, *tool_calls],
+                        "tool_results": [*state.tool_results, *tool_results],
+                    }),
+                    context_utilization=usage.context_utilization if usage else None,
+                    threshold=threshold,
+                    keep_last_n_turns=keep_last,
+                ):
+                    current_state, compaction_event = compact_implementation_context(
+                        state.model_copy(update={
+                            "tool_calls": [*state.tool_calls, *tool_calls],
+                            "tool_results": [*state.tool_results, *tool_results],
+                            "driver_session_id": session_id,
+                            "agentic_status": "completed" if is_complete else "failed",
+                            "final_response": message.content if is_complete else None,
+                            "error": message.content if message.is_error else None,
+                        }),
+                        keep_last_n_turns=keep_last,
+                        reason=(
+                            f"context utilization {usage.context_utilization:.1%} "
+                            f"crossed threshold {threshold:.1%}"
+                            if usage and usage.context_utilization is not None
+                            else "context threshold crossed"
+                        ),
+                    )
+                    if compaction_event is not None:
+                        yield current_state, compaction_event
                 continue  # Result is the final message
 
             if event:

--- a/amelia/agents/developer.py
+++ b/amelia/agents/developer.py
@@ -33,6 +33,67 @@ if TYPE_CHECKING:
     from amelia.sandbox.provider import SandboxProvider
 
 
+def _parse_compaction_threshold() -> float:
+    """Parse and validate the context compaction threshold from env config.
+
+    Reads ``AMELIA_CONTEXT_COMPACTION_THRESHOLD`` (default
+    :data:`DEFAULT_COMPACTION_THRESHOLD`). The value must be a float in the
+    interval ``(0, 1]`` — values outside that range produce nonsensical
+    compaction behavior.
+
+    Raises:
+        ValueError: If the env value is non-numeric or out of range.
+
+    Returns:
+        Validated compaction threshold.
+    """
+    raw = os.environ.get(
+        "AMELIA_CONTEXT_COMPACTION_THRESHOLD",
+        str(DEFAULT_COMPACTION_THRESHOLD),
+    )
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"AMELIA_CONTEXT_COMPACTION_THRESHOLD must be a number in (0, 1], "
+            f"got {raw!r}"
+        ) from exc
+    if not 0 < value <= 1:
+        raise ValueError(
+            f"AMELIA_CONTEXT_COMPACTION_THRESHOLD must be in (0, 1], got {value}"
+        )
+    return value
+
+
+def _parse_keep_last_turns() -> int:
+    """Parse and validate the keep-last-turns config from env.
+
+    Reads ``AMELIA_CONTEXT_KEEP_LAST_TURNS`` (default
+    :data:`DEFAULT_KEEP_LAST_N_TURNS`). Must be an integer >= 1.
+
+    Raises:
+        ValueError: If the env value is non-numeric or < 1.
+
+    Returns:
+        Validated keep-last-turns count.
+    """
+    raw = os.environ.get(
+        "AMELIA_CONTEXT_KEEP_LAST_TURNS",
+        str(DEFAULT_KEEP_LAST_N_TURNS),
+    )
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"AMELIA_CONTEXT_KEEP_LAST_TURNS must be an integer >= 1, got {raw!r}"
+        ) from exc
+    if value < 1:
+        raise ValueError(
+            f"AMELIA_CONTEXT_KEEP_LAST_TURNS must be >= 1, got {value}"
+        )
+    return value
+
+
 class Developer:
     """Developer agent that executes code changes agentically.
 
@@ -119,6 +180,9 @@ class Developer:
         if not state.goal:
             raise ValueError("ImplementationState must have a goal set")
 
+        compaction_threshold = _parse_compaction_threshold()
+        keep_last_turns = _parse_keep_last_turns()
+
         cwd = profile.repo_root
         prompt = (
             prompt_builder(state) if prompt_builder is not None else self._build_prompt(state)
@@ -197,26 +261,14 @@ class Developer:
                 yield current_state, event
 
                 usage = self.driver.get_usage()
-                threshold = float(
-                    os.environ.get(
-                        "AMELIA_CONTEXT_COMPACTION_THRESHOLD",
-                        str(DEFAULT_COMPACTION_THRESHOLD),
-                    )
-                )
-                keep_last = int(
-                    os.environ.get(
-                        "AMELIA_CONTEXT_KEEP_LAST_TURNS",
-                        str(DEFAULT_KEEP_LAST_N_TURNS),
-                    )
-                )
                 if should_compact_context(
                     state.model_copy(update={
                         "tool_calls": [*state.tool_calls, *tool_calls],
                         "tool_results": [*state.tool_results, *tool_results],
                     }),
                     context_utilization=usage.context_utilization if usage else None,
-                    threshold=threshold,
-                    keep_last_n_turns=keep_last,
+                    threshold=compaction_threshold,
+                    keep_last_n_turns=keep_last_turns,
                 ):
                     current_state, compaction_event = compact_implementation_context(
                         state.model_copy(update={
@@ -227,10 +279,10 @@ class Developer:
                             "final_response": message.content if is_complete else None,
                             "error": message.content if message.is_error else None,
                         }),
-                        keep_last_n_turns=keep_last,
+                        keep_last_n_turns=keep_last_turns,
                         reason=(
                             f"context utilization {usage.context_utilization:.1%} "
-                            f"crossed threshold {threshold:.1%}"
+                            f"crossed threshold {compaction_threshold:.1%}"
                             if usage and usage.context_utilization is not None
                             else "context threshold crossed"
                         ),

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -12,6 +12,7 @@ from weakref import WeakKeyDictionary
 
 import httpx
 import openai
+import tiktoken
 from deepagents import create_deep_agent
 from deepagents.backends import FilesystemBackend
 from deepagents.backends.protocol import (
@@ -44,12 +45,39 @@ from amelia.drivers.base import (
 from amelia.logging import log_claude_result, log_todos
 
 
-__all__ = ["ApiDriver", "LocalSandbox"]
+__all__ = ["ApiDriver", "LocalSandbox", "truncate_text_to_token_budget"]
 
 # Maximum output size before truncation (100KB)
 _MAX_OUTPUT_SIZE = 100_000
+# Default token budget for shell/tool output returned to the model.
+_MAX_OUTPUT_TOKENS = int(os.environ.get("AMELIA_MAX_TOOL_OUTPUT_TOKENS", "12000"))
 # Default command timeout in seconds
 _DEFAULT_TIMEOUT = 300
+
+
+def _default_tokenizer() -> tiktoken.Encoding:
+    """Return a stable tokenizer for local budgeting."""
+    return tiktoken.get_encoding("cl100k_base")
+
+
+def truncate_text_to_token_budget(
+    text: str,
+    *,
+    max_tokens: int,
+    tokenizer: tiktoken.Encoding | None = None,
+) -> tuple[str, bool, int]:
+    """Truncate text by token count and include an explicit marker."""
+    enc = tokenizer or _default_tokenizer()
+    tokens = enc.encode(text)
+    original_tokens = len(tokens)
+    if original_tokens <= max_tokens:
+        return text, False, original_tokens
+
+    marker = f"\n... [tool output truncated to {max_tokens} tokens from {original_tokens}]"
+    marker_tokens = enc.encode(marker)
+    content_budget = max(0, max_tokens - len(marker_tokens))
+    truncated = enc.decode(tokens[:content_budget]) + marker
+    return truncated, True, original_tokens
 
 
 class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
@@ -67,6 +95,17 @@ class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
     Attributes:
         cwd: Working directory for command execution.
     """
+
+    def __init__(
+        self,
+        *args: Any,
+        max_output_tokens: int | None = None,
+        tokenizer: tiktoken.Encoding | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.max_output_tokens = max_output_tokens or _MAX_OUTPUT_TOKENS
+        self.tokenizer = tokenizer or _default_tokenizer()
 
     @property
     def id(self) -> str:
@@ -93,14 +132,19 @@ class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
                 timeout=_DEFAULT_TIMEOUT,
             )
             output = result.stdout + result.stderr
-            truncated = len(output) > _MAX_OUTPUT_SIZE
-            if truncated:
-                output = output[:_MAX_OUTPUT_SIZE] + "\n... [output truncated]"
+            output, truncated_by_tokens, _ = truncate_text_to_token_budget(
+                output,
+                max_tokens=self.max_output_tokens,
+                tokenizer=self.tokenizer,
+            )
+            truncated_by_bytes = len(output) > _MAX_OUTPUT_SIZE
+            if truncated_by_bytes:
+                output = output[:_MAX_OUTPUT_SIZE] + "\n... [output truncated by byte safety limit]"
 
             return ExecuteResponse(
                 output=output,
                 exit_code=result.returncode,
-                truncated=truncated,
+                truncated=truncated_by_tokens or truncated_by_bytes,
             )
         except subprocess.TimeoutExpired:
             return ExecuteResponse(
@@ -164,6 +208,7 @@ class ApiDriver(DriverInterface):
     """
 
     DEFAULT_MODEL = "minimax/minimax-m2"
+    tokenizer: ClassVar[tiktoken.Encoding] = _default_tokenizer()
 
     # Maximum number of sessions to retain before evicting oldest
     # Configurable via AMELIA_DRIVER_MAX_SESSIONS environment variable

--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -47,10 +47,35 @@ from amelia.logging import log_claude_result, log_todos
 
 __all__ = ["ApiDriver", "LocalSandbox", "truncate_text_to_token_budget"]
 
+
+def _parse_max_output_tokens(raw: str) -> int:
+    """Parse a non-negative integer from an env-var string with a clear error.
+
+    Raises:
+        ValueError: If the value is non-numeric or negative.
+
+    Returns:
+        The parsed non-negative token count.
+    """
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"AMELIA_MAX_TOOL_OUTPUT_TOKENS must be a non-negative integer, got {raw!r}"
+        ) from exc
+    if value < 0:
+        raise ValueError(
+            f"AMELIA_MAX_TOOL_OUTPUT_TOKENS must be non-negative, got {value}"
+        )
+    return value
+
+
 # Maximum output size before truncation (100KB)
 _MAX_OUTPUT_SIZE = 100_000
 # Default token budget for shell/tool output returned to the model.
-_MAX_OUTPUT_TOKENS = int(os.environ.get("AMELIA_MAX_TOOL_OUTPUT_TOKENS", "12000"))
+_MAX_OUTPUT_TOKENS = _parse_max_output_tokens(
+    os.environ.get("AMELIA_MAX_TOOL_OUTPUT_TOKENS", "12000")
+)
 # Default command timeout in seconds
 _DEFAULT_TIMEOUT = 300
 
@@ -66,7 +91,11 @@ def truncate_text_to_token_budget(
     max_tokens: int,
     tokenizer: tiktoken.Encoding | None = None,
 ) -> tuple[str, bool, int]:
-    """Truncate text by token count and include an explicit marker."""
+    """Truncate text by token count and include an explicit marker.
+
+    The returned string never exceeds ``max_tokens`` when encoded — even when
+    the marker itself is longer than ``max_tokens``.
+    """
     enc = tokenizer or _default_tokenizer()
     tokens = enc.encode(text)
     original_tokens = len(tokens)
@@ -75,7 +104,10 @@ def truncate_text_to_token_budget(
 
     marker = f"\n... [tool output truncated to {max_tokens} tokens from {original_tokens}]"
     marker_tokens = enc.encode(marker)
-    content_budget = max(0, max_tokens - len(marker_tokens))
+    if len(marker_tokens) >= max_tokens:
+        truncated = enc.decode(tokens[:max_tokens])
+        return truncated, True, original_tokens
+    content_budget = max_tokens - len(marker_tokens)
     truncated = enc.decode(tokens[:content_budget]) + marker
     return truncated, True, original_tokens
 
@@ -104,7 +136,14 @@ class LocalSandbox(FilesystemBackend, SandboxBackendProtocol):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.max_output_tokens = max_output_tokens or _MAX_OUTPUT_TOKENS
+        if max_output_tokens is None:
+            self.max_output_tokens = _MAX_OUTPUT_TOKENS
+        elif max_output_tokens <= 0:
+            raise ValueError(
+                f"max_output_tokens must be a positive integer, got {max_output_tokens}"
+            )
+        else:
+            self.max_output_tokens = max_output_tokens
         self.tokenizer = tokenizer or _default_tokenizer()
 
     @property

--- a/amelia/pipelines/implementation/context_compaction.py
+++ b/amelia/pipelines/implementation/context_compaction.py
@@ -1,0 +1,182 @@
+"""Deterministic context compaction for implementation workflows."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, TypeVar
+from uuid import uuid4
+
+from amelia.core.agentic_state import ToolCall, ToolResult
+from amelia.server.models.events import EventLevel, EventType, WorkflowEvent
+
+
+if TYPE_CHECKING:
+    from amelia.pipelines.implementation.state import ImplementationState
+
+T = TypeVar("T")
+
+COMPACTION_MARKER_TOOL_NAME = "context_compaction"
+COMPACTION_MARKER_CALL_ID_PREFIX = "context-compaction-marker"
+DEFAULT_KEEP_LAST_N_TURNS = 6
+DEFAULT_COMPACTION_THRESHOLD = 0.85
+
+
+class ReplaceList(list[T]):
+    """List wrapper that tells LangGraph reducers to replace instead of append.
+
+    ImplementationState tool_calls/tool_results are reducer-backed append-only
+    lists. Returning a normal shorter list from a graph node would be appended
+    to the prior state instead of pruning it. Wrapping the compacted value in
+    ReplaceList lets the custom reducer distinguish intentional state rewrites
+    from normal incremental appends.
+    """
+
+
+def compacting_list_reducer(left: Sequence[T], right: Sequence[T]) -> list[T]:
+    """Append normal updates, but allow explicit compaction rewrites."""
+    if isinstance(right, ReplaceList):
+        return list(right)
+    return [*left, *right]
+
+
+def _marker_id(existing_calls: Sequence[ToolCall]) -> str:
+    return f"{COMPACTION_MARKER_CALL_ID_PREFIX}-{sum(1 for c in existing_calls if c.tool_name == COMPACTION_MARKER_TOOL_NAME) + 1}"
+
+
+def _build_marker_output(
+    omitted_calls: Sequence[ToolCall],
+    omitted_results: Sequence[ToolResult],
+    *,
+    reason: str | None,
+) -> str:
+    first = omitted_calls[0].id if omitted_calls else "unknown"
+    last = omitted_calls[-1].id if omitted_calls else "unknown"
+    names = ", ".join(dict.fromkeys(call.tool_name for call in omitted_calls[:10]))
+    result_tokens = sum(len(result.output.split()) for result in omitted_results)
+    reason_text = f" Reason: {reason}." if reason else ""
+    return (
+        "[CONTEXT COMPACTED] "
+        f"Omitted {len(omitted_calls)} middle tool turn(s) to keep the workflow within "
+        f"the model context window.{reason_text} "
+        f"Protected first turn and the most recent turns are preserved. "
+        f"Omitted range: {first}..{last}. "
+        f"Tool names seen: {names or 'unknown'}. "
+        f"Approx omitted result words: {result_tokens}."
+    )
+
+
+def _split_for_compaction(
+    calls: Sequence[ToolCall],
+    results: Sequence[ToolResult],
+    keep_last_n_turns: int,
+) -> tuple[
+    list[ToolCall],
+    list[ToolResult],
+    list[ToolCall],
+    list[ToolResult],
+    list[ToolCall],
+    list[ToolResult],
+]:
+    keep_last = max(1, keep_last_n_turns)
+    protected_count = 1
+    tail_start = max(protected_count, len(calls) - keep_last)
+    return (
+        list(calls[:protected_count]),
+        list(results[:protected_count]),
+        list(calls[protected_count:tail_start]),
+        list(results[protected_count:tail_start]),
+        list(calls[tail_start:]),
+        list(results[tail_start:]),
+    )
+
+
+def compact_implementation_context(
+    state: ImplementationState,
+    *,
+    keep_last_n_turns: int = DEFAULT_KEEP_LAST_N_TURNS,
+    reason: str | None = None,
+) -> tuple[ImplementationState, WorkflowEvent | None]:
+    """Compact middle implementation tool history while preserving continuity.
+
+    The first tool turn is protected as setup context, the most recent N turns
+    remain verbatim for continuation, and the omitted middle is represented by a
+    transparent marker in both calls and results.
+    """
+    if len(state.tool_calls) != len(state.tool_results):
+        paired_turns = min(len(state.tool_calls), len(state.tool_results))
+        calls = state.tool_calls[:paired_turns]
+        results = state.tool_results[:paired_turns]
+    else:
+        calls = state.tool_calls
+        results = state.tool_results
+
+    if len(calls) <= keep_last_n_turns + 2:
+        return state, None
+
+    protected_calls, protected_results, omitted_calls, omitted_results, tail_calls, tail_results = (
+        _split_for_compaction(calls, results, keep_last_n_turns)
+    )
+    if not omitted_calls:
+        return state, None
+
+    marker_id = _marker_id(calls)
+    marker_call = ToolCall(
+        id=marker_id,
+        tool_name=COMPACTION_MARKER_TOOL_NAME,
+        tool_input={
+            "omitted_turns": len(omitted_calls),
+            "first_omitted_call_id": omitted_calls[0].id,
+            "last_omitted_call_id": omitted_calls[-1].id,
+        },
+    )
+    marker_result = ToolResult(
+        call_id=marker_id,
+        tool_name=COMPACTION_MARKER_TOOL_NAME,
+        output=_build_marker_output(omitted_calls, omitted_results, reason=reason),
+        success=True,
+    )
+
+    compacted_calls: list[ToolCall] = [*protected_calls, marker_call, *tail_calls]
+    compacted_results: list[ToolResult] = [*protected_results, marker_result, *tail_results]
+    compacted_state = state.model_copy(update={
+        "tool_calls": ReplaceList(compacted_calls),
+        "tool_results": ReplaceList(compacted_results),
+    })
+
+    event = WorkflowEvent(
+        id=uuid4(),
+        workflow_id=state.workflow_id,
+        sequence=0,
+        timestamp=datetime.now(UTC),
+        agent="developer",
+        event_type=EventType.CONTEXT_COMPACTED,
+        level=EventLevel.INFO,
+        message=(
+            f"Compacted workflow context: omitted {len(omitted_calls)} middle tool turn(s), "
+            f"kept first turn and last {len(tail_calls)} turn(s)."
+        ),
+        data={
+            "omitted_turns": len(omitted_calls),
+            "kept_first_turns": len(protected_calls),
+            "kept_recent_turns": len(tail_calls),
+            "first_omitted_call_id": omitted_calls[0].id,
+            "last_omitted_call_id": omitted_calls[-1].id,
+            "reason": reason,
+        },
+    )
+    return compacted_state, event
+
+
+def should_compact_context(
+    state: ImplementationState,
+    *,
+    context_utilization: float | None,
+    threshold: float = DEFAULT_COMPACTION_THRESHOLD,
+    keep_last_n_turns: int = DEFAULT_KEEP_LAST_N_TURNS,
+) -> bool:
+    """Return whether context metadata says this state should be compacted."""
+    if not isinstance(context_utilization, int | float):
+        return False
+    if context_utilization is None or context_utilization < threshold:
+        return False
+    return len(state.tool_calls) > keep_last_n_turns + 2

--- a/amelia/pipelines/implementation/context_compaction.py
+++ b/amelia/pipelines/implementation/context_compaction.py
@@ -43,23 +43,55 @@ def _marker_id(existing_calls: Sequence[ToolCall]) -> str:
     return f"{COMPACTION_MARKER_CALL_ID_PREFIX}-{sum(1 for c in existing_calls if c.tool_name == COMPACTION_MARKER_TOOL_NAME) + 1}"
 
 
+def _aggregate_prior_markers(
+    omitted_calls: Sequence[ToolCall],
+) -> tuple[int, str | None, str | None]:
+    """Sum omitted_turns from prior compaction markers in ``omitted_calls``.
+
+    Returns ``(total_omitted_turns, first_real_call_id, last_real_call_id)``.
+    Real call IDs skip marker calls; ``None`` is returned when no real calls
+    exist in the range.
+    """
+    total = 0
+    first_real: str | None = None
+    last_real: str | None = None
+    for call in omitted_calls:
+        if call.tool_name == COMPACTION_MARKER_TOOL_NAME:
+            prior = call.tool_input.get("omitted_turns")
+            if isinstance(prior, int):
+                total += prior
+            prior_first = call.tool_input.get("first_omitted_call_id")
+            if isinstance(prior_first, str) and first_real is None:
+                first_real = prior_first
+            prior_last = call.tool_input.get("last_omitted_call_id")
+            if isinstance(prior_last, str):
+                last_real = prior_last
+        else:
+            if first_real is None:
+                first_real = call.id
+            last_real = call.id
+            total += 1
+    return total, first_real, last_real
+
+
 def _build_marker_output(
     omitted_calls: Sequence[ToolCall],
     omitted_results: Sequence[ToolResult],
     *,
     reason: str | None,
+    total_omitted_turns: int,
+    first_call_id: str,
+    last_call_id: str,
 ) -> str:
-    first = omitted_calls[0].id if omitted_calls else "unknown"
-    last = omitted_calls[-1].id if omitted_calls else "unknown"
     names = ", ".join(dict.fromkeys(call.tool_name for call in omitted_calls[:10]))
     result_tokens = sum(len(result.output.split()) for result in omitted_results)
     reason_text = f" Reason: {reason}." if reason else ""
     return (
         "[CONTEXT COMPACTED] "
-        f"Omitted {len(omitted_calls)} middle tool turn(s) to keep the workflow within "
+        f"Omitted {total_omitted_turns} middle tool turn(s) to keep the workflow within "
         f"the model context window.{reason_text} "
         f"Protected first turn and the most recent turns are preserved. "
-        f"Omitted range: {first}..{last}. "
+        f"Omitted range: {first_call_id}..{last_call_id}. "
         f"Tool names seen: {names or 'unknown'}. "
         f"Approx omitted result words: {result_tokens}."
     )
@@ -119,20 +151,33 @@ def compact_implementation_context(
     if not omitted_calls:
         return state, None
 
+    total_omitted, first_call_id, last_call_id = _aggregate_prior_markers(omitted_calls)
+    if first_call_id is None:
+        first_call_id = "unknown"
+    if last_call_id is None:
+        last_call_id = "unknown"
+
     marker_id = _marker_id(calls)
     marker_call = ToolCall(
         id=marker_id,
         tool_name=COMPACTION_MARKER_TOOL_NAME,
         tool_input={
-            "omitted_turns": len(omitted_calls),
-            "first_omitted_call_id": omitted_calls[0].id,
-            "last_omitted_call_id": omitted_calls[-1].id,
+            "omitted_turns": total_omitted,
+            "first_omitted_call_id": first_call_id,
+            "last_omitted_call_id": last_call_id,
         },
     )
     marker_result = ToolResult(
         call_id=marker_id,
         tool_name=COMPACTION_MARKER_TOOL_NAME,
-        output=_build_marker_output(omitted_calls, omitted_results, reason=reason),
+        output=_build_marker_output(
+            omitted_calls,
+            omitted_results,
+            reason=reason,
+            total_omitted_turns=total_omitted,
+            first_call_id=first_call_id,
+            last_call_id=last_call_id,
+        ),
         success=True,
     )
 
@@ -152,15 +197,15 @@ def compact_implementation_context(
         event_type=EventType.CONTEXT_COMPACTED,
         level=EventLevel.INFO,
         message=(
-            f"Compacted workflow context: omitted {len(omitted_calls)} middle tool turn(s), "
+            f"Compacted workflow context: omitted {total_omitted} middle tool turn(s), "
             f"kept first turn and last {len(tail_calls)} turn(s)."
         ),
         data={
-            "omitted_turns": len(omitted_calls),
+            "omitted_turns": total_omitted,
             "kept_first_turns": len(protected_calls),
             "kept_recent_turns": len(tail_calls),
-            "first_omitted_call_id": omitted_calls[0].id,
-            "last_omitted_call_id": omitted_calls[-1].id,
+            "first_omitted_call_id": first_call_id,
+            "last_omitted_call_id": last_call_id,
             "reason": reason,
         },
     )

--- a/amelia/pipelines/implementation/state.py
+++ b/amelia/pipelines/implementation/state.py
@@ -20,7 +20,6 @@ global namespace. See rebuild_implementation_state() for the implementation.
 
 from __future__ import annotations
 
-import operator
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
@@ -29,6 +28,7 @@ from pydantic import Field
 from amelia.core.agentic_state import AgenticStatus, ToolCall, ToolResult
 from amelia.core.types import Design, Issue, PlanValidationResult, ReviewResult
 from amelia.pipelines.base import BasePipelineState
+from amelia.pipelines.implementation.context_compaction import compacting_list_reducer
 from amelia.tools.write_plan_schema import WritePlanInput
 
 
@@ -49,8 +49,8 @@ class ImplementationState(BasePipelineState):
     # Override pipeline_type with literal
     pipeline_type: Literal["implementation"] = "implementation"
 
-    tool_calls: Annotated[list[ToolCall], operator.add] = Field(default_factory=list)
-    tool_results: Annotated[list[ToolResult], operator.add] = Field(default_factory=list)
+    tool_calls: Annotated[list[ToolCall], compacting_list_reducer] = Field(default_factory=list)
+    tool_results: Annotated[list[ToolResult], compacting_list_reducer] = Field(default_factory=list)
     agentic_status: AgenticStatus = AgenticStatus.RUNNING
 
     issue: Issue | None = None

--- a/amelia/server/models/events.py
+++ b/amelia/server/models/events.py
@@ -73,6 +73,7 @@ class EventType(StrEnum):
     SYSTEM_ERROR = "system_error"
     SYSTEM_WARNING = "system_warning"
     TOOL_POLICY_DECISION = "tool_policy_decision"
+    CONTEXT_COMPACTED = "context_compacted"
 
     # Streaming (ephemeral, not persisted)
     STREAM = "stream"
@@ -213,6 +214,7 @@ _INFO_TYPES: frozenset[AnyEventType] = frozenset({
     EventType.PR_AUTO_FIX_STARTED,
     EventType.PR_AUTO_FIX_COMPLETED,
     EventType.PR_COMMENTS_RESOLVED,
+    EventType.CONTEXT_COMPACTED,
 })
 
 

--- a/dashboard/src/types/events.ts
+++ b/dashboard/src/types/events.ts
@@ -62,6 +62,7 @@ export type EventType =
   | 'system_error'
   | 'system_warning'
   | 'tool_policy_decision'
+  | 'context_compacted'
   // Streaming (ephemeral, not persisted)
   | 'stream'
   // Trace (stream events)

--- a/tests/unit/agents/test_developer.py
+++ b/tests/unit/agents/test_developer.py
@@ -10,7 +10,8 @@ import pytest
 from amelia.agents.developer import Developer
 from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.core.types import AgentConfig, SandboxConfig
-from amelia.drivers.base import AgenticMessage, AgenticMessageType
+from amelia.drivers.base import AgenticMessage, AgenticMessageType, DriverUsage
+from amelia.pipelines.implementation.context_compaction import COMPACTION_MARKER_TOOL_NAME
 from amelia.pipelines.implementation.state import ImplementationState
 
 
@@ -169,6 +170,65 @@ class TestDeveloperRunNoDoubleCount:
         )
         assert final_state.tool_results[0].call_id == "new-1"
         assert final_state.tool_results[0].tool_name == "bash"
+
+    async def test_run_compacts_when_context_utilization_crosses_threshold(
+        self,
+        mock_driver,
+        state_with_existing_tool_data,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Developer.run() should compact returned state and emit a visible event."""
+        state, profile = state_with_existing_tool_data
+        state = state.model_copy(update={
+            "tool_calls": [
+                ToolCall(id=f"old-{i}", tool_name="read_file", tool_input={"path": f"{i}.py"})
+                for i in range(6)
+            ],
+            "tool_results": [
+                ToolResult(
+                    call_id=f"old-{i}",
+                    tool_name="read_file",
+                    output=f"old output {i}",
+                    success=True,
+                )
+                for i in range(6)
+            ],
+        })
+        monkeypatch.setenv("AMELIA_CONTEXT_COMPACTION_THRESHOLD", "0.8")
+        monkeypatch.setenv("AMELIA_CONTEXT_KEEP_LAST_TURNS", "2")
+
+        async def mock_stream(*args: Any, **kwargs: Any) -> AsyncIterator[AgenticMessage]:
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_CALL,
+                tool_name="bash",
+                tool_input={"command": "true"},
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(
+                type=AgenticMessageType.TOOL_RESULT,
+                tool_name="bash",
+                tool_output="ok",
+                tool_call_id="new-1",
+            )
+            yield AgenticMessage(type=AgenticMessageType.RESULT, content="Done", session_id="sess-1")
+
+        mock_driver.execute_agentic = mock_stream
+        mock_driver.get_usage.return_value = DriverUsage(context_utilization=0.9)
+        config = AgentConfig(driver="claude", model="sonnet")
+
+        yielded = []
+        with patch("amelia.agents._driver_init.get_driver", return_value=mock_driver):
+            developer = Developer(config)
+            async for item in developer.run(state, profile, workflow_id=state.workflow_id):
+                yielded.append(item)
+
+        compacted_state, compaction_event = yielded[-1]
+        assert compaction_event.event_type == "context_compacted"
+        assert any(
+            result.tool_name == COMPACTION_MARKER_TOOL_NAME
+            for result in compacted_state.tool_results
+        )
+        assert len(compacted_state.tool_results) < 7
 
 
 async def test_developer_passes_allowed_tools_when_tool_context_set(

--- a/tests/unit/agents/test_developer.py
+++ b/tests/unit/agents/test_developer.py
@@ -310,3 +310,54 @@ async def test_developer_omits_allowed_tools_without_tool_context(
             pass
 
     assert "allowed_tools" not in captured or captured.get("allowed_tools") is None
+
+
+class TestDeveloperCompactionConfigValidation:
+    """Developer.run() parses compaction env config eagerly with validation."""
+
+    def test_invalid_threshold_raises_value_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from amelia.agents.developer import _parse_compaction_threshold
+
+        monkeypatch.setenv("AMELIA_CONTEXT_COMPACTION_THRESHOLD", "not-a-number")
+        with pytest.raises(ValueError, match="AMELIA_CONTEXT_COMPACTION_THRESHOLD"):
+            _parse_compaction_threshold()
+
+        monkeypatch.setenv("AMELIA_CONTEXT_COMPACTION_THRESHOLD", "1.5")
+        with pytest.raises(ValueError, match=r"\(0, 1\]"):
+            _parse_compaction_threshold()
+
+        monkeypatch.setenv("AMELIA_CONTEXT_COMPACTION_THRESHOLD", "0")
+        with pytest.raises(ValueError, match=r"\(0, 1\]"):
+            _parse_compaction_threshold()
+
+    def test_invalid_keep_last_raises_value_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from amelia.agents.developer import _parse_keep_last_turns
+
+        monkeypatch.setenv("AMELIA_CONTEXT_KEEP_LAST_TURNS", "not-an-int")
+        with pytest.raises(ValueError, match="AMELIA_CONTEXT_KEEP_LAST_TURNS"):
+            _parse_keep_last_turns()
+
+        monkeypatch.setenv("AMELIA_CONTEXT_KEEP_LAST_TURNS", "0")
+        with pytest.raises(ValueError, match=">= 1"):
+            _parse_keep_last_turns()
+
+        monkeypatch.setenv("AMELIA_CONTEXT_KEEP_LAST_TURNS", "-3")
+        with pytest.raises(ValueError, match=">= 1"):
+            _parse_keep_last_turns()
+
+    def test_valid_config_parses(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from amelia.agents.developer import _parse_compaction_threshold, _parse_keep_last_turns
+
+        monkeypatch.setenv("AMELIA_CONTEXT_COMPACTION_THRESHOLD", "0.9")
+        monkeypatch.setenv("AMELIA_CONTEXT_KEEP_LAST_TURNS", "4")
+        assert _parse_compaction_threshold() == 0.9
+        assert _parse_keep_last_turns() == 4

--- a/tests/unit/pipelines/implementation/test_context_compaction.py
+++ b/tests/unit/pipelines/implementation/test_context_compaction.py
@@ -6,8 +6,10 @@ from uuid import uuid4
 
 from amelia.core.agentic_state import ToolCall, ToolResult
 from amelia.pipelines.implementation.context_compaction import (
+    COMPACTION_MARKER_CALL_ID_PREFIX,
     COMPACTION_MARKER_TOOL_NAME,
     ReplaceList,
+    _aggregate_prior_markers,
     compact_implementation_context,
     compacting_list_reducer,
     should_compact_context,
@@ -92,3 +94,70 @@ def test_should_compact_context_uses_context_utilization_threshold() -> None:
     )
     assert not should_compact_context(state, context_utilization=0.5, threshold=0.9)
     assert not should_compact_context(_state_with_turns(2), context_utilization=0.91, threshold=0.9)
+
+
+def test_re_compaction_flattens_prior_marker_and_uses_real_call_ids() -> None:
+    """Re-compacting already-compacted history sums prior marker turns.
+
+    After the first compaction the omitted range is represented by a single
+    marker call. A second compaction must not report just "1 turn omitted"
+    or point its omitted range at the marker id; it aggregates the prior
+    marker's omitted_turns and uses the original real call ids.
+    """
+    state = _state_with_turns(8)
+    first, _ = compact_implementation_context(state, keep_last_n_turns=2, reason="round 1")
+
+    second, event = compact_implementation_context(first, keep_last_n_turns=1, reason="round 2")
+    assert event is not None
+    assert event.data is not None
+
+    marker_calls = [c for c in second.tool_calls if c.tool_name == COMPACTION_MARKER_TOOL_NAME]
+    assert len(marker_calls) == 1
+    new_marker = marker_calls[0]
+
+    assert new_marker.id == f"{COMPACTION_MARKER_CALL_ID_PREFIX}-2"
+    # omitted = 5 (from prior marker) + 1 (real call-6) = 6
+    assert new_marker.tool_input["omitted_turns"] == 6
+    assert new_marker.tool_input["first_omitted_call_id"] == "call-1"
+    assert new_marker.tool_input["last_omitted_call_id"] == "call-6"
+    assert event.data["omitted_turns"] == 6
+    assert event.data["first_omitted_call_id"] == "call-1"
+    assert event.data["last_omitted_call_id"] == "call-6"
+
+
+def test_aggregate_prior_markers_sums_marker_and_real_turns() -> None:
+    calls = [
+        ToolCall(
+            id=f"{COMPACTION_MARKER_CALL_ID_PREFIX}-1",
+            tool_name=COMPACTION_MARKER_TOOL_NAME,
+            tool_input={
+                "omitted_turns": 4,
+                "first_omitted_call_id": "real-1",
+                "last_omitted_call_id": "real-4",
+            },
+        ),
+        ToolCall(id="real-5", tool_name="read_file", tool_input={}),
+        ToolCall(id="real-6", tool_name="read_file", tool_input={}),
+    ]
+    total, first, last = _aggregate_prior_markers(calls)
+    assert total == 6
+    assert first == "real-1"
+    assert last == "real-6"
+
+
+def test_aggregate_prior_markers_only_markers_uses_marker_metadata() -> None:
+    calls = [
+        ToolCall(
+            id=f"{COMPACTION_MARKER_CALL_ID_PREFIX}-1",
+            tool_name=COMPACTION_MARKER_TOOL_NAME,
+            tool_input={
+                "omitted_turns": 3,
+                "first_omitted_call_id": "a",
+                "last_omitted_call_id": "c",
+            },
+        ),
+    ]
+    total, first, last = _aggregate_prior_markers(calls)
+    assert total == 3
+    assert first == "a"
+    assert last == "c"

--- a/tests/unit/pipelines/implementation/test_context_compaction.py
+++ b/tests/unit/pipelines/implementation/test_context_compaction.py
@@ -1,0 +1,94 @@
+"""Tests for implementation context compaction."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from amelia.core.agentic_state import ToolCall, ToolResult
+from amelia.pipelines.implementation.context_compaction import (
+    COMPACTION_MARKER_TOOL_NAME,
+    ReplaceList,
+    compact_implementation_context,
+    compacting_list_reducer,
+    should_compact_context,
+)
+from amelia.pipelines.implementation.state import ImplementationState
+
+
+def _state_with_turns(count: int) -> ImplementationState:
+    return ImplementationState(
+        workflow_id=uuid4(),
+        profile_id="test-profile",
+        created_at=datetime.now(UTC),
+        status="running",
+        goal="implement context compaction",
+        plan_markdown="# Plan",
+        tool_calls=[
+            ToolCall(id=f"call-{i}", tool_name="read_file", tool_input={"path": f"file-{i}.py"})
+            for i in range(count)
+        ],
+        tool_results=[
+            ToolResult(
+                call_id=f"call-{i}",
+                tool_name="read_file",
+                output=f"result {i}",
+                success=True,
+            )
+            for i in range(count)
+        ],
+    )
+
+
+def test_compaction_preserves_first_turn_recent_turns_and_marker() -> None:
+    state = _state_with_turns(8)
+
+    compacted, event = compact_implementation_context(
+        state,
+        keep_last_n_turns=2,
+        reason="test threshold crossed",
+    )
+
+    assert [call.id for call in compacted.tool_calls] == [
+        "call-0",
+        "context-compaction-marker-1",
+        "call-6",
+        "call-7",
+    ]
+    assert [result.call_id for result in compacted.tool_results] == [
+        "call-0",
+        "context-compaction-marker-1",
+        "call-6",
+        "call-7",
+    ]
+    marker = compacted.tool_results[1]
+    assert marker.tool_name == COMPACTION_MARKER_TOOL_NAME
+    assert "Omitted 5 middle tool turn(s)" in marker.output
+    assert "call-1" in marker.output
+    assert "call-5" in marker.output
+    assert event is not None
+    assert event.data is not None
+    assert event.data["omitted_turns"] == 5
+
+
+def test_compaction_reducer_can_replace_append_only_state() -> None:
+    existing = _state_with_turns(5).tool_results
+    compacted, _ = compact_implementation_context(_state_with_turns(5), keep_last_n_turns=1)
+
+    merged = compacting_list_reducer(existing, ReplaceList(compacted.tool_results))
+
+    assert merged == compacted.tool_results
+    assert len(merged) < len(existing)
+    assert any(result.tool_name == COMPACTION_MARKER_TOOL_NAME for result in merged)
+
+
+def test_should_compact_context_uses_context_utilization_threshold() -> None:
+    state = _state_with_turns(4)
+
+    assert should_compact_context(
+        state,
+        context_utilization=0.91,
+        threshold=0.9,
+        keep_last_n_turns=1,
+    )
+    assert not should_compact_context(state, context_utilization=0.5, threshold=0.9)
+    assert not should_compact_context(_state_with_turns(2), context_utilization=0.91, threshold=0.9)

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -12,6 +12,7 @@ from amelia.drivers.api.deepagents import (
     ApiDriver,
     LocalSandbox,
     _create_chat_model,
+    _parse_max_output_tokens,
     truncate_text_to_token_budget,
 )
 from amelia.drivers.base import AgenticMessage, AgenticMessageType
@@ -343,7 +344,7 @@ class TestLocalSandbox:
         sandbox = LocalSandbox(
             root_dir=str(tmp_path),
             virtual_mode=False,
-            max_output_tokens=8,
+            max_output_tokens=50,
         )
 
         result = sandbox.execute(
@@ -351,8 +352,8 @@ class TestLocalSandbox:
         )
 
         assert result.truncated is True
-        assert "[tool output truncated to 8 tokens" in result.output
-        assert len(sandbox.tokenizer.encode(result.output)) < 40
+        assert "[tool output truncated to 50 tokens" in result.output
+        assert len(sandbox.tokenizer.encode(result.output)) < 200
 
 
 class TestTokenAwareTruncation:
@@ -363,16 +364,17 @@ class TestTokenAwareTruncation:
     def test_truncate_text_to_token_budget_uses_tokenizer_not_bytes(self) -> None:
         text = "antidisestablishmentarianism " * 20
 
+        max_tokens = 50
         truncated, was_truncated, original_tokens = truncate_text_to_token_budget(
             text,
-            max_tokens=10,
+            max_tokens=max_tokens,
         )
 
         assert was_truncated is True
-        assert original_tokens > 10
-        assert len(ApiDriver.tokenizer.encode(truncated)) <= 18
+        assert original_tokens > max_tokens
+        assert len(ApiDriver.tokenizer.encode(truncated)) <= max_tokens
         assert len(truncated.encode()) > 10
-        assert "[tool output truncated to 10 tokens" in truncated
+        assert "[tool output truncated to 50 tokens" in truncated
 
     def test_execute_returns_timeout_error_on_slow_command(
         self, tmp_path: Path
@@ -457,6 +459,66 @@ class TestTokenAwareTruncation:
         assert result.error is None
         assert result.file_data is not None
         assert "content here" in result.file_data["content"]
+
+
+class TestParseMaxOutputTokens:
+    """Tests for _parse_max_output_tokens import-time validation."""
+
+    def test_parses_valid_integer(self) -> None:
+        assert _parse_max_output_tokens("12000") == 12000
+        assert _parse_max_output_tokens("0") == 0
+
+    def test_rejects_non_numeric_with_clear_value_error(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            _parse_max_output_tokens("abc")
+
+    def test_rejects_negative_with_clear_value_error(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            _parse_max_output_tokens("-5")
+
+
+class TestLocalSandboxMaxOutputTokensValidation:
+    """Tests for LocalSandbox max_output_tokens None-vs-invalid handling."""
+
+    def test_none_uses_default(self, tmp_path: Path) -> None:
+        sandbox = LocalSandbox(root_dir=str(tmp_path), virtual_mode=False)
+        assert sandbox.max_output_tokens > 0
+
+    def test_zero_raises_value_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="positive integer"):
+            LocalSandbox(root_dir=str(tmp_path), virtual_mode=False, max_output_tokens=0)
+
+    def test_negative_raises_value_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="positive integer"):
+            LocalSandbox(root_dir=str(tmp_path), virtual_mode=False, max_output_tokens=-10)
+
+    def test_explicit_positive_value_is_used(self, tmp_path: Path) -> None:
+        sandbox = LocalSandbox(
+            root_dir=str(tmp_path), virtual_mode=False, max_output_tokens=42
+        )
+        assert sandbox.max_output_tokens == 42
+
+
+class TestTruncateMarkerFitsBudget:
+    """truncate_text_to_token_budget must never exceed max_tokens."""
+
+    def test_marker_longer_than_budget_returns_truncated_within_budget(self) -> None:
+        from amelia.drivers.api.deepagents import ApiDriver
+
+        text = "antidisestablishmentarianism " * 100
+        max_tokens = 2
+        truncated, was_truncated, original = truncate_text_to_token_budget(
+            text, max_tokens=max_tokens
+        )
+        assert was_truncated is True
+        assert original > max_tokens
+        encoded = len(ApiDriver.tokenizer.encode(truncated))
+        assert encoded <= max_tokens
+
+    def test_zero_budget_returns_empty_string(self) -> None:
+        truncated, was_truncated, _ = truncate_text_to_token_budget("hello world", max_tokens=0)
+        assert was_truncated is True
+        assert truncated == ""
 
 
 class TestExecuteAgenticYieldsAgenticMessage:

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -8,7 +8,12 @@ from langchain.agents.structured_output import ToolStrategy
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from pydantic import BaseModel
 
-from amelia.drivers.api.deepagents import ApiDriver, LocalSandbox, _create_chat_model
+from amelia.drivers.api.deepagents import (
+    ApiDriver,
+    LocalSandbox,
+    _create_chat_model,
+    truncate_text_to_token_budget,
+)
 from amelia.drivers.base import AgenticMessage, AgenticMessageType
 
 
@@ -332,6 +337,42 @@ class TestLocalSandbox:
         from amelia.drivers.api.deepagents import _DEFAULT_TIMEOUT
 
         assert _DEFAULT_TIMEOUT == 300
+
+    def test_execute_truncates_output_by_token_budget_not_bytes(self, tmp_path: Path) -> None:
+        """Large tool output should be bounded by model-token budget, not byte count."""
+        sandbox = LocalSandbox(
+            root_dir=str(tmp_path),
+            virtual_mode=False,
+            max_output_tokens=8,
+        )
+
+        result = sandbox.execute(
+            "python - <<'PY'\nprint('antidisestablishmentarianism ' * 40)\nPY"
+        )
+
+        assert result.truncated is True
+        assert "[tool output truncated to 8 tokens" in result.output
+        assert len(sandbox.tokenizer.encode(result.output)) < 40
+
+
+class TestTokenAwareTruncation:
+    @pytest.fixture
+    def sandbox(self, tmp_path: Path) -> LocalSandbox:
+        return LocalSandbox(root_dir=str(tmp_path), virtual_mode=False)
+
+    def test_truncate_text_to_token_budget_uses_tokenizer_not_bytes(self) -> None:
+        text = "antidisestablishmentarianism " * 20
+
+        truncated, was_truncated, original_tokens = truncate_text_to_token_budget(
+            text,
+            max_tokens=10,
+        )
+
+        assert was_truncated is True
+        assert original_tokens > 10
+        assert len(ApiDriver.tokenizer.encode(truncated)) <= 18
+        assert len(truncated.encode()) > 10
+        assert "[tool output truncated to 10 tokens" in truncated
 
     def test_execute_returns_timeout_error_on_slow_command(
         self, tmp_path: Path


### PR DESCRIPTION
Problem:
Amelia could measure context usage after #505 but still had no strategy to compact long workflow history before model limits were hit.

Change:
- Adds simple context compaction for implementation tool_calls/tool_results with protected first turn, recent turns, and explicit omitted-turn markers.
- Replaces append-only reducers with a controlled ReplaceList path for compaction rewrites.
- Adds token-aware sandbox output truncation.
- Triggers Developer compaction when context utilization crosses the configured threshold and emits context_compacted events.
- Keeps LLM-generated summaries deferred.

Verification:
- uv run ruff check --fix amelia tests
- uv run mypy amelia
- unset SSL_CERT_FILE; GIT_CONFIG_GLOBAL=/dev/null uv run pytest tests/unit/
- push pre-push hook: ruff, mypy, 2623 passed, dashboard build passed

Depends on #661
Closes #229