### PR TITLE
feat(context): document deepagents built-in compaction (#229)

### DIFF
--- a/amelia/drivers/api/deepagents.py
+++ b/amelia/drivers/api/deepagents.py
@@ -636,6 +636,18 @@ class ApiDriver(DriverInterface):
             # LLM APIs are stateless - always pass system prompt with every request
             effective_system_prompt = instructions or ""
 
+            # DeepAgents' built-in context compression is active by default:
+            # 1. FilesystemMiddleware offloads tool results >20K tokens to
+            #    /large_tool_results/<tool_call_id> on the backend (head+tail preview
+            #    replaces the inline content; agent can read_file the full result).
+            # 2. SummarizationMiddleware triggers at 85% context utilization, keeping
+            #    10% of recent context. Large tool-call args in older messages are
+            #    clipped first (truncate_args_settings). Evicted history is offloaded
+            #    to /conversation_history/{thread_id}.md. On ContextOverflowError,
+            #    the middleware summarizes and retries instead of bubbling the error.
+            # 3. LocalSandbox (extends FilesystemBackend) provides the backend write()
+            #    path needed for both offload mechanisms.
+            # No custom compaction middleware is needed — see issue #229.
             agent = create_deep_agent(
                 model=chat_model,
                 system_prompt=effective_system_prompt,

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -696,7 +696,15 @@ class TestContextCompaction:
     async def test_no_middleware_excludes_summarization(
         self, mock_deepagents_local_sandbox: MagicMock
     ) -> None:
-        """No custom middleware should exclude DeepAgents' default summarization."""
+        """No custom middleware is passed, so DeepAgents' built-in defaults are unaltered.
+
+        This guards against accidentally passing a middleware that would override or
+        veto the built-in FilesystemMiddleware/SummarizationMiddleware stack that
+        ``create_deep_agent`` prepends regardless of the user-supplied ``middleware``
+        arg. It does not (and cannot, against this mock) directly assert that
+        summarization remains registered — that is documented at the call site in
+        ``execute_agentic``.
+        """
         driver = ApiDriver(model="test/model", cwd="/test/path")
         mock_deepagents_local_sandbox.stream_chunks = [
             {"messages": [AIMessage(content="done")]},
@@ -707,16 +715,46 @@ class TestContextCompaction:
         call_kwargs = mock_deepagents_local_sandbox.create_deep_agent.call_args.kwargs
         assert call_kwargs["middleware"] in ((), [])
 
-    def test_token_aware_truncation_preserved(self) -> None:
-        """Sandbox output truncation should remain separate from context compaction."""
+    async def test_policy_middleware_coexists_with_default_compression(
+        self, mock_deepagents_local_sandbox: MagicMock
+    ) -> None:
+        """allowed_tools path forwards ToolPolicyMiddleware without overriding defaults.
+
+        Mirrors ``test_no_middleware_excludes_summarization`` for the non-empty
+        ``middleware=[policy_mw]`` path. DeepAgents' built-in
+        ``FilesystemMiddleware`` + ``SummarizationMiddleware`` are prepended to
+        the stack inside ``create_deep_agent`` regardless of the user-supplied
+        ``middleware`` kwarg, which is *appended* — never replaces. This test
+        cannot (against this mock) directly assert summarization stays
+        registered; that contract is documented at the call site in
+        ``execute_agentic``. It pins that the policy middleware is forwarded
+        as the sole entry, so a future change that drops built-in compression
+        or substitutes a veto middleware would surface here rather than
+        silently disabling it.
+        """
+        from amelia.tools.registry import ToolPolicyMiddleware
+
+        driver = ApiDriver(model="test/model", cwd="/test/path")
+        mock_deepagents_local_sandbox.stream_chunks = [
+            {"messages": [AIMessage(content="done")]},
+        ]
+
+        _ = [
+            msg
+            async for msg in driver.execute_agentic(
+                "test prompt", cwd="/test/path", allowed_tools=["read_file"]
+            )
+        ]
+
+        call_kwargs = mock_deepagents_local_sandbox.create_deep_agent.call_args.kwargs
+        middleware = call_kwargs["middleware"]
+        assert isinstance(middleware, list)
+        assert len(middleware) == 1
+        assert isinstance(middleware[0], ToolPolicyMiddleware)
+
+    def test_output_size_limit_preserved(self) -> None:
+        """Sandbox output byte-size truncation should remain separate from context compaction."""
         import amelia.drivers.api.deepagents as deepagents_module
 
         assert hasattr(deepagents_module, "_MAX_OUTPUT_SIZE")
         assert deepagents_module._MAX_OUTPUT_SIZE == 100_000
-        truncate_text_to_token_budget = getattr(
-            deepagents_module,
-            "truncate_text_to_token_budget",
-            None,
-        )
-        if truncate_text_to_token_budget is not None:
-            assert callable(truncate_text_to_token_budget)

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -663,3 +663,60 @@ class TestIncompleteTaskDetection:
         # Access the actual message from the call args (first positional argument)
         warning_messages = [call.args[0] if call.args else "" for call in warning_calls]
         assert any("without calling write_file" in msg for msg in warning_messages)
+
+
+class TestContextCompaction:
+    """Verify DeepAgents built-in context compression remains active."""
+
+    def test_local_sandbox_extends_filesystem_backend(self) -> None:
+        """LocalSandbox should support filesystem offload writes."""
+        from deepagents.backends import FilesystemBackend
+
+        assert issubclass(LocalSandbox, FilesystemBackend)
+
+    async def test_execute_agentic_passes_local_sandbox_backend(
+        self, mock_deepagents_local_sandbox: MagicMock
+    ) -> None:
+        """execute_agentic should pass a LocalSandbox backend to DeepAgents."""
+        driver = ApiDriver(model="test/model", cwd="/test/path")
+        mock_deepagents_local_sandbox.stream_chunks = [
+            {"messages": [AIMessage(content="done")]},
+        ]
+
+        _ = [msg async for msg in driver.execute_agentic("test prompt", cwd="/test/path")]
+
+        mock_deepagents_local_sandbox.backend_class.assert_called_once_with(
+            root_dir="/test/path",
+            virtual_mode=True,
+        )
+        call_kwargs = mock_deepagents_local_sandbox.create_deep_agent.call_args.kwargs
+        assert "backend" in call_kwargs
+        assert call_kwargs["backend"] is mock_deepagents_local_sandbox.backend_class.return_value
+
+    async def test_no_middleware_excludes_summarization(
+        self, mock_deepagents_local_sandbox: MagicMock
+    ) -> None:
+        """No custom middleware should exclude DeepAgents' default summarization."""
+        driver = ApiDriver(model="test/model", cwd="/test/path")
+        mock_deepagents_local_sandbox.stream_chunks = [
+            {"messages": [AIMessage(content="done")]},
+        ]
+
+        _ = [msg async for msg in driver.execute_agentic("test prompt", cwd="/test/path")]
+
+        call_kwargs = mock_deepagents_local_sandbox.create_deep_agent.call_args.kwargs
+        assert call_kwargs["middleware"] in ((), [])
+
+    def test_token_aware_truncation_preserved(self) -> None:
+        """Sandbox output truncation should remain separate from context compaction."""
+        import amelia.drivers.api.deepagents as deepagents_module
+
+        assert hasattr(deepagents_module, "_MAX_OUTPUT_SIZE")
+        assert deepagents_module._MAX_OUTPUT_SIZE == 100_000
+        truncate_text_to_token_budget = getattr(
+            deepagents_module,
+            "truncate_text_to_token_budget",
+            None,
+        )
+        if truncate_text_to_token_budget is not None:
+            assert callable(truncate_text_to_token_budget)

--- a/tests/unit/test_api_driver.py
+++ b/tests/unit/test_api_driver.py
@@ -728,8 +728,10 @@ class TestContextCompaction:
         cannot (against this mock) directly assert summarization stays
         registered; that contract is documented at the call site in
         ``execute_agentic``. It pins that the policy middleware is forwarded
-        as the sole entry, so a future change that drops built-in compression
-        or substitutes a veto middleware would surface here rather than
+        ahead of any caller-supplied middleware (the merge path at
+        ``deepagents.py`` ``middleware = [policy_mw, *(middleware or [])]``),
+        so a future change that drops built-in compression, substitutes a veto
+        middleware, or reorders the merge would surface here rather than
         silently disabling it.
         """
         from amelia.tools.registry import ToolPolicyMiddleware
@@ -739,18 +741,23 @@ class TestContextCompaction:
             {"messages": [AIMessage(content="done")]},
         ]
 
+        existing_middleware = [MagicMock(name="caller_middleware")]
         _ = [
             msg
             async for msg in driver.execute_agentic(
-                "test prompt", cwd="/test/path", allowed_tools=["read_file"]
+                "test prompt",
+                cwd="/test/path",
+                allowed_tools=["read_file"],
+                middleware=existing_middleware,
             )
         ]
 
         call_kwargs = mock_deepagents_local_sandbox.create_deep_agent.call_args.kwargs
         middleware = call_kwargs["middleware"]
         assert isinstance(middleware, list)
-        assert len(middleware) == 1
+        assert len(middleware) == 2
         assert isinstance(middleware[0], ToolPolicyMiddleware)
+        assert middleware[1] is existing_middleware[0]
 
     def test_output_size_limit_preserved(self) -> None:
         """Sandbox output byte-size truncation should remain separate from context compaction."""


### PR DESCRIPTION
## Summary

- Documents DeepAgents' built-in context compression mechanisms in `ApiDriver.execute_agentic`
- Adds `TestContextCompaction` test class verifying built-in compression stays active
- Alternative approach to PR #664: leverage built-in compression rather than adding custom compaction middleware

## Motivation

Issue #229 asks for context compaction to prevent context window overflow during long agent sessions. Research revealed that DeepAgents (`create_deep_agent`) already includes three built-in compression mechanisms that are active by default when Amelia calls it:

1. **FilesystemMiddleware** — offloads tool results >20K tokens to `/large_tool_results/<tool_call_id>` on the backend (head+tail preview replaces inline content)
2. **SummarizationMiddleware** — triggers at 85% context utilization, keeping 10% of recent context. Large tool-call args clipped first. Evicted history offloaded to `/conversation_history/{thread_id}.md`
3. **LocalSandbox** (extends FilesystemBackend) — provides the backend `write()` path for both offload mechanisms

This PR documents the built-in compression and adds tests verifying it stays active, rather than introducing custom compaction middleware (PR #664). This makes the compression behavior maintainable upstream by DeepAgents rather than in Amelia.

Closes #229. Alternative approach to #664 for comparison.

## Changes

### Added
- `TestContextCompaction` test class in `tests/unit/test_api_driver.py`:
  - `test_local_sandbox_extends_filesystem_backend` — verifies the offload backend
  - `test_execute_agentic_passes_local_sandbox_backend` — verifies backend is passed to `create_deep_agent`
  - `test_no_middleware_excludes_summarization` — verifies empty middleware doesn't override defaults
  - `test_policy_middleware_coexists_with_default_compression` — verifies non-empty middleware path
  - `test_output_size_limit_preserved` — verifies byte-size truncation stays separate

### Changed
- `amelia/drivers/api/deepagents.py`: 12-line comment block documenting the three built-in compression mechanisms near the `create_deep_agent` call

## Test Plan

- [x] `uv run ruff check amelia tests` — all checks passed
- [x] `uv run mypy amelia` — no issues found in 204 source files
- [x] `uv run pytest tests/unit/` — 2626 passed, 56 deselected, 1 warning

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy amelia`)
- [x] Documentation updated (comment block in deepagents.py)
