### PR TITLE
ci(release): fail the gate on a drifted uv.lock

### DIFF
--- a/.claude/commands/gen-release-notes.md
+++ b/.claude/commands/gen-release-notes.md
@@ -228,12 +228,24 @@ cd dashboard && npm version X.Y.Z --no-git-tag-version && cd ..
 # Or manually edit: "version": "X.Y.Z"
 ```
 
+### 6d. Lockfile (uv.lock)
+
+Bumping `pyproject.toml` invalidates `uv.lock`'s own `amelia` entry
+(`source = { editable = "." }`), whose `version` still points at the previous
+release. Regenerate it so the lock tracks the new version — `uv lock --check`
+(first step of `make check` / pre-push / CI) fails the gate on a stale lock:
+
+```bash
+uv lock
+```
+
 **Verify all versions match** after updating:
 
 ```bash
 echo "pyproject.toml: $(grep '^version = ' pyproject.toml)"
 echo "amelia/__init__.py: $(grep '__version__' amelia/__init__.py)"
 echo "dashboard/package.json: $(grep '\"version\"' dashboard/package.json)"
+echo "uv.lock: $(uv lock --check 2>&1 | tail -1)"
 ```
 
 ## Step 7: Output Summary

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -41,8 +41,11 @@ Run `/gen-release-notes ${PREV_TAG}` to:
 3. Determine the next version number
 4. Update `CHANGELOG.md` with the new version section
 5. Update `pyproject.toml` with the new version
+6. Regenerate `uv.lock` (`uv lock`) so its editable-root `amelia` entry tracks the new version
 
-**Do not proceed** until CHANGELOG.md and pyproject.toml are updated.
+Bumping `pyproject.toml` invalidates `uv.lock`'s own entry (`name = "amelia"`, `source = { editable = "." }`), whose `version` still points at the previous release. `uv lock --check` runs first in `make check`, the pre-push hook, and CI (before any `uv run`/`uv sync` can silently re-lock), and FAILS on a drifted lock — so a stale lock can never merge.
+
+**Do not proceed** until CHANGELOG.md, pyproject.toml, and uv.lock are updated.
 
 ## Step 2: Create Release Branch
 
@@ -62,7 +65,7 @@ git checkout -b "chore/release-${VERSION}"
 Commit all updated version files:
 
 ```bash
-git add CHANGELOG.md pyproject.toml amelia/__init__.py dashboard/package.json
+git add CHANGELOG.md pyproject.toml amelia/__init__.py dashboard/package.json uv.lock
 git commit -m "chore(release): bump version to ${VERSION}"
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Reads the freshly checked-out committed uv.lock BEFORE `uv sync` can heal
+      # it. Fails if a release bumped pyproject.toml but forgot `uv lock`, so a
+      # stale lock (which breaks `uv sync --locked` for reproducible installs)
+      # can never merge.
+      - name: Verify uv.lock is in sync
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 DB_PORT := $(or $(AMELIA_DB_PORT),5434)
 DATABASE_URL := postgresql://amelia:amelia@localhost:$(DB_PORT)/amelia_test
 
-.PHONY: db db-stop test test-db test-integration test-all lint type-check check dev help
+.PHONY: db db-stop test test-db test-integration test-all lint type-check check lock-check dev help
 
 ## Database
 db:                    ## Start postgres (detached)
@@ -33,8 +33,11 @@ lint:                  ## Lint and auto-fix
 type-check:            ## Type check
 	uv run mypy amelia
 
-check:                 ## Run all checks (lint + types + unit tests)
-	$(MAKE) lint type-check test
+lock-check:            ## Fail if uv.lock has drifted from pyproject.toml
+	uv lock --check
+
+check:                 ## Run all checks (lock + lint + types + unit tests)
+	$(MAKE) lock-check lint type-check test
 
 ## Dev
 dev:                   ## Start full stack (API + dashboard)

--- a/tests/integration/test_agent_tool_restriction.py
+++ b/tests/integration/test_agent_tool_restriction.py
@@ -28,7 +28,7 @@ async def test_readonly_agent_cannot_write_file(tmp_path: Path) -> None:
     from amelia.drivers.api import ApiDriver
 
     driver = ApiDriver(
-        model=os.environ.get("AMELIA_TEST_MODEL", "anthropic/claude-3.5-sonnet"),
+        model=os.environ.get("AMELIA_TEST_MODEL", "anthropic/claude-sonnet-4"),
         cwd=str(tmp_path),
     )
 


### PR DESCRIPTION
## Summary

Hardens the release process by failing CI (and `make check`) when `uv.lock` has drifted from `pyproject.toml`. Also fixes a deprecated OpenRouter model id in an existing integration test.

## Changes

### Added
- **`uv lock --check` gate.** New `lock-check` Makefile target, run first in `make check` and added as the first step in CI — before any `uv sync`/`uv run`, which would silently re-lock and mask drift. CI re-runs it on a fresh checkout of the pushed commit, so a stale lock can never merge.

### Changed
- **Release skill docs** (`.claude/commands/release.md`, `.claude/commands/gen-release-notes.md`) — run `uv lock` on the version bump and stage `uv.lock`, so the release flow keeps the lock in sync.

### Fixed
- **Tool-restriction integration test** now uses `anthropic/claude-sonnet-4` instead of the deprecated `anthropic/claude-3.5-sonnet` (404 'No endpoints found' on OpenRouter), matching the single-provider id the CLI agentic real-call test already uses.

## Motivation

The release skill bumps `pyproject.toml` but never ran `uv lock`, so `uv.lock`'s own `amelia` entry (`source = editable "."`) shipped one release behind every time. A stale self-version breaks `uv sync --locked` for reproducible installs and dirties every user's tree on `git pull && uv sync`. The gate catches this before merge.

## Testing

- [x] Unit tests added/updated — n/a (CI/tooling change)
- [x] Integration tests added/updated — model-id fix
- [x] Manual testing performed

Verified locally: `uv lock --check` resolves cleanly (242 packages, in sync) and `ruff check` on the modified test file passes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes